### PR TITLE
fix foreign keys in in auto migrations

### DIFF
--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -335,6 +335,21 @@ def serialise_params(params: t.Dict[str, t.Any]) -> SerialisedParams:
             extra_imports.append(
                 Import(module=Table.__module__, target="Table")
             )
+
+            extra_imports.append(
+                Import(
+                    module=value._meta.primary_key.__class__.__module__,
+                    target=value._meta.primary_key.__class__.__name__,
+                )
+            )
+            # Include the extra imports and definitions required for the
+            # primary column params.
+            pk_serialised_params: SerialisedParams = serialise_params(
+                params=value._meta.primary_key._meta.params
+            )
+            extra_imports.extend(pk_serialised_params.extra_imports)
+            extra_definitions.extend(pk_serialised_params.extra_definitions)
+
             continue
 
         # Plain class type

--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -99,7 +99,20 @@ class SerialisedTableType:
     def __repr__(self):
         tablename = self.table_type._meta.tablename
         class_name = self.table_type.__name__
-        return f'class {class_name}(Table, tablename="{tablename}"): pass'
+
+        # We have to add the primary key column definition too, so foreign
+        # keys can be created with the correct type.
+        pk_column = self.table_type._meta.primary_key
+        pk_column_name = pk_column._meta.name
+        serialised_pk_column = SerialisedColumnInstance(
+            pk_column,
+            serialised_params=serialise_params(params=pk_column._meta.params),
+        )
+
+        return (
+            f'class {class_name}(Table, tablename="{tablename}"): '
+            f"{pk_column_name} = {serialised_pk_column}"
+        )
 
     def __lt__(self, other):
         return repr(self) < repr(other)

--- a/tests/apps/migrations/auto/test_serialisation.py
+++ b/tests/apps/migrations/auto/test_serialisation.py
@@ -64,7 +64,12 @@ class TestSerialiseParams(TestCase):
             self.assertTrue(len(serialised.extra_definitions) == 1)
             self.assertEqual(
                 serialised.extra_definitions[0].__str__(),
-                'class Manager(Table, tablename="manager"): pass',
+                (
+                    'class Manager(Table, tablename="manager"): '
+                    "id = Serial(null=False, primary_key=True, unique=False, "
+                    "index=False, index_method=IndexMethod.btree, "
+                    "choices=None)"
+                ),
             )
 
     def test_function(self):


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/170

The issue was with auto migrations, and serialising Foreign Keys.

The old approach didn't include the custom primary key:

<img width="471" alt="Screenshot 2021-08-20 at 08 45 00" src="https://user-images.githubusercontent.com/350976/130198769-c93c1a1a-c42e-428e-8fad-9d9a694add7f.png">

The new approach does:

<img width="484" alt="Screenshot 2021-08-20 at 08 44 49" src="https://user-images.githubusercontent.com/350976/130198772-086f42d6-10e1-48f2-983f-75d4e5a72199.png">

This is important because when creating a `ForeignKey` the type needs to be the same as the primary key being referenced.