### PR TITLE
Added WhereRaw

### DIFF
--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -30,6 +30,8 @@ Equal / Not Equal
         b.name != 'Rustaceans'
     ).run_sync()
 
+-------------------------------------------------------------------------------
+
 Greater than / less than
 ------------------------
 
@@ -41,6 +43,8 @@ You can use the ``<, >, <=, >=`` operators, which work as you expect.
     b.select().where(
         b.popularity >= 100
     ).run_sync()
+
+-------------------------------------------------------------------------------
 
 like / ilike
 -------------
@@ -64,6 +68,8 @@ The percentage operator is required to designate where the match should occur.
 
 ``ilike`` is identical, except it's case insensitive.
 
+-------------------------------------------------------------------------------
+
 not_like
 --------
 
@@ -75,6 +81,8 @@ Usage is the same as ``like`` excepts it excludes matching rows.
     b.select().where(
         b.name.not_like('Py%')
     ).run_sync()
+
+-------------------------------------------------------------------------------
 
 is_in / not_in
 --------------
@@ -92,6 +100,8 @@ is_in / not_in
     b.select().where(
         b.name.not_in(['Rustaceans'])
     ).run_sync()
+
+-------------------------------------------------------------------------------
 
 Complex queries - and / or
 ---------------------------
@@ -150,4 +160,32 @@ Rather than using the ``|`` and ``&`` characters, you can use the ``And`` and
             And(b.popularity >= 100, b.popularity < 1000),
             b.name == 'Pythonistas'
         )
+    ).run_sync()
+
+-------------------------------------------------------------------------------
+
+WhereRaw
+--------
+
+In certain situations you may want to have raw SQL in your where clause. For
+example, there could be a Postgres function you need to call.
+
+.. code-block:: python
+
+    from piccolo.columns.combination import WhereRaw
+
+    b = Band
+    b.select().where(
+        WhereRaw("name = 'Pythonistas'")
+    ).run_sync()
+
+``WhereRaw`` can be combined into complex queries, just as you'd expect:
+
+.. code-block:: python
+
+    from piccolo.columns.combination import WhereRaw
+
+    b = Band
+    b.select().where(
+        WhereRaw("name = 'Pythonistas'") | (b.popularity > 1000)
     ).run_sync()

--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -167,16 +167,27 @@ Rather than using the ``|`` and ``&`` characters, you can use the ``And`` and
 WhereRaw
 --------
 
-In certain situations you may want to have raw SQL in your where clause. For
-example, there could be a Postgres function you need to call.
+In certain situations you may want to have raw SQL in your where clause.
 
 .. code-block:: python
 
     from piccolo.columns.combination import WhereRaw
 
-    b = Band
-    b.select().where(
+    Band.select().where(
         WhereRaw("name = 'Pythonistas'")
+    ).run_sync()
+
+It's important to parameterise your SQL statements if the values come from an
+untrusted source, otherwise it could lead to a SQL injection attack.
+
+.. code-block:: python
+
+    from piccolo.columns.combination import WhereRaw
+
+    value = "Could be dangerous"
+
+    Band.select().where(
+        WhereRaw("name = {}", value)
     ).run_sync()
 
 ``WhereRaw`` can be combined into complex queries, just as you'd expect:

--- a/piccolo/columns/combination.py
+++ b/piccolo/columns/combination.py
@@ -54,6 +54,27 @@ class Undefined:
 UNDEFINED = Undefined()
 
 
+class WhereRaw(CombinableMixin):
+    def __init__(self, sql: str, *args: t.Any) -> None:
+        """
+        Execute raw SQL queries in your where clause. Use with caution!
+
+        await Band.where(
+            WhereRaw("name = 'Pythonistas'")
+        )
+
+        Or passing in parameters:
+
+        await Band.where(
+            WhereRaw("name = {}", 'Pythonistas')
+        )
+        """
+        self.querystring = QueryString(sql, *args)
+
+    def __str__(self):
+        return self.querystring.__str__()
+
+
 class Where(CombinableMixin):
 
     __slots__ = ("column", "value", "values", "operator")

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from piccolo.apps.user.tables import BaseUser
+from piccolo.columns.combination import WhereRaw
 from piccolo.query.methods.select import Count
 
 from ..base import DBTestCase, postgres_only, sqlite_only
@@ -114,6 +115,59 @@ class TestSelect(DBTestCase):
 
         self.assertEqual(
             response, [{"name": "Pythonistas"}, {"name": "CSharps"}]
+        )
+
+    def test_where_raw(self):
+        """
+        Make sure raw SQL passed in to a where clause works as expected.
+        """
+        self.insert_rows()
+
+        response = (
+            Band.select(Band.name)
+            .where(WhereRaw("name = 'Pythonistas'"))
+            .run_sync()
+        )
+
+        print(f"response = {response}")
+
+        self.assertEqual(response, [{"name": "Pythonistas"}])
+
+    def test_where_raw_with_args(self):
+        """
+        Make sure raw SQL with args, passed in to a where clause, works
+        as expected.
+        """
+        self.insert_rows()
+
+        response = (
+            Band.select(Band.name)
+            .where(WhereRaw("name = {}", "Pythonistas"))
+            .run_sync()
+        )
+
+        print(f"response = {response}")
+
+        self.assertEqual(response, [{"name": "Pythonistas"}])
+
+    def test_where_raw_combined_with_where(self):
+        """
+        Make sure WhereRaw can be combined with Where.
+        """
+        self.insert_rows()
+
+        response = (
+            Band.select(Band.name)
+            .where(
+                WhereRaw("name = 'Pythonistas'") | (Band.name == "Rustaceans")
+            )
+            .run_sync()
+        )
+
+        print(f"response = {response}")
+
+        self.assertEqual(
+            response, [{"name": "Pythonistas"}, {"name": "Rustaceans"}]
         )
 
     def test_where_and(self):


### PR DESCRIPTION
This allows raw SQL to be executed in where clauses.

It's an escape hatch, allowing database features to be accessed which are otherwise not possible when using Piccolo.

For example, GIS and JSON functions.

https://github.com/piccolo-orm/piccolo/issues/55

