### PR TITLE
add alias and as_alias to Count method

### DIFF
--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -247,7 +247,7 @@ class Selectable(metaclass=ABCMeta):
 
     def as_alias(self, alias: str) -> Selectable:
         """
-        Set an alias for a Column, the output will rename Column to the alias
+        Allows column names to be changed in the result of a select.
         """
         self.alias = alias
         return self

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -243,6 +243,10 @@ class Selectable(metaclass=ABCMeta):
         """
         pass
 
+    def as_alias(self, alias: str) -> Selectable:
+        self.alias: t.Optional[str] = alias
+        return self
+
 
 class Column(Selectable):
     """

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -234,6 +234,8 @@ class ColumnMeta:
 
 
 class Selectable(metaclass=ABCMeta):
+    alias: t.Optional[str]
+
     @abstractmethod
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         """
@@ -247,7 +249,7 @@ class Selectable(metaclass=ABCMeta):
         """
         Set an alias for a Column, the output will rename Column to the alias
         """
-        self.alias: t.Optional[str] = alias
+        self.alias = alias
         return self
 
 

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -244,6 +244,9 @@ class Selectable(metaclass=ABCMeta):
         pass
 
     def as_alias(self, alias: str) -> Selectable:
+        """
+        Set an alias for a Column, the output will rename Column to the alias
+        """
         self.alias: t.Optional[str] = alias
         return self
 

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -63,8 +63,15 @@ class Count(Selectable):
     they have null values or not.
     """
 
-    def __init__(self, column: t.Optional[Column] = None):
+    def __init__(
+        self, column: t.Optional[Column] = None, alias: str = "count"
+    ):
         self.column = column
+        self.alias = alias
+
+    def as_alias(self, alias: str) -> Count:
+        self.alias = alias
+        return self
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         if self.column is None:
@@ -73,7 +80,7 @@ class Count(Selectable):
             column_name = self.column._meta.get_full_name(
                 just_alias=just_alias
             )
-        return f"COUNT({column_name}) AS count"
+        return f"COUNT({column_name}) AS {self.alias}"
 
 
 class Max(Selectable):

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -45,10 +45,6 @@ class Avg(Selectable):
             raise ValueError("Column type must be numeric to run the query.")
         self.alias = alias
 
-    def as_alias(self, alias: str) -> Avg:
-        self.alias = alias
-        return self
-
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)
         return f"AVG({column_name}) AS {self.alias}"

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -61,6 +61,10 @@ class Count(Selectable):
     If a column is specified, the count is for non-null values in that
     column. If no column is specified, the count is for all rows, whether
     they have null values or not.
+
+    Band.select(Band.name, Count()).group_by(Band.name).run()
+    Band.select(Band.name, Count(alias="total")).group_by(Band.name).run()
+    Band.select(Band.name, Count().as_alias("total")).group_by(Band.name).run()
     """
 
     def __init__(
@@ -68,10 +72,6 @@ class Count(Selectable):
     ):
         self.column = column
         self.alias = alias
-
-    def as_alias(self, alias: str) -> Count:
-        self.alias = alias
-        return self
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         if self.column is None:
@@ -96,10 +96,6 @@ class Max(Selectable):
         self.column = column
         self.alias = alias
 
-    def as_alias(self, alias: str) -> Max:
-        self.alias = alias
-        return self
-
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)
         return f"MAX({column_name}) AS {self.alias}"
@@ -117,10 +113,6 @@ class Min(Selectable):
     def __init__(self, column: Column, alias: str = "min"):
         self.column = column
         self.alias = alias
-
-    def as_alias(self, alias: str) -> Min:
-        self.alias = alias
-        return self
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)
@@ -142,10 +134,6 @@ class Sum(Selectable):
         else:
             raise ValueError("Column type must be numeric to run the query.")
         self.alias = alias
-
-    def as_alias(self, alias: str) -> Sum:
-        self.alias = alias
-        return self
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -437,7 +437,7 @@ class TestSelect(DBTestCase):
 
     def test_count_with_alias_group_by(self):
         """
-        Test grouping and counting all rows with count alias.
+        Test grouping and counting all rows with alias.
         """
         self.insert_rows()
         self.insert_rows()
@@ -457,6 +457,13 @@ class TestSelect(DBTestCase):
                 {"name": "Rustaceans", "total": 2},
             ]
         )
+
+    def test_count_with_as_alias_group_by(self):
+        """
+        Test grouping and counting all rows with as_alias.
+        """
+        self.insert_rows()
+        self.insert_rows()
 
         response = (
             Band.select(Band.name, Count().as_alias("total"))

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -435,6 +435,45 @@ class TestSelect(DBTestCase):
             ]
         )
 
+    def test_count_with_alias_group_by(self):
+        """
+        Test grouping and counting all rows with count alias.
+        """
+        self.insert_rows()
+        self.insert_rows()
+
+        response = (
+            Band.select(Band.name, Count(alias="total"))
+            .group_by(Band.name)
+            .order_by(Band.name)
+            .run_sync()
+        )
+
+        self.assertTrue(
+            response
+            == [
+                {"name": "CSharps", "total": 2},
+                {"name": "Pythonistas", "total": 2},
+                {"name": "Rustaceans", "total": 2},
+            ]
+        )
+
+        response = (
+            Band.select(Band.name, Count().as_alias("total"))
+            .group_by(Band.name)
+            .order_by(Band.name)
+            .run_sync()
+        )
+
+        self.assertTrue(
+            response
+            == [
+                {"name": "CSharps", "total": 2},
+                {"name": "Pythonistas", "total": 2},
+                {"name": "Rustaceans", "total": 2},
+            ]
+        )
+
     def test_count_column_group_by(self):
         """
         Test grouping and counting a specific column. Any null values in the


### PR DESCRIPTION
Closes #155 

Right now all aggregate functions implement `as_alias` method and have `alias`. This adds the same functionality to `Count`. I didn't add any docs as it was already mentioned in `select` part for aggregate queries.

I've moved `as_alias` method to `Selectable` so each aggregate method doesn't implement this.