### PR TITLE
table_finder type coercion

### DIFF
--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -48,6 +48,11 @@ def table_finder(
         imported. `exclude_tags` overrides `include_tags`.
 
     """
+    if isinstance(modules, str):
+        # Guard against the user just entering a string, for example
+        # 'blog.tables', instead of ['blog.tables'].
+        modules = [modules]
+
     table_subclasses: t.List[t.Type[Table]] = []
 
     for module_path in modules:

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -71,6 +71,20 @@ class TestTableFinder(TestCase):
         with self.assertRaises(ImportError):
             table_finder(modules=["foo.bar.baz"])
 
+    def test_table_finder_coercion(self):
+        """
+        Should convert a string argument to a list.
+        """
+        tables = table_finder(modules="tests.example_app.tables")
+
+        table_class_names = [i.__name__ for i in tables]
+        table_class_names.sort()
+
+        self.assertEqual(
+            table_class_names,
+            ["Band", "Concert", "Manager", "Poster", "Ticket", "Venue"],
+        )
+
     def test_include_tags(self):
         """
         Should return all Table subclasses with a matching tag.


### PR DESCRIPTION
A small change to `table_finder`, so it still works if a string is passed in, instead of a list of strings. It's a mistake I commonly make.