### PR TITLE
modified exit codes when no migrations are left to run / reverse

### DIFF
--- a/piccolo/apps/migrations/commands/backwards.py
+++ b/piccolo/apps/migrations/commands/backwards.py
@@ -40,7 +40,10 @@ class BackwardsMigrationManager(BaseMigrationManager):
             app_name=self.app_name
         )
         if len(ran_migration_ids) == 0:
-            sys.exit("No migrations to reverse!")
+            # Make sure a status of 0 is returned, as we don't want this
+            # to appear as an error in automated scripts.
+            print("No migrations to reverse!")
+            sys.exit(0)
 
         #######################################################################
 

--- a/piccolo/apps/migrations/commands/forwards.py
+++ b/piccolo/apps/migrations/commands/forwards.py
@@ -38,7 +38,10 @@ class ForwardsMigrationManager(BaseMigrationManager):
         print(f"Haven't run = {havent_run}")
 
         if len(havent_run) == 0:
-            sys.exit("No migrations left to run!")
+            # Make sure a status of 0 is returned, as we don't want this
+            # to appear as an error in automated scripts.
+            print("No migrations left to run!")
+            sys.exit(0)
 
         if self.migration_id == "all":
             subset = havent_run

--- a/tests/apps/migrations/commands/test_forwards_backwards.py
+++ b/tests/apps/migrations/commands/test_forwards_backwards.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 from unittest import TestCase
+from unittest.mock import patch, call, MagicMock
 
 from piccolo.apps.migrations.tables import Migration
 from piccolo.apps.migrations.commands.backwards import backwards
@@ -121,7 +122,8 @@ class TestForwardsBackwards(TestCase):
             )
         )
 
-    def test_backwards_no_migrations(self):
+    @patch("piccolo.apps.migrations.commands.backwards.print")
+    def test_backwards_no_migrations(self, print_):
         """
         Test running migrations backwards if none have been run previously.
         """
@@ -134,11 +136,13 @@ class TestForwardsBackwards(TestCase):
                 )
             )
 
-        self.assertEqual(
-            manager.exception.__str__(), "No migrations to reverse!"
+        self.assertEqual(manager.exception.code, 0)
+        self.assertTrue(
+            print_.mock_calls[-1] == call("No migrations to reverse!")
         )
 
-    def test_forwards_no_migrations(self):
+    @patch("piccolo.apps.migrations.commands.forwards.print")
+    def test_forwards_no_migrations(self, print_: MagicMock):
         """
         Test running the migrations if they've already run.
         """
@@ -147,8 +151,9 @@ class TestForwardsBackwards(TestCase):
         with self.assertRaises(SystemExit) as manager:
             run_sync(forwards(app_name="example_app", migration_id="all"))
 
-        self.assertEqual(
-            manager.exception.__str__(), "No migrations left to run!"
+        self.assertEqual(manager.exception.code, 0)
+        self.assertTrue(
+            print_.mock_calls[-1] == call("No migrations left to run!")
         )
 
     def test_forwards_fake(self):


### PR DESCRIPTION
Returning a status code of 0, otherwise build scripts may fail.

See https://github.com/piccolo-orm/piccolo/issues/28 for more info.