### PR TITLE
changing exit code when creating a migration and no changes are required

### DIFF
--- a/piccolo/apps/migrations/commands/new.py
+++ b/piccolo/apps/migrations/commands/new.py
@@ -75,7 +75,8 @@ async def _create_new_migration(app_config: AppConfig, auto=False) -> None:
         )
 
         if sum([len(i.statements) for i in alter_statements]) == 0:
-            sys.exit("No changes detected - exiting.")
+            print("No changes detected - exiting.")
+            sys.exit(0)
 
         file_contents = render_template(
             migration_id=_id,

--- a/tests/apps/migrations/commands/test_new.py
+++ b/tests/apps/migrations/commands/test_new.py
@@ -1,13 +1,14 @@
 import os
 import shutil
 from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
 
-from piccolo.conf.apps import AppConfig
 from piccolo.apps.migrations.commands.new import (
     _create_new_migration,
     BaseMigrationManager,
     new,
 )
+from piccolo.conf.apps import AppConfig
 from piccolo.utils.sync import run_sync
 
 from tests.base import postgres_only
@@ -41,13 +42,16 @@ class TestNewMigrationCommand(TestCase):
         self.assertTrue(len(migration_modules.keys()) == 1)
 
     @postgres_only
-    def test_new_command(self):
+    @patch("piccolo.apps.migrations.commands.new.print")
+    def test_new_command(self, print_: MagicMock):
         """
         Call the command, when no migration changes are needed.
         """
         with self.assertRaises(SystemExit) as manager:
             run_sync(new(app_name="example_app", auto=True))
 
-        self.assertEqual(
-            manager.exception.__str__(), "No changes detected - exiting."
+        self.assertEqual(manager.exception.code, 0)
+
+        self.assertTrue(
+            print_.mock_calls[-1] == call("No changes detected - exiting.")
         )


### PR DESCRIPTION
Related to this issue:

https://github.com/piccolo-orm/piccolo/issues/45