### PR TITLE
Frozen queries

### DIFF
--- a/docs/src/piccolo/query_clauses/batch.rst
+++ b/docs/src/piccolo/query_clauses/batch.rst
@@ -33,5 +33,5 @@ There's currently no synchronous version. However, it's easy enough to achieve:
             async for _batch in batch:
                 print(_batch)
 
-    import asyncio
-    asyncio.run(get_batch())
+    from piccolo.utils.sync import run_sync
+    run_sync(get_batch())

--- a/docs/src/piccolo/query_clauses/freeze.rst
+++ b/docs/src/piccolo/query_clauses/freeze.rst
@@ -1,0 +1,10 @@
+.. _freeze:
+
+freeze
+======
+
+You can use the ``freeze`` clause with any query type.
+
+.. currentmodule:: piccolo.query.base
+
+.. automethod:: Query.freeze

--- a/docs/src/piccolo/query_clauses/index.rst
+++ b/docs/src/piccolo/query_clauses/index.rst
@@ -16,3 +16,4 @@ by modifying the return values.
     ./order_by
     ./where
     ./batch
+    ./freeze

--- a/piccolo/apps/user/tables.py
+++ b/piccolo/apps/user/tables.py
@@ -41,9 +41,7 @@ class BaseUser(Table, tablename="piccolo_user"):
     )
 
     def __init__(self, **kwargs):
-        """
-        Generating passwords upfront is expensive, so might need reworking.
-        """
+        # Generating passwords upfront is expensive, so might need reworking.
         password = kwargs.get("password", None)
         if password:
             kwargs["password"] = self.__class__.hash_password(password)

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -214,10 +214,23 @@ class Query:
         limit, output etc).
 
         """
+        querystrings = self.querystrings
+        for querystring in querystrings:
+            querystring.freeze(engine_type=self.engine_type)
+
         # Copy the query, so we don't store any references to the original.
         query = self.__class__(
             table=self.table, frozen_querystrings=self.querystrings
         )
+
+        if hasattr(self, "limit_delegate"):
+            # Needed for `response_handler`
+            query.limit_delegate = self.limit_delegate.copy()  # type: ignore
+
+        if hasattr(self, "output_delegate"):
+            # Needed for `_process_results`
+            query.output_delegate = self.output_delegate.copy()  # type: ignore
+
         return FrozenQuery(query=query)
 
     ###########################################################################

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -187,7 +187,7 @@ class Query:
         This is a performance optimisation when the same query is run
         repeatedly. For example:
 
-        .. code-block: python
+        .. code-block:: python
 
             TOP_BANDS = Band.select(
                 Band.name
@@ -207,11 +207,16 @@ class Query:
 
         It means that Piccolo doesn't have to work as hard each time the query
         is run to generate the corresponding SQL - some of it is cached. If the
-        query is defined within the endpoint, it has to generate the SQL from
-        scratch each time.
+        query is defined within the view/endpoint, it has to generate the SQL
+        from scratch each time.
 
-        Once a query is frozen, you can't apply any more clauses to it (where,
-        limit, output etc).
+        Once a query is frozen, you can't apply any more clauses to it
+        (``where``, ``limit``, ``output`` etc).
+
+        Even though ``freeze`` helps with performance, there are limits to
+        how much it can help, as most of the time is still spent waiting for a
+        response from the database. However, for high throughput apps and data
+        science scripts, it's a worthwhile optimisation.
 
         """
         querystrings = self.querystrings

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -506,7 +506,7 @@ class Alter(Query):
         return self
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         if self._drop_table is not None:
             return [self._drop_table.querystring]
 

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -293,8 +293,8 @@ class Alter(Query):
         "_set_unique",
     )
 
-    def __init__(self, table: t.Type[Table]):
-        super().__init__(table)
+    def __init__(self, table: t.Type[Table], **kwargs):
+        super().__init__(table, **kwargs)
         self._add_foreign_key_constraint: t.List[AddForeignKeyConstraint] = []
         self._add: t.List[AddColumn] = []
         self._drop_contraint: t.List[DropConstraint] = []

