### PR TITLE
Programmatic migrations

### DIFF
--- a/piccolo/apps/migrations/commands/backwards.py
+++ b/piccolo/apps/migrations/commands/backwards.py
@@ -43,7 +43,7 @@ class BackwardsMigrationManager(BaseMigrationManager):
             app_name=self.app_name
         )
         if len(ran_migration_ids) == 0:
-            # Make sure a status of 0 is returned, as we don't want this
+            # Make sure a success is returned, as we don't want this
             # to appear as an error in automated scripts.
             message = "No migrations to reverse!"
             print(message)

--- a/piccolo/apps/migrations/commands/base.py
+++ b/piccolo/apps/migrations/commands/base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import dataclass
 import importlib
 import os
 import sys
@@ -12,6 +13,12 @@ from piccolo.apps.migrations.auto.migration_manager import MigrationManager
 from piccolo.apps.migrations.auto.diffable_table import DiffableTable
 from piccolo.apps.migrations.auto.schema_snapshot import SchemaSnapshot
 from piccolo.apps.migrations.tables import Migration
+
+
+@dataclass
+class MigrationResult:
+    success: bool
+    message: t.Optional[str] = None
 
 
 class BaseMigrationManager(Finder):

--- a/piccolo/apps/migrations/commands/forwards.py
+++ b/piccolo/apps/migrations/commands/forwards.py
@@ -100,15 +100,13 @@ async def run_forwards(
             if not response.success:
                 return response
 
+        return MigrationResult(success=True)
+
     else:
         manager = ForwardsMigrationManager(
             app_name=app_name, migration_id=migration_id, fake=fake
         )
-        response = await manager.run()
-        if not response.success:
-            return response
-
-    return MigrationResult(success=True)
+        return await manager.run()
 
 
 async def forwards(

--- a/piccolo/apps/migrations/commands/forwards.py
+++ b/piccolo/apps/migrations/commands/forwards.py
@@ -3,26 +3,22 @@ import sys
 import typing as t
 
 from piccolo.apps.migrations.auto import MigrationManager
-from piccolo.apps.migrations.commands.base import BaseMigrationManager
+from piccolo.apps.migrations.commands.base import (
+    BaseMigrationManager,
+    MigrationResult,
+)
 from piccolo.apps.migrations.tables import Migration
 from piccolo.conf.apps import AppConfig, MigrationModule
 
 
 class ForwardsMigrationManager(BaseMigrationManager):
-    def __init__(
-        self,
-        app_name: str,
-        migration_id: str,
-        fake: bool = False,
-        *args,
-        **kwargs,
-    ):
+    def __init__(self, app_name: str, migration_id: str, fake: bool = False):
         self.app_name = app_name
         self.migration_id = migration_id
         self.fake = fake
         super().__init__()
 
-    async def run_migrations(self, app_config: AppConfig) -> None:
+    async def run_migrations(self, app_config: AppConfig) -> MigrationResult:
         already_ran = await Migration.get_migrations_which_ran(
             app_name=self.app_name
         )
@@ -38,10 +34,11 @@ class ForwardsMigrationManager(BaseMigrationManager):
         print(f"Haven't run = {havent_run}")
 
         if len(havent_run) == 0:
-            # Make sure a status of 0 is returned, as we don't want this
+            # Make sure this still appears successful, as we don't want this
             # to appear as an error in automated scripts.
-            print("No migrations left to run!")
-            sys.exit(0)
+            message = "No migrations left to run!"
+            print(message)
+            return MigrationResult(success=True, message=message)
 
         if self.migration_id == "all":
             subset = havent_run
@@ -51,7 +48,9 @@ class ForwardsMigrationManager(BaseMigrationManager):
             try:
                 index = havent_run.index(self.migration_id)
             except ValueError:
-                sys.exit(f"{self.migration_id} is unrecognised")
+                message = f"{self.migration_id} is unrecognised"
+                print(message, file=sys.stderr)
+                return MigrationResult(success=False, message=message)
             else:
                 subset = havent_run[: index + 1]
 
@@ -71,13 +70,45 @@ class ForwardsMigrationManager(BaseMigrationManager):
                 Migration(name=_id, app_name=self.app_name)
             ).run()
 
-    async def run(self):
+        return MigrationResult(success=True, message="Ran successfully")
+
+    async def run(self) -> MigrationResult:
         print("Running migrations ...")
         await self.create_migration_table()
 
         app_config = self.get_app_config(app_name=self.app_name)
 
-        await self.run_migrations(app_config)
+        return await self.run_migrations(app_config)
+
+
+async def run_forwards(
+    app_name: str, migration_id: str = "all", fake: bool = False
+) -> MigrationResult:
+    """
+    Run the migrations. This function can be used to programatically run
+    migrations - for example, in a unit test.
+    """
+    if app_name == "all":
+        sorted_app_names = BaseMigrationManager().get_sorted_app_names()
+        for _app_name in sorted_app_names:
+            print(f"\nMigrating {_app_name}")
+            print("------------------------------------------------")
+            manager = ForwardsMigrationManager(
+                app_name=_app_name, migration_id="all", fake=fake
+            )
+            response = await manager.run()
+            if not response.success:
+                return response
+
+    else:
+        manager = ForwardsMigrationManager(
+            app_name=app_name, migration_id=migration_id, fake=fake
+        )
+        response = await manager.run()
+        if not response.success:
+            return response
+
+    return MigrationResult(success=True)
 
 
 async def forwards(
@@ -97,17 +128,9 @@ async def forwards(
         If set, will record the migrations as being run without actually
         running them.
     """
-    if app_name == "all":
-        sorted_app_names = BaseMigrationManager().get_sorted_app_names()
-        for _app_name in sorted_app_names:
-            print(f"\nMigrating {_app_name}")
-            print("------------------------------------------------")
-            manager = ForwardsMigrationManager(
-                app_name=_app_name, migration_id="all", fake=fake
-            )
-            await manager.run()
-    else:
-        manager = ForwardsMigrationManager(
-            app_name=app_name, migration_id=migration_id, fake=fake
-        )
-        await manager.run()
+    response = await run_forwards(
+        app_name=app_name, migration_id=migration_id, fake=fake
+    )
+
+    if not response.success:
+        sys.exit(1)

--- a/tests/apps/app/commands/test_show_all.py
+++ b/tests/apps/app/commands/test_show_all.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
-from unittest.mock import call, patch
+from unittest.mock import call, patch, MagicMock
 
 from piccolo.apps.app.commands.show_all import show_all
 
 
 class TestShowAll(TestCase):
     @patch("piccolo.apps.app.commands.show_all.print")
-    def test_show_all(self, print_):
+    def test_show_all(self, print_: MagicMock):
         show_all()
 
         self.assertEqual(

--- a/tests/apps/migrations/commands/test_forwards_backwards.py
+++ b/tests/apps/migrations/commands/test_forwards_backwards.py
@@ -120,10 +120,17 @@ class TestForwardsBackwards(TestCase):
                 )
             )
 
-        self.assertTrue(
-            print_.mock_calls[0]
-            .args[0]
-            .startswith("Unrecognized migration name - must be one of ")
+        self.assertEqual(
+            len(
+                [
+                    i
+                    for i in print_.mock_calls
+                    if i.args[0].startswith(
+                        "Unrecognized migration name - must be one of "
+                    )
+                ]
+            ),
+            1,
         )
 
     @patch("piccolo.apps.migrations.commands.backwards.print")

--- a/tests/apps/migrations/commands/test_forwards_backwards.py
+++ b/tests/apps/migrations/commands/test_forwards_backwards.py
@@ -120,17 +120,10 @@ class TestForwardsBackwards(TestCase):
                 )
             )
 
-        self.assertEqual(
-            len(
-                [
-                    i
-                    for i in print_.mock_calls
-                    if i.args[0].startswith(
-                        "Unrecognized migration name - must be one of "
-                    )
-                ]
-            ),
-            1,
+        self.assertTrue(
+            tuple(print_.mock_calls[0])[1][0].startswith(
+                "Unrecognized migration name - must be one of "
+            )
         )
 
     @patch("piccolo.apps.migrations.commands.backwards.print")


### PR DESCRIPTION
If trying to run migrations programatically (e.g. in unit tests, as opposed to the command line), it isn't particularly user friendly, as any error states trigger `sys.exit`.

Reported here: https://github.com/piccolo-orm/piccolo/issues/85

The `forwards` and `backwards` commands have been refactored slightly to expose a nicer interface when run programatically.