### PR TITLE
Migrations change column types

### DIFF
--- a/piccolo/apps/migrations/auto/diffable_table.py
+++ b/piccolo/apps/migrations/auto/diffable_table.py
@@ -110,6 +110,8 @@ class DiffableTable:
                         column_name=column._meta.name,
                         params=deserialise_params(delta),
                         old_params=old_params,
+                        column_class=column.__class__,
+                        old_column_class=existing_column.__class__,
                     )
                 )
 

--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 import inspect
-from piccolo.query.methods import alter
 import typing as t
 
 from piccolo.columns import Column, column_types

--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -340,9 +340,20 @@ class MigrationManager:
                 )
                 column_name = alter_column.column_name
 
+                ###############################################################
+
                 # Change the column type if possible
-                column_class = alter_column.column_class
-                old_column_class = alter_column.old_column_class
+                column_class = (
+                    alter_column.old_column_class
+                    if backwards
+                    else alter_column.column_class
+                )
+                old_column_class = (
+                    alter_column.column_class
+                    if backwards
+                    else alter_column.old_column_class
+                )
+
                 if (old_column_class is not None) and (
                     column_class is not None
                 ):
@@ -360,6 +371,8 @@ class MigrationManager:
                         await _Table.alter().set_column_type(
                             old_column=old_column, new_column=new_column
                         )
+
+                ###############################################################
 
                 null = params.get("null")
                 if null is not None:

--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -333,12 +333,18 @@ class MigrationManager:
             _Table._meta.tablename = alter_columns[0].tablename
 
             for alter_column in alter_columns:
+
                 params = (
                     alter_column.old_params
                     if backwards
                     else alter_column.params
                 )
-                column_name = alter_column.column_name
+
+                old_params = (
+                    alter_column.params
+                    if backwards
+                    else alter_column.old_params
+                )
 
                 ###############################################################
 
@@ -358,13 +364,11 @@ class MigrationManager:
                     column_class is not None
                 ):
                     if old_column_class != column_class:
-                        old_column = old_column_class(
-                            **alter_column.old_params
-                        )
+                        old_column = old_column_class(**old_params)
                         old_column._meta._table = _Table
                         old_column._meta._name = alter_column.column_name
 
-                        new_column = column_class(**alter_column.params)
+                        new_column = column_class(**params)
                         new_column._meta._table = _Table
                         new_column._meta._name = alter_column.column_name
 
@@ -373,6 +377,8 @@ class MigrationManager:
                         )
 
                 ###############################################################
+
+                column_name = alter_column.column_name
 
                 null = params.get("null")
                 if null is not None:

--- a/piccolo/apps/migrations/auto/operations.py
+++ b/piccolo/apps/migrations/auto/operations.py
@@ -26,6 +26,8 @@ class AlterColumn:
     tablename: str
     params: t.Dict[str, t.Any]
     old_params: t.Dict[str, t.Any]
+    column_class: t.Optional[t.Type[Column]] = None
+    old_column_class: t.Optional[t.Type[Column]] = None
 
 
 @dataclass

--- a/piccolo/apps/migrations/auto/schema_differ.py
+++ b/piccolo/apps/migrations/auto/schema_differ.py
@@ -308,17 +308,45 @@ class SchemaDiffer:
             else:
                 continue
 
-            for i in delta.alter_columns:
-                new_params = serialise_params(i.params)
+            for alter_column in delta.alter_columns:
+                new_params = serialise_params(alter_column.params)
                 extra_imports.extend(new_params.extra_imports)
                 extra_definitions.extend(new_params.extra_definitions)
 
-                old_params = serialise_params(i.old_params)
+                old_params = serialise_params(alter_column.old_params)
                 extra_imports.extend(old_params.extra_imports)
                 extra_definitions.extend(old_params.extra_definitions)
 