--- a/piccolo/query/methods/count.py
+++ b/piccolo/query/methods/count.py
@@ -27,7 +27,7 @@ class Count(Query):
         return response[0]["count"]
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         select = Select(self.table)
         select.where_delegate._where = self.where_delegate._where
         return [

--- a/piccolo/query/methods/count.py
+++ b/piccolo/query/methods/count.py
@@ -15,8 +15,8 @@ if t.TYPE_CHECKING:  # pragma: no cover
 class Count(Query):
     __slots__ = ("where_delegate",)
 
-    def __init__(self, table: t.Type[Table]):
-        super().__init__(table)
+    def __init__(self, table: t.Type[Table], **kwargs):
+        super().__init__(table, **kwargs)
         self.where_delegate = WhereDelegate()
 
     def where(self, where: Combinable) -> Count:

--- a/piccolo/query/methods/create.py
+++ b/piccolo/query/methods/create.py
@@ -27,7 +27,7 @@ class Create(Query):
         self.only_default_columns = only_default_columns
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         prefix = "CREATE TABLE"
         if self.if_not_exists:
             prefix += " IF NOT EXISTS"

--- a/piccolo/query/methods/create.py
+++ b/piccolo/query/methods/create.py
@@ -21,8 +21,9 @@ class Create(Query):
         table: t.Type[Table],
         if_not_exists: bool = False,
         only_default_columns: bool = False,
+        **kwargs,
     ):
-        super().__init__(table)
+        super().__init__(table, **kwargs)
         self.if_not_exists = if_not_exists
         self.only_default_columns = only_default_columns
 

--- a/piccolo/query/methods/create_index.py
+++ b/piccolo/query/methods/create_index.py
@@ -17,11 +17,12 @@ class CreateIndex(Query):
         columns: t.List[t.Union[Column, str]],
         method: IndexMethod = IndexMethod.btree,
         if_not_exists: bool = False,
+        **kwargs,
     ):
         self.columns = columns
         self.method = method
         self.if_not_exists = if_not_exists
-        super().__init__(table)
+        super().__init__(table, **kwargs)
 
     @property
     def column_names(self) -> t.List[str]:

--- a/piccolo/query/methods/delete.py
+++ b/piccolo/query/methods/delete.py
@@ -18,8 +18,8 @@ class Delete(Query):
 
     __slots__ = ("force", "where_delegate")
 
-    def __init__(self, table: t.Type[Table], force: bool = False):
-        super().__init__(table)
+    def __init__(self, table: t.Type[Table], force: bool = False, **kwargs):
+        super().__init__(table, **kwargs)
         self.force = force
         self.where_delegate = WhereDelegate()
 

--- a/piccolo/query/methods/delete.py
+++ b/piccolo/query/methods/delete.py
@@ -40,7 +40,7 @@ class Delete(Query):
             )
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         query = f"DELETE FROM {self.table._meta.tablename}"
         if self.where_delegate._where:
             query += " WHERE {}"

--- a/piccolo/query/methods/drop_index.py
+++ b/piccolo/query/methods/drop_index.py
@@ -15,10 +15,11 @@ class DropIndex(Query):
         table: t.Type[Table],
         columns: t.List[t.Union[Column, str]],
         if_exists: bool = True,
+        **kwargs,
     ):
         self.columns = columns
-        self.if_exists = True
-        super().__init__(table)
+        self.if_exists = if_exists
+        super().__init__(table, **kwargs)
 
     @property
     def column_names(self) -> t.List[str]:

--- a/piccolo/query/methods/drop_index.py
+++ b/piccolo/query/methods/drop_index.py
@@ -27,7 +27,7 @@ class DropIndex(Query):
         ]
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         column_names = self.column_names
         index_name = self.table._get_index_name(column_names)
         query = "DROP INDEX"

