### PR TITLE
wrap pip install statements including optional requirements in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ await b.remove().run()
 Installing with PostgreSQL driver:
 
 ```
-pip install piccolo[postgres]
+pip install 'piccolo[postgres]'
 ```
 
 Installing with SQLite driver:
 
 ```
-pip install piccolo[sqlite]
+pip install 'piccolo[sqlite]'
 ```
 
 ## Building a web app?

--- a/docs/src/piccolo/getting_started/installing_piccolo.rst
+++ b/docs/src/piccolo/getting_started/installing_piccolo.rst
@@ -22,15 +22,15 @@ Now install piccolo, ideally inside a `virtualenv <https://docs.python-guide.org
     pip install piccolo
 
     # Install Piccolo with PostgreSQL driver:
-    pip install piccolo[postgres]
+    pip install 'piccolo[postgres]'
 
     # Install Piccolo with SQLite driver:
-    pip install piccolo[sqlite]
+    pip install 'piccolo[sqlite]'
 
     # Optional: orjson for improved JSON serialisation performance
-    pip install piccolo[orjson]
+    pip install 'piccolo[orjson]'
 
     # Optional: uvloop as default event loop instead of asyncio
     # If using Piccolo with Uvicorn, Uvicorn will set uvloop as
     # default event loop if installed
-    pip install piccolo[uvloop]
+    pip install 'piccolo[uvloop]'

--- a/docs/src/piccolo/query_clauses/output.rst
+++ b/docs/src/piccolo/query_clauses/output.rst
@@ -26,7 +26,7 @@ To return the data as a JSON string:
 Piccolo can use `orjson <https://github.com/ijl/orjson>`_ for JSON serialisation,
 which is blazing fast, and can handle most Python types, including dates,
 datetimes, and UUIDs. To install Piccolo with orjson support use
-``pip install piccolo[orjson]``.
+``pip install 'piccolo[orjson]'``.
 
 as_list
 ~~~~~~~

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -145,7 +145,7 @@ def run(
         import IPython  # type: ignore
     except ImportError:
         sys.exit(
-            "Install iPython using `pip install piccolo[playground,sqlite]` "
+            "Install iPython using `pip install 'piccolo[playground,sqlite]'` "
             "to use this feature."
         )
 

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -330,12 +330,12 @@ class Finder:
             if str(exc) == "No module named 'asyncpg'":
                 raise ModuleNotFoundError(
                     "PostgreSQL driver not found. "
-                    "Try running 'pip install piccolo[postgres]'"
+                    "Try running `pip install 'piccolo[postgres]'`"
                 )
             elif str(exc) == "No module named 'aiosqlite'":
                 raise ModuleNotFoundError(
                     "SQLite driver not found. "
-                    "Try running 'pip install piccolo[sqlite]'"
+                    "Try running `pip install 'piccolo[sqlite]'`"
                 )
             else:
                 raise exc

--- a/piccolo/utils/lazy_loader.py
+++ b/piccolo/utils/lazy_loader.py
@@ -38,12 +38,12 @@ class LazyLoader(types.ModuleType):
             if str(exc) == "No module named 'asyncpg'":
                 raise ModuleNotFoundError(
                     "PostgreSQL driver not found. "
-                    "Try running 'pip install piccolo[postgres]'"
+                    "Try running `pip install 'piccolo[postgres]'`"
                 )
             elif str(exc) == "No module named 'aiosqlite'":
                 raise ModuleNotFoundError(
                     "SQLite driver not found. "
-                    "Try running 'pip install piccolo[sqlite]'"
+                    "Try running `pip install 'piccolo[sqlite]'`"
                 )
             else:
                 raise exc


### PR DESCRIPTION
Reported here: https://github.com/piccolo-orm/piccolo/issues/158

When installing Piccolo with optional requirements, if it isn't wrapped in quotes it doesn't work on ZSH (which is the new default terminal on the Mac).

I've just updated them as follows:

```bash
# old
pip install piccolo[postgres]

# new
pip install 'piccolo[postgres]'
```