### PR TITLE
Migration fixes

### DIFF
--- a/piccolo/apps/migrations/auto/diffable_table.py
+++ b/piccolo/apps/migrations/auto/diffable_table.py
@@ -51,10 +51,7 @@ class ColumnComparison:
 
     def __eq__(self, value) -> bool:
         if isinstance(value, ColumnComparison):
-            return (
-                serialise_params(self.column._meta.params).params
-                == serialise_params(value.column._meta.params).params
-            ) and (self.column._meta.name == value.column._meta.name)
+            return self.column._meta.name == value.column._meta.name
         return False
 
 


### PR DESCRIPTION
A fix for https://github.com/piccolo-orm/piccolo/issues/123

When migrations were comparing columns, it was triggering the `__eq__` method of `Column`, which was raising an error.

Created a `ColumnComparison` class, which wraps `Column` when comparing is required.