### PR TITLE
added docs about the id column

### DIFF
--- a/docs/src/piccolo/schema/defining.rst
+++ b/docs/src/piccolo/schema/defining.rst
@@ -23,6 +23,23 @@ For a full list of columns, see :ref:`ColumnTypes`.
 
 -------------------------------------------------------------------------------
 
+Default columns
+---------------
+
+id
+~~
+
+Each table is automatically given a ``PrimaryKey`` column called ``id``, which
+is an auto incrementing integer.
+
+It is used to uniquely identify a row, and is referenced by ``ForeignKey``
+columns on other tables.
+
+If you specify your own ``id`` column, you may get unexpected behaviour, so
+it's not recommended at the moment.
+
+-------------------------------------------------------------------------------
+
 Tablename
 ---------
 


### PR DESCRIPTION
Each table is automatically given a ``PrimaryKey`` column called ``id``.

This was undocumented, and causes confusion:

https://github.com/piccolo-orm/piccolo/issues/32
https://github.com/piccolo-orm/piccolo/issues/63

It is now documented, but the ``PrimaryKey`` could still be improved - for example, by being able to override the name of this column.