### PR TITLE
replacing asyncio.run with run_sync

### DIFF
--- a/piccolo/apps/migrations/commands/backwards.py
+++ b/piccolo/apps/migrations/commands/backwards.py
@@ -1,7 +1,6 @@
-import asyncio
-
 from piccolo.apps.migrations.auto import MigrationManager
 from piccolo.apps.migrations.tables import Migration
+from piccolo.utils.sync import run_sync
 from .base import BaseMigrationManager
 
 
@@ -69,12 +68,10 @@ class BackwardsMigrationManager(BaseMigrationManager):
             for migration_id in reversed_migration_ids:
                 print(f"Reversing {migration_id}")
                 migration_module = migration_modules[migration_id]
-                response = asyncio.run(
-                    migration_module.forwards()
-                )  # type: ignore
+                response = run_sync(migration_module.forwards())
 
                 if isinstance(response, MigrationManager):
-                    asyncio.run(response.run_backwards())
+                    run_sync(response.run_backwards())
 
                 Migration.delete().where(
                     Migration.name == migration_id

--- a/piccolo/apps/migrations/commands/base.py
+++ b/piccolo/apps/migrations/commands/base.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import asyncio
 import importlib
 import os
 import sys
@@ -13,6 +12,7 @@ from piccolo.apps.migrations.auto.migration_manager import MigrationManager
 from piccolo.apps.migrations.auto.diffable_table import DiffableTable
 from piccolo.apps.migrations.auto.schema_snapshot import SchemaSnapshot
 from piccolo.apps.migrations.tables import Migration
+from piccolo.utils.sync import run_sync
 
 
 class BaseMigrationManager(Finder):
@@ -85,7 +85,7 @@ class BaseMigrationManager(Finder):
         ] = self.get_migration_modules(migrations_folder)
 
         for _, migration_module in migration_modules.items():
-            response = asyncio.run(migration_module.forwards())
+            response = run_sync(migration_module.forwards())
             if isinstance(response, MigrationManager):
                 if max_migration_id:
                     if response.migration_id == max_migration_id:

--- a/piccolo/apps/migrations/commands/forwards.py
+++ b/piccolo/apps/migrations/commands/forwards.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import asyncio
 import sys
 import typing as t
 
@@ -8,6 +7,7 @@ from piccolo.conf.apps import AppConfig
 from piccolo.apps.migrations.tables import Migration
 from piccolo.apps.migrations.auto import MigrationManager
 from piccolo.conf.apps import MigrationModule
+from piccolo.utils.sync import run_sync
 
 
 class ForwardsMigrationManager(BaseMigrationManager):
@@ -60,10 +60,10 @@ class ForwardsMigrationManager(BaseMigrationManager):
                 print(f"Faked {_id}")
             else:
                 migration_module = migration_modules[_id]
-                response = asyncio.run(migration_module.forwards())
+                response = run_sync(migration_module.forwards())
 
                 if isinstance(response, MigrationManager):
-                    asyncio.run(response.run())
+                    run_sync(response.run())
 
                 print(f"Ran {_id}")
 

--- a/piccolo/engine/sqlite.py
+++ b/piccolo/engine/sqlite.py
@@ -8,8 +8,7 @@ import sqlite3
 import typing as t
 import uuid
 
-import aiosqlite
-from aiosqlite import Cursor, Connection
+from aiosqlite import connect, Connection, Cursor
 
 from piccolo.engine.base import Batch, Engine
 from piccolo.engine.exceptions import TransactionError
@@ -353,7 +352,7 @@ class SQLiteEngine(Engine):
     ###########################################################################
 
     async def get_connection(self) -> Connection:
-        connection = await aiosqlite.connect(**self.connection_kwargs)
+        connection = await connect(**self.connection_kwargs)
         connection.row_factory = dict_factory  # type: ignore
         await connection.execute("PRAGMA foreign_keys = 1")
         return connection
@@ -363,7 +362,7 @@ class SQLiteEngine(Engine):
     async def _run_in_new_connection(
         self, query: str, args: t.List[t.Any] = [], query_type: str = "generic"
     ):
-        async with aiosqlite.connect(**self.connection_kwargs) as connection:
+        async with connect(**self.connection_kwargs) as connection:
             await connection.execute("PRAGMA foreign_keys = 1")
 
             connection.row_factory = dict_factory  # type: ignore


### PR DESCRIPTION
There were still a few places which used `asyncio.run` to run coroutines synchronously - but `piccolo.utils.sync.run_sync` accommodates more edge cases, so using that instead.