### PR TITLE
Added aliases for CLI commands

### DIFF
--- a/piccolo/apps/app/piccolo_app.py
+++ b/piccolo/apps/app/piccolo_app.py
@@ -1,8 +1,13 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.new import new
 from .commands.show_all import show_all
 
 
 APP_CONFIG = AppConfig(
-    app_name="app", migrations_folder_path="", commands=[new, show_all]
+    app_name="app",
+    migrations_folder_path="",
+    commands=[
+        Command(callable=new, aliases=["create"]),
+        Command(callable=show_all, aliases=["show", "all", "list"]),
+    ],
 )

--- a/piccolo/apps/asgi/piccolo_app.py
+++ b/piccolo/apps/asgi/piccolo_app.py
@@ -1,7 +1,9 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.new import new
 
 
 APP_CONFIG = AppConfig(
-    app_name="asgi", migrations_folder_path="", commands=[new]
+    app_name="asgi",
+    migrations_folder_path="",
+    commands=[Command(callable=new, aliases=["create"])],
 )

--- a/piccolo/apps/meta/piccolo_app.py
+++ b/piccolo/apps/meta/piccolo_app.py
@@ -1,7 +1,9 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.version import version
 
 
 APP_CONFIG = AppConfig(
-    app_name="meta", migrations_folder_path="", commands=[version]
+    app_name="meta",
+    migrations_folder_path="",
+    commands=[Command(callable=version, aliases=["v"])],
 )

--- a/piccolo/apps/migrations/piccolo_app.py
+++ b/piccolo/apps/migrations/piccolo_app.py
@@ -1,4 +1,4 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.backwards import backwards
 from .commands.check import check
 from .commands.clean import clean
@@ -9,5 +9,11 @@ from .commands.new import new
 APP_CONFIG = AppConfig(
     app_name="migrations",
     migrations_folder_path="",
-    commands=[backwards, check, clean, forwards, new],
+    commands=[
+        Command(callable=backwards, aliases=["b", "back", "backward"]),
+        Command(callable=check),
+        Command(callable=clean),
+        Command(callable=forwards, aliases=["f", "forward"]),
+        Command(callable=new, aliases=["n", "create"]),
+    ],
 )

--- a/piccolo/apps/playground/piccolo_app.py
+++ b/piccolo/apps/playground/piccolo_app.py
@@ -1,7 +1,9 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.run import run
 
 
 APP_CONFIG = AppConfig(
-    app_name="playground", migrations_folder_path="", commands=[run]
+    app_name="playground",
+    migrations_folder_path="",
+    commands=[Command(callable=run, aliases=["start"])],
 )

--- a/piccolo/apps/project/piccolo_app.py
+++ b/piccolo/apps/project/piccolo_app.py
@@ -1,7 +1,9 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.new import new
 
 
 APP_CONFIG = AppConfig(
-    app_name="project", migrations_folder_path="", commands=[new]
+    app_name="project",
+    migrations_folder_path="",
+    commands=[Command(callable=new, aliases=["create"])],
 )

--- a/piccolo/apps/shell/piccolo_app.py
+++ b/piccolo/apps/shell/piccolo_app.py
@@ -1,7 +1,9 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.run import run
 
 
 APP_CONFIG = AppConfig(
-    app_name="shell", migrations_folder_path="", commands=[run]
+    app_name="shell",
+    migrations_folder_path="",
+    commands=[Command(callable=run, aliases=["start"])],
 )

--- a/piccolo/apps/sql_shell/piccolo_app.py
+++ b/piccolo/apps/sql_shell/piccolo_app.py
@@ -1,7 +1,9 @@
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.run import run
 
 
 APP_CONFIG = AppConfig(
-    app_name="sql_shell", migrations_folder_path="", commands=[run]
+    app_name="sql_shell",
+    migrations_folder_path="",
+    commands=[Command(callable=run, aliases=["start"])],
 )

--- a/piccolo/apps/user/piccolo_app.py
+++ b/piccolo/apps/user/piccolo_app.py
@@ -1,6 +1,6 @@
 import os
 
-from piccolo.conf.apps import AppConfig
+from piccolo.conf.apps import AppConfig, Command
 from .commands.change_password import change_password
 from .commands.change_permissions import change_permissions
 from .commands.create import create
@@ -17,5 +17,9 @@ APP_CONFIG = AppConfig(
     ),
     table_classes=[BaseUser],
     migration_dependencies=[],
-    commands=[create, change_password, change_permissions],
+    commands=[
+        Command(callable=create, aliases=["new"]),
+        Command(callable=change_password, aliases=["password", "pass"]),
+        Command(callable=change_permissions, aliases=["perm", "perms"]),
+    ],
 )

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -85,6 +85,12 @@ def table_finder(
 
 
 @dataclass
+class Command:
+    callable: t.Callable
+    aliases: t.List[str] = field(default_factory=list)
+
+
+@dataclass
 class AppConfig:
     """
     Each app needs an AppConfig, which is defined in piccolo_app.py.
@@ -94,7 +100,14 @@ class AppConfig:
     migrations_folder_path: str
     table_classes: t.List[t.Type[Table]] = field(default_factory=list)
     migration_dependencies: t.List[str] = field(default_factory=list)
-    commands: t.List[t.Callable] = field(default_factory=list)
+    commands: t.List[t.Union[t.Callable, Command]] = field(
+        default_factory=list
+    )
+
+    def __post_init__(self):
+        self.commands = [
+            i if isinstance(i, Command) else Command(i) for i in self.commands
+        ]
 
     def register_table(self, table_class: t.Type[Table]):
         self.table_classes.append(table_class)

--- a/piccolo/main.py
+++ b/piccolo/main.py
@@ -61,7 +61,11 @@ def main():
         user_config,
     ]:
         for command in _app_config.commands:
-            cli.register(command, group_name=_app_config.app_name)
+            cli.register(
+                command.callable,
+                group_name=_app_config.app_name,
+                aliases=command.aliases,
+            )
 
     ###########################################################################
     # Get user defined apps.
@@ -78,11 +82,15 @@ def main():
         for app_name, _app_config in APP_REGISTRY.app_configs.items():
             for command in _app_config.commands:
                 if cli.command_exists(
-                    group_name=app_name, command_name=command.__name__
+                    group_name=app_name, command_name=command.callable.__name__
                 ):
                     # Skipping - already registered.
                     continue
-                cli.register(command, group_name=app_name)
+                cli.register(
+                    command.callable,
+                    group_name=app_name,
+                    aliases=command.aliases,
+                )
 
         if "migrations" not in sys.argv:
             # Show a warning if any migrations haven't been run.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ asyncpg>=0.21.0
 black
 colorama>=0.4.0
 Jinja2>=2.11.0
-targ>=0.2.0
+targ>=0.3.3
 inflection>=0.5.1


### PR DESCRIPTION
The targ library (used for the Piccolo CLI) now supports aliases for commands.

So now some longer Piccolo commands have an abbreviated form, and aliases have also been added for common typos in command names.

```bash
# These are equivalent:
piccolo migrations forwards all
piccolo migrations forward all
piccolo migrations f all
```
