### PR TITLE
`get_or_create` method

### DIFF
--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -89,6 +89,23 @@ object, you can do so using ``get_related``.
     >>> print(manager.name)
     'Guido'
 
+get_or_create
+-------------
+
+With ``get_or_create`` you can get an existing record matching the criteria,
+or create a new one with the ``defaults`` arguments:
+
+.. code-block:: python
+
+    band = Band.objects().get_or_create(
+        Band.name == 'Pythonistas', defaults={Band.popularity: 100}
+    ).run_sync()
+
+    # Or using string column names
+    band = Band.objects().get_or_create(
+        Band.name == 'Pythonistas', defaults={'popularity': 100}
+    ).run_sync()
+
 Query clauses
 -------------
 

--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -50,6 +50,13 @@ class GetOrCreate:
 
         return instance
 
+    def __await__(self):
+        """
+        If the user doesn't explicity call .run(), proxy to it as a
+        convenience.
+        """
+        return self.run().__await__()
+
     def run_sync(self):
         return run_sync(self.run())
 
@@ -97,7 +104,9 @@ class Objects(Query):
         return self
 
     def get_or_create(
-        self, where: Combinable, defaults: t.Dict[t.Union[Column, str], t.Any]
+        self,
+        where: Combinable,
+        defaults: t.Dict[t.Union[Column, str], t.Any] = {},
     ):
         return GetOrCreate(query=self, where=where, defaults=defaults)
 

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -1,3 +1,5 @@
+from piccolo.utils.sync import run_sync
+
 from ..base import DBTestCase, postgres_only, sqlite_only
 from ..example_app.tables import Band
 
@@ -59,3 +61,32 @@ class TestObjects(DBTestCase):
         self.assertEqual(
             [i.name for i in response], ["Pythonistas", "Rustaceans"]
         )
+
+    def test_get_or_create(self):
+        run_sync(
+            Band.objects().get_or_create(
+                Band.name == "Pink Floyd", defaults={"popularity": 100}
+            )
+        )
+
+        instance = (
+            Band.objects().where(Band.name == "Pink Floyd").first().run_sync()
+        )
+
+        self.assertTrue(isinstance(instance, Band))
+        self.assertTrue(instance.name == "Pink Floyd")
+        self.assertTrue(instance.popularity == 100)
+
+        run_sync(
+            Band.objects().get_or_create(
+                Band.name == "Pink Floyd", defaults={Band.popularity: 100}
+            )
+        )
+
+        instance = (
+            Band.objects().where(Band.name == "Pink Floyd").first().run_sync()
+        )
+
+        self.assertTrue(isinstance(instance, Band))
+        self.assertTrue(instance.name == "Pink Floyd")
+        self.assertTrue(instance.popularity == 100)

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -1,5 +1,3 @@
-from piccolo.utils.sync import run_sync
-
 from ..base import DBTestCase, postgres_only, sqlite_only
 from ..example_app.tables import Band
 
@@ -63,11 +61,9 @@ class TestObjects(DBTestCase):
         )
 
     def test_get_or_create(self):
-        run_sync(
-            Band.objects().get_or_create(
-                Band.name == "Pink Floyd", defaults={"popularity": 100}
-            )
-        )
+        Band.objects().get_or_create(
+            Band.name == "Pink Floyd", defaults={"popularity": 100}
+        ).run_sync()
 
         instance = (
             Band.objects().where(Band.name == "Pink Floyd").first().run_sync()
@@ -77,11 +73,9 @@ class TestObjects(DBTestCase):
         self.assertTrue(instance.name == "Pink Floyd")
         self.assertTrue(instance.popularity == 100)
 
-        run_sync(
-            Band.objects().get_or_create(
-                Band.name == "Pink Floyd", defaults={Band.popularity: 100}
-            )
-        )
+        Band.objects().get_or_create(
+            Band.name == "Pink Floyd", defaults={Band.popularity: 100}
+        ).run_sync()
 
         instance = (
             Band.objects().where(Band.name == "Pink Floyd").first().run_sync()


### PR DESCRIPTION
Closes #165 

This is a simple draft to get some feedback for `get_or_create` method and will need refactoring.

As the `get_or_create` needs to do one or two queries, it cannot return an `Objects` for user to call `run` method.
It has to run the `.run()` or `.run_sync()` methods itself.