--- a/piccolo/query/methods/exists.py
+++ b/piccolo/query/methods/exists.py
@@ -29,7 +29,7 @@ class Exists(Query):
         return bool(response[0]["exists"])
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         select = Select(table=self.table)
         select.where_delegate._where = self.where_delegate._where
         return [

--- a/piccolo/query/methods/exists.py
+++ b/piccolo/query/methods/exists.py
@@ -16,8 +16,8 @@ if t.TYPE_CHECKING:  # pragma: no cover
 class Exists(Query):
     __slots__ = ("where_delegate",)
 
-    def __init__(self, table: t.Type[Table]):
-        super().__init__(table)
+    def __init__(self, table: t.Type[Table], **kwargs):
+        super().__init__(table, **kwargs)
         self.where_delegate = WhereDelegate()
 
     def where(self, where: Combinable) -> Exists:

--- a/piccolo/query/methods/insert.py
+++ b/piccolo/query/methods/insert.py
@@ -14,8 +14,8 @@ if t.TYPE_CHECKING:  # pragma: no cover
 class Insert(Query):
     __slots__ = ("add_delegate",)
 
-    def __init__(self, table: t.Type[Table], *instances: Table):
-        super().__init__(table)
+    def __init__(self, table: t.Type[Table], *instances: Table, **kwargs):
+        super().__init__(table, **kwargs)
         self.add_delegate = AddDelegate()
         self.add(*instances)
 

--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -81,7 +81,7 @@ class Objects(Query):
             return response
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         select = Select(table=self.table)
 
         for attr in (

--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -35,8 +35,8 @@ class Objects(Query):
         "where_delegate",
     )
 
-    def __init__(self, table: t.Type[Table]):
-        super().__init__(table)
+    def __init__(self, table: t.Type[Table], **kwargs):
+        super().__init__(table, **kwargs)
         self.limit_delegate = LimitDelegate()
         self.offset_delegate = OffsetDelegate()
         self.order_by_delegate = OrderByDelegate()

--- a/piccolo/query/methods/raw.py
+++ b/piccolo/query/methods/raw.py
@@ -14,9 +14,12 @@ class Raw(Query):
     __slots__ = ("querystring",)
 
     def __init__(
-        self, table: t.Type[Table], querystring: QueryString = QueryString("")
+        self,
+        table: t.Type[Table],
+        querystring: QueryString = QueryString(""),
+        **kwargs
     ):
-        super().__init__(table)
+        super().__init__(table, **kwargs)
         self.querystring = querystring
 
     @property

--- a/piccolo/query/methods/raw.py
+++ b/piccolo/query/methods/raw.py
@@ -20,5 +20,5 @@ class Raw(Query):
         self.querystring = querystring
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         return [self.querystring]

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -65,8 +65,9 @@ class Select(Query):
         table: t.Type[Table],
         columns_list: t.Sequence[t.Union[Selectable, str]] = [],
         exclude_secrets: bool = False,
+        **kwargs,
     ):
-        super().__init__(table)
+        super().__init__(table, **kwargs)
         self.exclude_secrets = exclude_secrets
 
         self.columns_delegate = ColumnsDelegate()

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -212,7 +212,7 @@ class Select(Query):
         return True
 
     @property
-    def querystrings(self) -> t.Sequence[QueryString]:
+    def default_querystrings(self) -> t.Sequence[QueryString]:
         # JOIN
         self._check_valid_call_chain(self.columns_delegate.selected_columns)
 

--- a/piccolo/query/methods/update.py
+++ b/piccolo/query/methods/update.py
@@ -17,8 +17,8 @@ class Update(Query):
 
     __slots__ = ("values_delegate", "where_delegate")
 
-    def __init__(self, table: t.Type[Table]):
-        super().__init__(table)
+    def __init__(self, table: t.Type[Table], **kwargs):
+        super().__init__(table, **kwargs)
         self.values_delegate = ValuesDelegate()
         self.where_delegate = WhereDelegate()
 

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -29,6 +29,9 @@ class Limit:
     def __str__(self) -> str:
         return self.querystring.__str__()
 
+    def copy(self) -> Limit:
+        return self.__class__(number=self.number)
+
 
 @dataclass
 class Offset:
@@ -73,6 +76,13 @@ class Output:
     as_json: bool = False
     as_list: bool = False
     as_objects: bool = False
+
+    def copy(self) -> Output:
+        return self.__class__(
+            as_json=self.as_json,
+            as_list=self.as_list,
+            as_objects=self.as_objects,
+        )
 
 
 @dataclass
@@ -120,7 +130,7 @@ class OrderByDelegate:
 class LimitDelegate:
 
     _limit: t.Optional[Limit] = None
-    _first = False
+    _first: bool = False
 
     def limit(self, number: int):
         self._limit = Limit(number)
@@ -128,6 +138,10 @@ class LimitDelegate:
     def first(self):
         self.limit(1)
         self._first = True
