### PR TITLE
the `where` clause can now accept `Table` instances

### DIFF
--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -5,7 +5,7 @@ from piccolo.columns.combination import WhereRaw
 from piccolo.query.methods.select import Count
 
 from ..base import DBTestCase, postgres_only, sqlite_only
-from ..example_app.tables import Band, Concert
+from ..example_app.tables import Band, Concert, Manager
 
 
 class TestSelect(DBTestCase):
@@ -27,6 +27,30 @@ class TestSelect(DBTestCase):
         print(f"response = {response}")
 
         self.assertDictEqual(response[0], {"name": "Pythonistas"})
+
+    def test_where_equals(self):
+        self.insert_row()
+
+        manager = Manager.objects().first().run_sync()
+
+        # This is the recommended way of running these types of queries:
+        response = (
+            Band.select(Band.name)
+            .where(Band.manager.id == manager.id)
+            .run_sync()
+        )
+        self.assertEqual(response, [{"name": "Pythonistas"}])
+
+        # Other cases which should work:
+        response = (
+            Band.select(Band.name).where(Band.manager == manager).run_sync()
+        )
+        self.assertEqual(response, [{"name": "Pythonistas"}])
+
+        response = (
+            Band.select(Band.name).where(Band.manager.id == manager).run_sync()
+        )
+        self.assertEqual(response, [{"name": "Pythonistas"}])
 
     def test_where_like(self):
         self.insert_rows()


### PR DESCRIPTION
Slightly modified the `where` clause.

```python
# This is how you're supposed to do it:
await Band.select().where(Band.manager.id == some_manager.id).run()

# The following queries will now also work:
await Band.select().where(Band.manager == some_manager).run()
await Band.select().where(Band.manager.id == some_manager).run()
```