### PR TITLE
Mixin fix

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -609,7 +609,11 @@ class MigrationManager:
                 _Table._meta.tablename = add_columns[0].tablename
 
                 for add_column in add_columns:
-                    column = add_column.column
+                    # We fetch the column from the Table, as the metaclass
+                    # copies and sets it up properly.
+                    column = _Table._meta.get_column_by_name(
+                        add_column.column._meta.name
+                    )
                     await _Table.alter().add_column(
                         name=column._meta.name, column=column
                     ).run()

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -215,6 +215,10 @@ class PostgresEngine(Engine):
         When the engine starts, it will try and create these extensions
         in Postgres.
 
+    :param log_queries:
+        If True, all SQL and DDL statements are printed out before being run.
+        Useful for debugging.
+
     """  # noqa: E501
 
     __slots__ = ("config", "extensions", "pool", "transaction_connection")
@@ -226,9 +230,11 @@ class PostgresEngine(Engine):
         self,
         config: t.Dict[str, t.Any],
         extensions: t.Sequence[str] = ["uuid-ossp"],
+        log_queries: bool = False,
     ) -> None:
         self.config = config
         self.extensions = extensions
+        self.log_queries = log_queries
         self.pool: t.Optional[Pool] = None
         database_name = config.get("database", "Unknown")
         self.transaction_connection = contextvars.ContextVar(
@@ -366,6 +372,9 @@ class PostgresEngine(Engine):
         query, query_args = querystring.compile_string(
             engine_type=self.engine_type
         )
+
+        if self.log_queries:
+            print(querystring)
 
         # If running inside a transaction:
         connection = self.transaction_connection.get()

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -172,7 +172,12 @@ class Table(metaclass=TableMetaclass):
 
             attribute = getattr(cls, attribute_name)
             if isinstance(attribute, Column):
-                column = attribute
+                # We have to copy, then override the existing column
+                # definition, in case this column is inheritted from a mixin.
+                # Otherwise, when we set attributes on that column, it will
+                # effect all other users of that mixin.
+                column = attribute.copy()
+                setattr(cls, attribute_name, column)
 
                 if isinstance(column, PrimaryKey):
                     # We want it at the start.
@@ -185,8 +190,8 @@ class Table(metaclass=TableMetaclass):
                 column._meta._name = attribute_name
                 column._meta._table = cls
 
-            if isinstance(column, ForeignKey):
-                foreign_key_columns.append(column)
+                if isinstance(column, ForeignKey):
+                    foreign_key_columns.append(column)
 
         cls._meta = TableMeta(
             tablename=tablename,

--- a/piccolo/utils/naming.py
+++ b/piccolo/utils/naming.py
@@ -1,14 +1,8 @@
-import re
+import inflection
 
 
-_camel_words = re.compile(r"([A-Z][a-z0-9_]+)")
-
-
-def _camel_to_snake(s):
-    """ Convert CamelCase to snake_case.
+def _camel_to_snake(string: str):
     """
-    return "_".join(
-        [
-            i.lower() for i in _camel_words.split(s)[1::2]
-        ]
-    )
+    Convert CamelCase to snake_case.
+    """
+    return inflection.underscore(string)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ black
 colorama>=0.4.0
 Jinja2>=2.11.0
 targ>=0.1.0
+inflection>=0.5.1

--- a/tests/apps/migrations/auto/test_migration_manager.py
+++ b/tests/apps/migrations/auto/test_migration_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+from piccolo.columns.column_types import ForeignKey
 from unittest.mock import patch, MagicMock
 
 from asyncpg.exceptions import UniqueViolationError
@@ -119,6 +120,7 @@ class TestMigrationManager(DBTestCase):
             table_class_name="Manager",
             tablename="manager",
             column_name="email",
