### PR TITLE
iPython improvements

### DIFF
--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -175,4 +175,7 @@ def run(
     print("\n")
 
     populate()
-    IPython.embed()
+
+    from IPython.core.interactiveshell import _asyncio_runner
+
+    IPython.embed(using=_asyncio_runner)

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -132,8 +132,7 @@ def run(
         import IPython
     except ImportError:
         print(
-            "Install iPython using `pip install ipython==7.6.1` to use this "
-            "feature."
+            "Install iPython using `pip install ipython` to use this feature."
         )
         sys.exit(1)
 

--- a/piccolo/apps/shell/commands/run.py
+++ b/piccolo/apps/shell/commands/run.py
@@ -10,8 +10,7 @@ def start_ipython_shell(**tables: t.Dict[str, t.Type[Table]]):
         import IPython
     except ImportError:
         print(
-            "Install iPython using `pip install ipython==7.6.1` to use this "
-            "feature."
+            "Install iPython using `pip install ipython` to use this feature."
         )
         sys.exit(1)
 

--- a/piccolo/apps/shell/commands/run.py
+++ b/piccolo/apps/shell/commands/run.py
@@ -19,7 +19,9 @@ def start_ipython_shell(**tables: t.Dict[str, t.Type[Table]]):
         if table_class_name not in existing_global_names:
             globals()[table_class_name] = table_class
 
-    IPython.embed()
+    from IPython.core.interactiveshell import _asyncio_runner
+
+    IPython.embed(using=_asyncio_runner)
 
 
 def run():


### PR DESCRIPTION
`piccolo shell run` and `piccolo playground run` used to recommend older versions of iPython, because iPython's support for top level await in recent versions was problematic. This was fixed in the improvements to `run_sync` (https://github.com/piccolo-orm/piccolo/pull/18).

Top level await has now been enabled in both of those commands.