### PR TITLE
fast api version fix

### DIFF
--- a/piccolo/apps/asgi/commands/templates/starlette/requirements.txt.jinja
+++ b/piccolo/apps/asgi/commands/templates/starlette/requirements.txt.jinja
@@ -1,5 +1,5 @@
+{{ router }}
+{{ server }}
 jinja2
 piccolo
 piccolo_admin
-{{ router }}
-{{ server }}


### PR DESCRIPTION
When using `piccolo asgi new` and specifying FastAPI, there's an issue because the latest version of Starlette isn't compatible with FastAPI.

https://github.com/tiangolo/fastapi/pull/2335

By re-ordering the dependencies it fixes this issue.