### PR TITLE
docs minor fix

### DIFF
--- a/docs/src/piccolo/engines/postgres_engine.rst
+++ b/docs/src/piccolo/engines/postgres_engine.rst
@@ -37,7 +37,7 @@ pool in the shutdown event handler.
 
 .. code-block:: python
 
-    from piccolo.engine import from starlette.applications import Starlette
+    from piccolo.engine import engine_finder
     from starlette.applications import Starlette
 
 


### PR DESCRIPTION
Hello, I noted there was a little error in the docs and fixed it.

I also noted this:
```
$ git grep connection_pool|wc
      6      20     639
```
and
```
$ git grep connnection_pool|wc
     15      52    1388
```

Basically, is it OK to have both `connection_pool` and `connnection_pool`?