### PR TITLE
fix error with unhashable types and `compare_dicts`

### DIFF
--- a/piccolo/apps/migrations/auto/diffable_table.py
+++ b/piccolo/apps/migrations/auto/diffable_table.py
@@ -20,8 +20,29 @@ def compare_dicts(dict_1, dict_2) -> t.Dict[str, t.Any]:
     """
     Returns a new dictionary which only contains key, value pairs which are in
     the first dictionary and not the second.
+
+    For example:
+        dict_1 = {'a': 1, 'b': 2}
+        dict_2 = {'a': 1}
+        returns {'b': 2}
+
+        dict_1 = {'a': 2, 'b': 2}
+        dict_2 = {'a': 1}
+        returns {'a': 2, 'b': 2}
+
     """
-    return dict(set(dict_1.items()) - set(dict_2.items()))
+    output = {}
+
+    for key, value in dict_1.items():
+
+        dict_2_value = dict_2.get(key, ...)
+        if dict_2_value is ...:
+            output[key] = value
+        else:
+            if dict_2_value != value:
+                output[key] = value
+
+    return output
 
 
 @dataclass


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/178

`compare_dicts` is used by migrations to work out if any `Column` arguments have changed (for example, `Varchar(length=255)` vs `Varchar(length=512)`.

It couldn't handle unhashable types properly (for examples, lists and dictionaries) because the previous implementation depended on comparing sets.