+
+    def copy(self) -> LimitDelegate:
+        _limit = self._limit.copy() if self._limit is not None else None
+        return self.__class__(_limit=_limit, _first=self._first)
 
 
 @dataclass
@@ -190,6 +204,10 @@ class OutputDelegate:
 
         if type(as_json) is bool:
             self._output.as_json = bool(as_json)
+
+    def copy(self) -> OutputDelegate:
+        _output = self._output.copy() if self._output is not None else None
+        return self.__class__(_output=_output)
 
 
 @dataclass

--- a/piccolo/querystring.py
+++ b/piccolo/querystring.py
@@ -32,7 +32,7 @@ class QueryString:
     engine - which helps prevent SQL Injection attacks.
     """
 
-    __slots__ = ("template", "args", "query_type")
+    __slots__ = ("template", "args", "query_type", "_frozen_compiled_strings")
 
     def __init__(
         self, template: str, *args: t.Any, query_type: str = "generic"
@@ -46,6 +46,9 @@ class QueryString:
         self.template = template
         self.args = args
         self.query_type = query_type
+        self._frozen_compiled_strings: t.Optional[
+            t.Tuple[str, t.List[t.Any]]
+        ] = None
 
     def __str__(self):
         """
@@ -124,6 +127,9 @@ class QueryString:
         Compiles the template ready for the engine - keeping the arguments
         separate from the template.
         """
+        if self._frozen_compiled_strings is not None:
+            return self._frozen_compiled_strings
+
         _, bundled, combined_args = self.bundle(
             start_index=1, bundled=[], combined_args=[]
         )
@@ -146,3 +152,8 @@ class QueryString:
             raise Exception("Engine type not recognised")
 
         return (string, combined_args)
+
+    def freeze(self, engine_type: str = "postgres"):
+        self._frozen_compiled_strings = self.compile_string(
+            engine_type=engine_type
+        )

--- a/tests/query/test_freeze.py
+++ b/tests/query/test_freeze.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+import timeit
+import typing as t
+from unittest.mock import patch
+
+from piccolo.query.base import Query
+
+from tests.base import DBTestCase
+from tests.example_app.tables import Band
+
+
+@dataclass
+class QueryResponse:
+    query: Query
+    response: t.Any
+
+
+class TestFreeze(DBTestCase):
+    def test_frozen_select_queries(self):
+        """
+        Make sure a variety of select queries work as expected when frozen.
+        """
+        self.insert_rows()
+
+        query_responses: t.List[QueryResponse] = [
+            QueryResponse(
+                query=(
+                    Band.select(Band.name)
+                    .order_by(Band.popularity, ascending=False)
+                    .first()
+                    .freeze()
+                ),
+                response={"name": "Rustaceans"},
+            ),
+            QueryResponse(
+                query=(
+                    Band.select(Band.name)
+                    .order_by(Band.popularity, ascending=False)
+                    .freeze()
+                ),
+                response=[
+                    {"name": "Rustaceans"},
+                    {"name": "Pythonistas"},
+                    {"name": "CSharps"},
+                ],
+            ),
+            QueryResponse(
+                query=(
+                    Band.select(Band.name)
+                    .where(Band.name == "Pythonistas")
+                    .freeze()
+                ),
+                response=[{"name": "Pythonistas"}],
+            ),
+            QueryResponse(
+                query=(
+                    Band.select(Band.name)
+                    .where(Band.name == "Pythonistas")
+                    .output(as_json=True)
+                    .freeze()
+                ),
+                response='[{"name":"Pythonistas"}]',
+            ),
+        ]
+
+        for query_response in query_responses:
+            result = query_response.query.run_sync()
+            self.assertEqual(result, query_response.response)
+
+    # def test_frozen_performance(self):
+    #     """
+    #     The frozen query performance should exceed the non-frozen. If not,
+    #     there's a problem.
+    #     """
+    #     with patch.object(Band._meta.db, "run_querystring"):
+    #         pass
+
+    #     iterations = 50
+    #     query = Band.select().where(Band.name == "Pythonistas").first()
+    #     query_duration = timeit.timeit(
+    #         lambda: query.run_sync(), number=iterations
+    #     )
+
+    #     # patch out the actual database call ... patching the engine is
+    #     # quite challenging ...
+
+    #     frozen_query = query.freeze()
+    #     frozen_query_duration = timeit.timeit(
+    #         lambda: frozen_query.run_sync(), number=iterations
+    #     )
+    #     self.assertTrue(query_duration > frozen_query_duration)
+
+    # def test_attribute_access(self):
+    #     pass