+            column_class=Varchar,
             column_class_name="Varchar",
             params={
                 "length": 100,
@@ -156,6 +158,7 @@ class TestMigrationManager(DBTestCase):
             table_class_name="Manager",
             tablename="manager",
             column_name="email",
+            column_class=Varchar,
             column_class_name="Varchar",
             params={
                 "length": 100,
@@ -187,6 +190,7 @@ class TestMigrationManager(DBTestCase):
             table_class_name="Manager",
             tablename="manager",
             column_name="advisor",
+            column_class=ForeignKey,
             column_class_name="ForeignKey",
             params={
                 "references": "self",
@@ -235,6 +239,7 @@ class TestMigrationManager(DBTestCase):
             table_class_name="Manager",
             tablename="manager",
             column_name="email",
+            column_class=Varchar,
             column_class_name="Varchar",
             params={
                 "length": 100,

--- a/tests/table/test_inheritance.py
+++ b/tests/table/test_inheritance.py
@@ -25,6 +25,14 @@ class Manager(StartedOnMixin, FavouriteMixin, Table):
     name = Varchar()
 
 
+class ManagerA(StartedOnMixin, Table):
+    name = Varchar()
+
+
+class ManagerB(StartedOnMixin, Table):
+    name = Varchar()
+
+
 class TestInheritance(TestCase):
     """
     Make sure columns can be inheritted from parent classes.
@@ -56,3 +64,43 @@ class TestInheritance(TestCase):
         self.assertEqual(response["started_on"], started_on)
         self.assertEqual(response["name"], name)
         self.assertEqual(response["favourite"], favourite)
+
+
+class TestRepeatedMixin(TestCase):
+    """
+    Make sure that if a mixin is used multiple times (i.e. across several
+    Table classes), that it still works as expected.
+    """
+
+    def setUp(self):
+        ManagerA.create_table().run_sync()
+        ManagerB.create_table().run_sync()
+
+    def tearDown(self):
+        ManagerA.alter().drop_table().run_sync()
+        ManagerB.alter().drop_table().run_sync()
+
+    def test_inheritance(self):
+        """
+        Make sure both tables work as expected (they both inherit from the
+        same mixin).
+        """
+        # Make sure the columns can be retrieved from both tables:
+        for column_name in ("started_on", "name"):
+            for Table_ in (ManagerA, ManagerB):
+                Table_._meta.get_column_by_name(column_name)
+
+        # Test saving and retrieving data:
+        started_on = datetime.datetime(year=1989, month=12, day=1)
+        name = "Guido"
+
+        for _Table in (ManagerA, ManagerB):
+            _Table(name=name, started_on=started_on).save().run_sync()
+
+            response = _Table.select().first().run_sync()
+            self.assertEqual(response["started_on"], started_on)
+            self.assertEqual(response["name"], name)
+
+        # Make sure the tables have the correct tablenames still.
+        self.assertEqual(ManagerA._meta.tablename, "manager_a")
+        self.assertEqual(ManagerB._meta.tablename, "manager_b")

--- a/tests/utils/test_naming.py
+++ b/tests/utils/test_naming.py
@@ -1,0 +1,15 @@
+from piccolo.utils.naming import _camel_to_snake
+from unittest import TestCase
+
+
+class TestCamelToSnake(TestCase):
+    def test_converting_tablenames(self):
+        """
+        Make sure Table names are converted correctly.
+        """
+        self.assertEqual(_camel_to_snake("HelloWorld"), "hello_world")
+        self.assertEqual(_camel_to_snake("Manager1"), "manager1")
+        self.assertEqual(_camel_to_snake("ManagerAbc"), "manager_abc")
+        self.assertEqual(_camel_to_snake("ManagerABC"), "manager_abc")
+        self.assertEqual(_camel_to_snake("ManagerABCFoo"), "manager_abc_foo")
+        self.assertEqual(_camel_to_snake("ManagerA"), "manager_a")


### PR DESCRIPTION
When multiple tables inheritted from the same mixin, the queries generated were incorrect.

Issue and solution reported here:

https://github.com/piccolo-orm/piccolo/issues/93

The `Table` metaclass now copies columns instead of just storing a reference to them.