### PR TITLE
added `change_permissions` command

### DIFF
--- a/docs/src/piccolo/authentication/baseuser.rst
+++ b/docs/src/piccolo/authentication/baseuser.rst
@@ -41,6 +41,25 @@ Change a user's password.
 
     piccolo user change_password
 
+user change_permissions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Change a user's permissions. The options are ``--admin``, ``--superuser`` and
+``--active``, which change the corresponding attributes on ``BaseUser``.
+
+For example:
+
+.. code-block:: bash
+
+    piccolo user change_permissions some_user --active=true
+
+The Piccolo Admin (see :ref:`Ecosystem`) uses these attributes to control who
+can login and what they can do.
+
+ * **active** and **admin** - must be true for a user to be able to login.
+ * **superuser** - must be true for a user to be able to change other user's
+   passwords.
+
 -------------------------------------------------------------------------------
 
 Within your code

--- a/piccolo/apps/user/commands/change_permissions.py
+++ b/piccolo/apps/user/commands/change_permissions.py
@@ -1,0 +1,50 @@
+import typing as t
+
+from piccolo.apps.user.tables import BaseUser
+from piccolo.utils.warnings import colored_string, Level
+
+if t.TYPE_CHECKING:
+    from piccolo.columns import Column
+
+
+async def change_permissions(
+    username: str,
+    admin: t.Optional[bool] = None,
+    superuser: t.Optional[bool] = None,
+    active: t.Optional[bool] = None,
+):
+    """
+    Change a user's permissions.
+
+    :param username:
+        Change the permissions for this user.
+    :param admin:
+        Set `admin` for the user (true / false).
+    :param superuser:
+        Set `superuser` for the user (true / false).
+    :param active:
+        Set `active` for the user (true / false).
+
+    """
+    if not await BaseUser.exists().where(BaseUser.username == username).run():
+        print(
+            colored_string(
+                f"User {username} doesn't exist!", level=Level.medium
+            )
+        )
+        return
+
+    params: t.Dict[Column, bool] = {}
+
+    if admin is not None:
+        params[BaseUser.admin] = admin
+
+    if superuser is not None:
+        params[BaseUser.superuser] = superuser
+
+    if active is not None:
+        params[BaseUser.active] = active
+
+    await BaseUser.update(params).where(BaseUser.username == username).run()
+
+    print(f"Updated permissions for {username}")

--- a/piccolo/apps/user/commands/create.py
+++ b/piccolo/apps/user/commands/create.py
@@ -44,6 +44,17 @@ def get_is_superuser() -> bool:
     return superuser == "y"
 
 
+def get_is_active() -> bool:
+    while True:
+        active = input("Active? Enter y or n:\n")
+        if active in ("y", "n"):
+            break
+        else:
+            print("Unrecognised option")
+
+    return active == "y"
+
+
 def create():
     """
     Create a new user.
@@ -61,13 +72,14 @@ def create():
 
     is_admin = get_is_admin()
     is_superuser = get_is_superuser()
+    is_active = get_is_active()
 
     user = BaseUser(
         username=username,
         password=password,
         admin=is_admin,
         email=email,
-        active=True,
+        active=is_active,
         superuser=is_superuser,
     )
     user.save().run_sync()

--- a/piccolo/apps/user/piccolo_app.py
+++ b/piccolo/apps/user/piccolo_app.py
@@ -2,6 +2,7 @@ import os
 
 from piccolo.conf.apps import AppConfig
 from .commands.change_password import change_password
+from .commands.change_permissions import change_permissions
 from .commands.create import create
 from .tables import BaseUser
 
@@ -16,5 +17,5 @@ APP_CONFIG = AppConfig(
     ),
     table_classes=[BaseUser],
     migration_dependencies=[],
-    commands=[create, change_password],
+    commands=[create, change_password, change_permissions],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ asyncpg>=0.21.0
 black
 colorama>=0.4.0
 Jinja2>=2.11.0
-targ>=0.1.0
+targ>=0.2.0
 inflection>=0.5.1

--- a/tests/apps/user/commands/test_create.py
+++ b/tests/apps/user/commands/test_create.py
@@ -35,6 +35,9 @@ class TestCreate(TestCase):
         "piccolo.apps.user.commands.create.get_is_superuser",
         return_value=True,
     )
+    @patch(
+        "piccolo.apps.user.commands.create.get_is_active", return_value=True,
+    )
     def test_create(self, *args, **kwargs):
         create()
 
@@ -45,6 +48,7 @@ class TestCreate(TestCase):
                 & (BaseUser.username == "bob123")
                 & (BaseUser.email == "bob@test.com")
                 & (BaseUser.superuser == True)
+                & (BaseUser.active == True)
             )
             .run_sync()
         )


### PR DESCRIPTION
From the command line you can now run:

```
piccolo user change_permissions user123 --superuser=true
```

The command can be used to change `active`, `superuser` and `admin` attributes of a user.