### PR TITLE
Fix protected tablename bug

### DIFF
--- a/piccolo/apps/migrations/auto/diffable_table.py
+++ b/piccolo/apps/migrations/auto/diffable_table.py
@@ -12,7 +12,7 @@ from piccolo.apps.migrations.auto.serialisation import (
     serialise_params,
     deserialise_params,
 )
-from piccolo.table import Table
+from piccolo.table import Table, create_table_class
 
 
 def compare_dicts(dict_1, dict_2) -> t.Dict[str, t.Any]:
@@ -144,10 +144,12 @@ class DiffableTable:
         """
         Converts the DiffableTable into a Table subclass.
         """
-        _Table: t.Type[Table] = type(
-            self.class_name,
-            (Table,),
-            {column._meta.name: column for column in self.columns},
+        _Table: t.Type[Table] = create_table_class(
+            class_name=self.class_name,
+            class_kwargs={"tablename": self.tablename},
+            class_members={
+                column._meta.name: column for column in self.columns
+            },
         )
-        _Table._meta.tablename = self.tablename
+
         return _Table

--- a/piccolo/apps/migrations/auto/serialisation_legacy.py
+++ b/piccolo/apps/migrations/auto/serialisation_legacy.py
@@ -3,7 +3,7 @@ import datetime
 import typing as t
 
 from piccolo.columns.column_types import OnDelete, OnUpdate
-from piccolo.table import Table
+from piccolo.table import Table, create_table_class
 from piccolo.columns.defaults.timestamp import TimestampNow
 
 
@@ -25,11 +25,10 @@ def deserialise_legacy_params(name: str, value: str) -> t.Any:
                 "`SomeClassName` or `SomeClassName|some_table_name`."
             )
 
-        _Table: t.Type[Table] = type(
-            class_name, (Table,), {},
+        _Table: t.Type[Table] = create_table_class(
+            class_name=class_name,
+            class_kwargs={"tablename": tablename} if tablename else {},
         )
-        if tablename:
-            _Table._meta.tablename = tablename
         return _Table
 
     ###########################################################################

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 import inspect
 import itertools
+import types
 import typing as t
 
 from piccolo.engine import Engine, engine_finder
@@ -719,3 +720,32 @@ class Table(metaclass=TableMetaclass):
         return (
             f"class {cls.__name__}({class_args}):\n" f"    {columns_string}\n"
         )
+
+
+def create_table_class(
+    class_name: str,
+    bases: t.Tuple[t.Type] = (Table,),
+    class_kwargs: t.Dict[str, t.Any] = {},
+    class_members: t.Dict[str, t.Any] = {},
+) -> t.Type[Table]:
+    """
+    Used to dynamically create ``Table``subclasses at runtime. Most users
+    will not require this. It's mostly used internally for Piccolo's
+    migrations.
+
+    :param class_name:
+        For example `'MyTable'`.
+    :param bases:
+        A tuple of parent classes - usually just `(Table,)`.
+    :param class_kwargs:
+        For example, `{'tablename': 'my_custom_tablename'}`.
+    :param class_members:
+        For example, `{'my_column': Varchar()}`.
+
+    """
+    return types.new_class(
+        name=class_name,
+        bases=bases,
+        kwds=class_kwargs,
+        exec_body=lambda namespace: namespace.update(class_members),
+    )

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,7 +8,7 @@ import pytest
 from piccolo.engine.finder import engine_finder
 from piccolo.engine.postgres import PostgresEngine
 from piccolo.engine.sqlite import SQLiteEngine
-from piccolo.table import Table
+from piccolo.table import Table, create_table_class
 
 
 ENGINE = engine_finder()
@@ -47,12 +47,13 @@ class DBTestCase(TestCase):
     """
 
     def run_sync(self, query):
-        _Table = type("_Table", (Table,), {})
+        _Table = create_table_class(class_name="_Table")
         return _Table.raw(query).run_sync()
 
     def table_exists(self, tablename: str) -> bool:
-        _Table: t.Type[Table] = type(tablename.upper(), (Table,), {})
-        _Table._meta.tablename = tablename
+        _Table: t.Type[Table] = create_table_class(
+            class_name=tablename.upper(), class_kwargs={"tablename": tablename}
+        )
         return _Table.table_exists().run_sync()
 
     ###########################################################################

--- a/tests/table/test_create_table_class.py
+++ b/tests/table/test_create_table_class.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+
+from piccolo.table import create_table_class
+from piccolo.columns import Varchar
+
+
+class TestCreateTableClass(TestCase):
+    def test_create_table_class(self):
+        """
+        Make sure a basic `Table` can be created successfully.
+        """
+        _Table = create_table_class(class_name="MyTable")
+        self.assertEqual(_Table._meta.tablename, "my_table")
+
+        _Table = create_table_class(
+            class_name="MyTable", class_kwargs={"tablename": "my_table_1"}
+        )
+        self.assertEqual(_Table._meta.tablename, "my_table_1")
+
+        column = Varchar()
+        _Table = create_table_class(
+            class_name="MyTable", class_members={"name": column}
+        )
+        self.assertTrue(column in _Table._meta.columns)
+
+    def test_protected_tablenames(self):
+        """
+        Make sure that the logic around protected tablenames still works as
+        expected.
+        """
+        with self.assertRaises(ValueError):
+            create_table_class(class_name="User")
+
+        with self.assertRaises(ValueError):
+            create_table_class(
+                class_name="MyUser", class_kwargs={"tablename": "user"}
+            )
+
+        # This shouldn't raise an error:
+        create_table_class(
+            class_name="User", class_kwargs={"tablename": "my_user"}
+        )


### PR DESCRIPTION
There was a bug when a `Table` subclass was called `User`. Even if the `tablename` value was specified, an error would be raised when trying to run the migrations.

```python
# Should work:
class User(Table, tablename="my_user"):
    ...
```

As discussed here:

https://github.com/piccolo-orm/piccolo/issues/111

The solution was to use `types.create_class`, instead of the `type` function.

