### PR TITLE
fixing a bug when running a migration with references="self"

### DIFF
--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -225,7 +225,8 @@ def deserialise_params(params: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
     for key, value in params.items():
         # This is purely for backwards compatibility.
         if isinstance(value, str) and not isinstance(value, Enum):
-            params[key] = deserialise_legacy_params(name=key, value=value)
+            if value != "self":
+                params[key] = deserialise_legacy_params(name=key, value=value)
         elif isinstance(value, SerialisedClass):
             params[key] = value.instance
         elif isinstance(value, SerialisedUUID):


### PR DESCRIPTION
When a `ForeignKey` has a `references` argument of `'self'`. For example:

```python
class Employee(Table):
    name = Varchar()
    manager = ForeignKey(references='self')
```

There was a bug when running a migration for adding such a `ForeignKey` column.


