### PR TITLE
Boolean equality

### DIFF
--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -30,6 +30,12 @@ Equal / Not Equal
         b.name != 'Rustaceans'
     ).run_sync()
 
+.. hint:: With ``Boolean`` columns, some linters will complain if you write
+    ``SomeTable.some_column == True`` (because it's more Pythonic to do
+    ``is True``). To work around this, you can do
+    ``SomeTable.some_column.eq(True)``. Likewise, with ``!=`` you can use
+    ``SomeTable.some_column.ne(True)``
+
 -------------------------------------------------------------------------------
 
 Greater than / less than

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -799,6 +799,46 @@ class Boolean(Column):
         kwargs.update({"default": default})
         super().__init__(**kwargs)
 
+    def eq(self, value) -> Where:
+        """
+        When using ``Boolean`` columns in ``where`` clauses, some Python
+        linters don't like it when you do something like:
+
+        .. code-block:: python
+
+            await MyTable.select().where(
+                MyTable.some_boolean_column == True
+            ).run()
+
+        It's more Pythonic to use ``is True`` rather than ``== True``, which is
+        why linters complain. The work around is to do the following instead:
+
+        .. code-block:: python
+
+            await MyTable.select().where(
+                MyTable.some_boolean_column.__eq__(True)
+            ).run()
+
+        Using the ``__eq__`` magic method is a bit untidy, which is why this
+        ``eq`` method exists.
+
+        .. code-block:: python
+
+            await MyTable.select().where(
+                MyTable.some_boolean_column.eq(True)
+            ).run()
+
+        The ``ne`` method exists for the same reason, for ``!=``.
+
+        """
+        return self.__eq__(value)
+
+    def ne(self, value) -> Where:
+        """
+        See the ``eq`` method for more details.
+        """
+        return self.__ne__(value)
+
 
 ###############################################################################
 

--- a/tests/columns/test_boolean.py
+++ b/tests/columns/test_boolean.py
@@ -49,4 +49,3 @@ class TestBoolean(TestCase):
         self.assertEqual(
             MyTable.count().where(MyTable.boolean.ne(True)).run_sync(), 1
         )
-

--- a/tests/columns/test_boolean.py
+++ b/tests/columns/test_boolean.py
@@ -31,3 +31,22 @@ class TestBoolean(TestCase):
                 .run_sync()["boolean"],
                 expected,
             )
+
+    def test_eq_and_ne(self):
+        """
+        Make sure the `eq` and `ne` methods works correctly.
+        """
+        MyTable.insert(
+            MyTable(boolean=True),
+            MyTable(boolean=False),
+            MyTable(boolean=True),
+        ).run_sync()
+
+        self.assertEqual(
+            MyTable.count().where(MyTable.boolean.eq(True)).run_sync(), 2
+        )
+
+        self.assertEqual(
+            MyTable.count().where(MyTable.boolean.ne(True)).run_sync(), 1
+        )
+


### PR DESCRIPTION
Add `ne` and `eq` methods to the `Boolean` column to avoid linter errors when doing `MyTable.some_boolean_column == True`.