### PR TITLE
allow like clauses without wildcards

### DIFF
--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -72,7 +72,11 @@ The percentage operator is required to designate where the match should occur.
         b.name.like('%is%')  # Matches anywhere in string
     ).run_sync()
 
-``ilike`` is identical, except it's case insensitive.
+    b.select().where(
+        b.name.like('Pythonistas')  # Matches the entire string
+    ).run_sync()
+
+``ilike`` is identical, except it's Postgres specific and case insensitive.
 
 -------------------------------------------------------------------------------
 

--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -10,25 +10,6 @@ class MyTable(Table):
     name = Varchar()
 
 
-class TestColumn(TestCase):
-    def test_like_raises(self):
-        """
-        Make sure an invalid 'like' argument raises an exception. Should
-        contain a % symbol.
-        """
-        column = MyTable.name
-        with self.assertRaises(ValueError):
-            column.like("guido")
-
-        with self.assertRaises(ValueError):
-            column.ilike("guido")
-
-        # Make sure valid args don't raise an exception.
-        for arg in ["%guido", "guido%", "%guido%"]:
-            column.like("%foo")
-            column.ilike("foo%")
-
-
 class TestCopy(TestCase):
     def test_copy(self):
         """


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/191

It previously wasn't possible to do a `like` or `ilike` clause without wildcards.

So if you just want to match on `'FOO'`, `'Foo'`, and `'foo'`, you can now do:

```python
class MyTable(Table):
    name = Varchar()

await MyTable.select(MyTable.name).where(MyTable.name.ilike('foo')).run()
```

In the past you had to include a wildcard, for example `ilike('foo%')`, which would also return `'foo bar'`, which might not be what the user wants.