### PR TITLE
Issue 39 empty date column migration fix

### DIFF
--- a/piccolo/columns/__init__.py
+++ b/piccolo/columns/__init__.py
@@ -1,5 +1,6 @@
 from .column_types import (  # noqa: F401
     Boolean,
+    Date,
     Decimal,
     Float,
     ForeignKey,

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -88,7 +88,7 @@ class AddColumn(AlterColumnStatement):
 class DropDefault(AlterColumnStatement):
     @property
     def querystring(self) -> QueryString:
-        return QueryString("DROP DEFAULT {}", self.column_name)
+        return QueryString(f"ALTER COLUMN {self.column_name} DROP DEFAULT")
 
 
 @dataclass

--- a/tests/apps/migrations/auto/test_migration_manager.py
+++ b/tests/apps/migrations/auto/test_migration_manager.py
@@ -337,6 +337,42 @@ class TestMigrationManager(DBTestCase):
         )
 
     @postgres_only
+    def test_alter_column_drop_default(self):
+        """
+        Test setting a column default to None with MigrationManager.
+        """
+        # Make sure it has a non-null default to start with.
+        manager_1 = MigrationManager()
+        manager_1.alter_column(
+            table_class_name="Manager",
+            tablename="manager",
+            column_name="name",
+            params={"default": "Mr Manager"},
+            old_params={"default": None},
+        )
+        asyncio.run(manager_1.run())
+
+        self.assertEqual(
+            self._get_column_default(),
+            [{"column_default": "'Mr Manager'::character varying"}],
+        )
+
+        # Drop the default.
+        manager_2 = MigrationManager()
+        manager_2.alter_column(
+            table_class_name="Manager",
+            tablename="manager",
+            column_name="name",
+            params={"default": None},
+            old_params={"default": "My Manager"},
+        )
+        asyncio.run(manager_2.run())
+
+        self.assertEqual(
+            self._get_column_default(), [{"column_default": None}],
+        )
+
+    @postgres_only
     def test_alter_column_add_index(self):
         """
         Test altering a column to add an index with MigrationManager.

--- a/tests/apps/migrations/auto/test_migration_manager.py
+++ b/tests/apps/migrations/auto/test_migration_manager.py
@@ -351,7 +351,6 @@ class TestMigrationManager(DBTestCase):
             old_params={"default": None},
         )
         asyncio.run(manager_1.run())
-
         self.assertEqual(
             self._get_column_default(),
             [{"column_default": "'Mr Manager'::character varying"}],
@@ -364,10 +363,34 @@ class TestMigrationManager(DBTestCase):
             tablename="manager",
             column_name="name",
             params={"default": None},
-            old_params={"default": "My Manager"},
+            old_params={"default": "Mr Manager"},
         )
         asyncio.run(manager_2.run())
+        self.assertEqual(
+            self._get_column_default(), [{"column_default": None}],
+        )
 
+        # And add it back once more to be sure.
+        manager_3 = manager_1
+        asyncio.run(manager_3.run())
+        self.assertEqual(
+            self._get_column_default(),
+            [{"column_default": "'Mr Manager'::character varying"}],
+        )
+
+        # Run them all backwards
+        asyncio.run(manager_3.run_backwards())
+        self.assertEqual(
+            self._get_column_default(), [{"column_default": None}],
+        )
+
+        asyncio.run(manager_2.run_backwards())
+        self.assertEqual(
+            self._get_column_default(),
+            [{"column_default": "'Mr Manager'::character varying"}],
+        )
+
+        asyncio.run(manager_1.run_backwards())
         self.assertEqual(
             self._get_column_default(), [{"column_default": None}],
         )


### PR DESCRIPTION
There's a bug when dropping the default for a column. The DDL statement was incorrect. Fixed the DDL, and added a test for it.

Fixes https://github.com/piccolo-orm/piccolo/issues/39