### PR TITLE
don't allow apps to be created with names the same as builtin Python modules

### DIFF
--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import importlib
 import os
 import sys
 import typing as t
@@ -16,6 +17,19 @@ JINJA_ENV = jinja2.Environment(
 )
 
 
+def module_exists(module_name: str) -> bool:
+    """
+    Check whether a Python module already exists with this name - for
+    example, a builtin module.
+    """
+    try:
+        importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return False
+    else:
+        return True
+
+
 def new_app(app_name: str, root: str = "."):
     print(f"Creating {app_name} app ...")
 
@@ -23,6 +37,13 @@ def new_app(app_name: str, root: str = "."):
 
     if os.path.exists(app_root):
         sys.exit("Folder already exists - exiting.")
+
+    if module_exists(app_name):
+        sys.exit(
+            f"A module called {app_name} already exists - possibly a builtin "
+            "Python module. Please choose a different name for your app."
+        )
+
     os.mkdir(app_root)
 
     with open(os.path.join(app_root, "__init__.py"), "w"):

--- a/tests/apps/app/commands/test_new.py
+++ b/tests/apps/app/commands/test_new.py
@@ -2,7 +2,13 @@ import os
 import shutil
 from unittest import TestCase
 
-from piccolo.apps.app.commands.new import new
+from piccolo.apps.app.commands.new import new, module_exists
+
+
+class TestModuleExists(TestCase):
+    def test_module_exists(self):
+        self.assertEqual(module_exists("sys"), True)
+        self.assertEqual(module_exists("abc123xyz"), False)
 
 
 class TestNewApp(TestCase):
@@ -18,3 +24,19 @@ class TestNewApp(TestCase):
         new(app_name=app_name, root=root)
 
         self.assertTrue(os.path.exists(app_path))
+
+    def test_new_with_clashing_name(self):
+        """
+        Test trying to create an app with the same name as a builtin Python
+        package - it shouldn't be allowed.
+        """
+        root = "/tmp"
+        app_name = "sys"
+
+        with self.assertRaises(SystemExit) as context:
+            new(app_name=app_name, root=root)
+
+        exception = context.exception
+        self.assertTrue(
+            exception.code.startswith("A module called sys already exists")
+        )


### PR DESCRIPTION
If you accidentally create a Piccolo app with the same name as a builtin Python module, it can lead to some very confusing bugs.

For example, an app called 'profile' (Python has a builtin module with the same name https://docs.python.org/3/library/profile.html).

 An error will now be raised in this situation.