### PR TITLE
Update PrimaryKey deprecation warning

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -530,7 +530,8 @@ class PrimaryKey(Serial):
 
         colored_warning(
             "`PrimaryKey` is deprecated and "
-            "will be removed in future versions.",
+            "will be removed in future versions. Use `UUID(primary_key=True)`"
+            " or `BigInt(primary_key=True)` instead.",
             category=DeprecationWarning,
         )
 

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -529,9 +529,11 @@ class PrimaryKey(Serial):
         kwargs.update({"primary_key": True, "index": False})
 
         colored_warning(
-            "`PrimaryKey` is deprecated and "
-            "will be removed in future versions. Use `UUID(primary_key=True)`"
-            " or `BigInt(primary_key=True)` instead.",
+            "`PrimaryKey` is deprecated and will be removed in future "
+            "versions. Use `UUID(primary_key=True)` or "
+            "`Serial(primary_key=True)` instead. If no primary key column is "
+            "specified, Piccolo will automatically add one for you called "
+            "`id`.",
             category=DeprecationWarning,
         )
 


### PR DESCRIPTION
The `PrimaryKey` deprecation warning doesn't tell you what you should use instead.

This PR leads people toward the two most likely options.