### PR TITLE
Column help text

### DIFF
--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -123,6 +123,7 @@ class ColumnMeta:
     index: bool = False
     index_method: IndexMethod = IndexMethod.btree
     required: bool = False
+    help_text: t.Optional[str] = None
 
     # Used for representing the table in migrations and the playground.
     params: t.Dict[str, t.Any] = field(default_factory=dict)
@@ -244,6 +245,13 @@ class Column(Selectable):
         the user must provide this value. Example uses are in serialisers for
         API endpoints, and form fields.
 
+    :param help_text:
+        This provides some context about what the column is being used for. For
+        example, for a `Decimal` column called `value`, it could say
+        'The units are millions of dollars'. The database doesn't use this
+        value, but tools such as Piccolo Admin use it to show a tooltip in the
+        GUI.
+
     """
 
     value_type: t.Type = int
@@ -257,11 +265,12 @@ class Column(Selectable):
         index: bool = False,
         index_method: IndexMethod = IndexMethod.btree,
         required: bool = False,
+        help_text: t.Optional[str] = None,
         **kwargs,
     ) -> None:
         # Used for migrations.
-        # We deliberately omit 'required' as it doesn't effect the actual
-        # schema.
+        # We deliberately omit 'required', and 'help_text' as they don't effect
+        # the actual schema.
         kwargs.update(
             {
                 "null": null,
@@ -288,6 +297,7 @@ class Column(Selectable):
             index_method=index_method,
             params=kwargs,
             required=required,
+            help_text=help_text,
         )
 
         self.alias: t.Optional[str] = None

--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -39,3 +39,13 @@ class TestCopy(TestCase):
         self.assertNotEqual(
             id(column._meta.call_chain), id(new_column._meta.call_chain)
         )
+
+
+class TestHelpText(TestCase):
+    def test_help_text(self):
+        """
+        Test adding help text to a column.
+        """
+        help_text = "This is some important help text for users."
+        column = Varchar(help_text=help_text)
+        self.assertTrue(column._meta.help_text == help_text)


### PR DESCRIPTION
Adding a `help_text` option to `Column` - will be used by Piccolo admin for adding tooltips in the GUI.