### PR TITLE
fixing a bug in the fluent interface, when accessing the id column

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -1199,8 +1199,6 @@ class ForeignKey(Integer):
                     i for i in new_column._meta.call_chain
                 ]
                 _column._meta.call_chain.append(new_column)
-                if _column._meta.name == "id":
-                    continue
                 setattr(new_column, _column._meta.name, _column)
                 foreign_key_meta.proxy_columns.append(_column)
 


### PR DESCRIPTION
If accessing `Concert.band_1.manager.id`, an attribute error would be raised, because `id` doesn't exist.

The bug only happened if traversing multiple foreign keys, and only if accessing the `id` column.