+                column_class = (
+                    alter_column.column_class.__name__
+                    if alter_column.column_class
+                    else "None"
+                )
+
+                old_column_class = (
+                    alter_column.old_column_class.__name__
+                    if alter_column.old_column_class
+                    else "None"
+                )
+
+                if alter_column.column_class is not None:
+                    extra_imports.append(
+                        Import(
+                            module=alter_column.column_class.__module__,
+                            target=alter_column.column_class.__name__,
+                        )
+                    )
+
+                if alter_column.old_column_class is not None:
+                    extra_imports.append(
+                        Import(
+                            module=alter_column.old_column_class.__module__,
+                            target=alter_column.old_column_class.__name__,
+                        )
+                    )
+
                 response.append(
-                    f"manager.alter_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{i.column_name}', params={new_params.params}, old_params={old_params.params})"  # noqa: E501
+                    f"manager.alter_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{alter_column.column_name}', params={new_params.params}, old_params={old_params.params}, column_class={column_class}, old_column_class={old_column_class})"  # noqa: E501
                 )
 
         return AlterStatements(

--- a/piccolo/columns/__init__.py
+++ b/piccolo/columns/__init__.py
@@ -1,4 +1,5 @@
 from .column_types import (  # noqa: F401
+    BigInt,
     Boolean,
     Bytea,
     Date,
@@ -14,6 +15,7 @@ from .column_types import (  # noqa: F401
     Real,
     Secret,
     Serial,
+    SmallInt,
     Text,
     Timestamp,
     Timestamptz,

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -463,14 +463,15 @@ class Column(Selectable):
         return output
 
     @property
+    def column_type(self):
+        return self.__class__.__name__.upper()
+
+    @property
     def querystring(self) -> QueryString:
         """
         Used when creating tables.
         """
-        column_type = getattr(
-            self, "column_type", self.__class__.__name__.upper()
-        )
-        query = f'"{self._meta.name}" {column_type}'
+        query = f'"{self._meta.name}" {self.column_type}'
         if self._meta.primary:
             query += " PRIMARY"
         if self._meta.key:

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -92,7 +92,7 @@ class DropDefault(AlterColumnStatement):
 
 
 @dataclass
-class SetColumnType:
+class SetColumnType(AlterStatement):
     __slots__ = ("old_column", "new_column")
 
     old_column: Column

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -100,7 +100,9 @@ class SetColumnType(AlterStatement):
 
     @property
     def querystring(self) -> QueryString:
-        self.new_column._meta._table = self.old_column._meta.table
+        if self.new_column._meta._table is None:
+            self.new_column._meta._table = self.old_column._meta.table
+
         column_name = self.old_column._meta.name
         return QueryString(
             f"ALTER COLUMN {column_name} TYPE {self.new_column.column_type}"

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -107,7 +107,7 @@ class SetDefault(AlterColumnStatement):
 
 
 @dataclass
-class Unique(AlterColumnStatement):
+class SetUnique(AlterColumnStatement):
     __slots__ = ("boolean",)
 
     boolean: bool
@@ -129,7 +129,7 @@ class Unique(AlterColumnStatement):
 
 
 @dataclass
-class Null(AlterColumnStatement):
+class SetNull(AlterColumnStatement):
     __slots__ = ("boolean",)
 
     boolean: bool
@@ -255,13 +255,13 @@ class Alter(Query):
         "_drop_default",
         "_drop_table",
         "_drop",
-        "_null",
         "_rename_columns",
         "_rename_table",
         "_set_default",
         "_set_digits",
         "_set_length",
-        "_unique",
+        "_set_null",
+        "_set_unique",
     )
 
     def __init__(self, table: t.Type[Table]):
@@ -272,13 +272,13 @@ class Alter(Query):
         self._drop_default: t.List[DropDefault] = []
         self._drop_table: t.Optional[DropTable] = None
         self._drop: t.List[DropColumn] = []
-        self._null: t.List[Null] = []
         self._rename_columns: t.List[RenameColumn] = []
         self._rename_table: t.List[RenameTable] = []
         self._set_default: t.List[SetDefault] = []
         self._set_digits: t.List[SetDigits] = []
         self._set_length: t.List[SetLength] = []
-        self._unique: t.List[Unique] = []
+        self._set_null: t.List[SetNull] = []
+        self._set_unique: t.List[SetUnique] = []
 
     def add_column(self, name: str, column: Column) -> Alter:
         """
@@ -349,7 +349,7 @@ class Alter(Query):
         Band.alter().set_null(Band.name, True)
         Band.alter().set_null('name', True)
         """
-        self._null.append(Null(column, boolean))
+        self._set_null.append(SetNull(column, boolean))
         return self
 
     def set_unique(
@@ -359,7 +359,7 @@ class Alter(Query):
         Band.alter().set_unique(Band.name, True)
         Band.alter().set_unique('name', True)
         """
-        self._unique.append(Unique(column, boolean))
+        self._set_unique.append(SetUnique(column, boolean))
         return self
 
     def set_length(self, column: t.Union[str, Varchar], length: int) -> Alter:
@@ -472,8 +472,8 @@ class Alter(Query):
                 self._rename_table,
                 self._drop,
                 self._drop_default,
-                self._unique,
-                self._null,
+                self._set_unique,
+                self._set_null,
                 self._set_length,
                 self._set_default,
                 self._set_digits,

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -92,16 +92,18 @@ class DropDefault(AlterColumnStatement):
 
 
 @dataclass
-class SetColumnType(AlterColumnStatement):
-    __slots__ = ("column_name", "column")
+class SetColumnType:
+    __slots__ = ("old_column", "new_column")
 
-    column_name: str
-    column: Column
+    old_column: Column
+    new_column: Column
 
     @property
     def querystring(self) -> QueryString:
+        self.new_column._meta._table = self.old_column._meta.table
+        column_name = self.old_column._meta.name
         return QueryString(
-            f"ALTER COLUMN {self.column_name} TYPE {self.column.column_type}"
+            f"ALTER COLUMN {column_name} TYPE {self.new_column.column_type}"
         )
 
 
@@ -349,12 +351,12 @@ class Alter(Query):
         self._rename_columns.append(RenameColumn(column, new_name))
         return self
 
-    def set_column_type(self, column_name: str, column: Column) -> Alter:
+    def set_column_type(self, old_column: Column, new_column: Column) -> Alter:
         """
         Change the type of a column.
         """
         self._set_column_type.append(
-            SetColumnType(column_name=column_name, column=column)
+            SetColumnType(old_column=old_column, new_column=new_column)
         )
         return self
 

--- a/tests/apps/migrations/auto/test_schema_differ.py
+++ b/tests/apps/migrations/auto/test_schema_differ.py
@@ -187,7 +187,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.alter_columns.statements) == 1)
         self.assertEqual(
             schema_differ.alter_columns.statements[0],
-            "manager.alter_column(table_class_name='Ticket', tablename='ticket', column_name='price', params={'digits': (4, 2)}, old_params={'digits': (5, 2)})",  # noqa
+            "manager.alter_column(table_class_name='Ticket', tablename='ticket', column_name='price', params={'digits': (4, 2)}, old_params={'digits': (5, 2)}, column_class=Numeric, old_column_class=Numeric)",  # noqa
         )
 
     def test_alter_default(self):

--- a/tests/table/test_alter.py
+++ b/tests/table/test_alter.py
@@ -137,6 +137,7 @@ class TestMultiple(DBTestCase):
         self.assertTrue("column_b" in column_names)
 
 
+# TODO - test more conversions.
 @postgres_only
 class TestSetColumnType(DBTestCase):
     def test_integer_to_bigint(self):


### PR DESCRIPTION
Piccolo migrations lacked the ability to change a column type. For example, with this schema:

```python
# Old table
class MyTable(Table):
    data = Timestamp()

# New table
class MyTable(Table):
    data = Timestamptz()
```

The type of the `data` column has changed. Piccolo migrations will now detect when a column type has changed, and will instruct Postgres to change it.

The issue was reported here:

https://github.com/piccolo-orm/piccolo/issues/56
