### PR TITLE
fix type annotation for Combinable - it didn't include WhereRaw

### DIFF
--- a/piccolo/custom_types.py
+++ b/piccolo/custom_types.py
@@ -3,10 +3,10 @@ import typing as t
 
 
 if t.TYPE_CHECKING:  # pragma: no cover
-    from piccolo.columns.combination import Where, And, Or  # noqa
+    from piccolo.columns.combination import Where, WhereRaw, And, Or  # noqa
 
 
-Combinable = t.Union["Where", "And", "Or"]
+Combinable = t.Union["Where", "WhereRaw", "And", "Or"]
 Iterable = t.Iterable[t.Any]
 
 


### PR DESCRIPTION
When adding `WhereRaw` I forgot to update the type annotation for `Combinable`.