--- a/tests/query/test_freeze.py
+++ b/tests/query/test_freeze.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
 import timeit
 import typing as t
-from unittest.mock import patch
 
 from piccolo.query.base import Query
 
-from tests.base import DBTestCase
+from tests.base import DBTestCase, sqlite_only
 from tests.example_app.tables import Band
 
 
@@ -52,43 +51,62 @@ class TestFreeze(DBTestCase):
                 ),
                 response=[{"name": "Pythonistas"}],
             ),
-            QueryResponse(
-                query=(
-                    Band.select(Band.name)
-                    .where(Band.name == "Pythonistas")
-                    .output(as_json=True)
-                    .freeze()
-                ),
-                response='[{"name":"Pythonistas"}]',
-            ),
         ]
 
         for query_response in query_responses:
             result = query_response.query.run_sync()
             self.assertEqual(result, query_response.response)
 
-    # def test_frozen_performance(self):
-    #     """
-    #     The frozen query performance should exceed the non-frozen. If not,
-    #     there's a problem.
-    #     """
-    #     with patch.object(Band._meta.db, "run_querystring"):
-    #         pass
+    def test_output_clause(self):
+        """
+        Make sure the output clause still works correctly with frozen queries.
+        """
+        self.insert_rows()
 
-    #     iterations = 50
-    #     query = Band.select().where(Band.name == "Pythonistas").first()
-    #     query_duration = timeit.timeit(
-    #         lambda: query.run_sync(), number=iterations
-    #     )
+        result = (
+            Band.select(Band.name)
+            .where(Band.name == "Pythonistas")
+            .output(as_json=True)
+            .freeze()
+            .run_sync()
+        )
+        # Some JSON encoders have a space after the colons and some don't,
+        # so normalise them.
+        self.assertEqual(result.replace(" ", ""), '[{"name":"Pythonistas"}]')
 
-    #     # patch out the actual database call ... patching the engine is
-    #     # quite challenging ...
+    @sqlite_only
+    def test_frozen_performance(self):
+        """
+        The frozen query performance should exceed the non-frozen. If not,
+        there's a problem.
 
-    #     frozen_query = query.freeze()
-    #     frozen_query_duration = timeit.timeit(
-    #         lambda: frozen_query.run_sync(), number=iterations
-    #     )
-    #     self.assertTrue(query_duration > frozen_query_duration)
+        Only test this on SQLite, as the latency from the database itself
+        is more predictable than with Postgres, and the test runs quickly.
 
-    # def test_attribute_access(self):
-    #     pass
+        """
+        iterations = 50
+        query = Band.select().where(Band.name == "Pythonistas").first()
+        query_duration = timeit.repeat(
+            lambda: query.run_sync(), repeat=iterations, number=1
+        )
+
+        frozen_query = query.freeze()
+        frozen_query_duration = timeit.repeat(
+            lambda: frozen_query.run_sync(), repeat=iterations, number=1
+        )
+
+        # Remove the outliers before comparing
+        self.assertTrue(
+            sum(sorted(query_duration)[5:-5])
+            > sum(sorted(frozen_query_duration)[5:-5])
+        )
+
+    def test_attribute_access(self):
+        """
+        Once frozen, you shouldn't be able to call additional methods on the
+        query (for example `.where`).
+        """
+        query = Band.select().freeze()
+
+        with self.assertRaises(AttributeError):
+            query.where(Band.name == "Pythonistas")


### PR DESCRIPTION
Added a ``freeze`` method to queries, which pre-calculates and caches the SQL which needs to be run.

This can aid performance when the same query is being run repeatedly.

Here's an example:

```python
TOP_BANDS = Band.select(
    Band.name
).order_by(
    Band.popularity,
    ascending=False
).limit(
    10
).output(
    as_json=True
).freeze()

# In the corresponding view/endpoint of whichever web framework
# you're using:
async def top_bands(self, request):
    return await TOP_BANDS.run()
```
