### PR TITLE
update-engine-docs-piccolo-conf-example

### DIFF
--- a/docs/src/piccolo/engines/index.rst
+++ b/docs/src/piccolo/engines/index.rst
@@ -95,7 +95,10 @@ variable accordingly.
 
     DB = SQLiteEngine(path='my_test_db.sqlite')
 
-.. hint:: You can also specify sub modules, like `my_module.piccolo_conf`.
+If the ``picolo_conf`` file is located in a sub-module (rather than the root of your project) you can specify the path:
+
+.. code-block:: bash
+    export PICCOLO_CONF=sub_module.piccolo_conf
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/engines/index.rst
+++ b/docs/src/piccolo/engines/index.rst
@@ -95,9 +95,11 @@ variable accordingly.
 
     DB = SQLiteEngine(path='my_test_db.sqlite')
 
-If the ``picolo_conf`` file is located in a sub-module (rather than the root of your project) you can specify the path:
+If the ``piccolo_conf.py`` file is located in a sub-module (rather than the
+root of your project) you can specify the path like this:
 
 .. code-block:: bash
+
     export PICCOLO_CONF=sub_module.piccolo_conf
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #102 
Add example of `PICCOLO_CONF` env variable inside sub-modules.