### PR TITLE
fix bug with `SerialisedBuiltin.__hash__` not returning a number

### DIFF
--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -23,7 +23,7 @@ class SerialisedBuiltin:
     builtin: t.Any
 
     def __hash__(self):
-        return self.builtin.__name__
+        return hash(self.builtin.__name__)
 
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()


### PR DESCRIPTION
Auto migrations could fail if a migration contained a builtin such as `list`, as the serialiser's hash method returned a `string` instead of an `int`.

https://github.com/piccolo-orm/piccolo/issues/89