### PR TITLE
make get_or_create work for complex where clauses

### DIFF
--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -113,6 +113,15 @@ or create a new one with the ``defaults`` arguments:
         Band.name == 'Pythonistas', defaults={'popularity': 100}
     ).run_sync()
 
+You can find out if an existing row was found, or if a new row was created:
+
+.. code-block:: python
+
+    band = Band.objects.get_or_create(
+        Band.name == 'Pythonistas'
+    ).run_sync()
+    band._was_created  # True if it was created, otherwise False if it was already in the db
+
 Complex where clauses are supported, but only within reason. For example:
 
 .. code-block:: python

--- a/piccolo/columns/combination.py
+++ b/piccolo/columns/combination.py
@@ -63,8 +63,6 @@ class And(Combination):
         Returns {Band.name: 'Pythonistas'}
 
         """
-        from piccolo.columns.combination import Where
-
         output = {}
         for combinable in (self.first, self.second):
             if isinstance(combinable, Where):

--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -33,6 +33,7 @@ class GetOrCreate:
     async def run(self):
         instance = await self.query.get(self.where).run()
         if instance:
+            instance._was_created = False
             return instance
 
         instance = self.query.table()
@@ -55,6 +56,8 @@ class GetOrCreate:
             setattr(instance, column._meta.name, value)
 
         await instance.save().run()
+
+        instance._was_created = True
 
         return instance
 

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -112,6 +112,7 @@ class TestObjects(DBTestCase):
             .run_sync()
         )
         self.assertIsInstance(instance, Band)
+        self.assertEqual(instance._was_created, False)
 
         # When the row doesn't exist in the db:
         instance = (
@@ -122,6 +123,7 @@ class TestObjects(DBTestCase):
             .run_sync()
         )
         self.assertIsInstance(instance, Band)
+        self.assertEqual(instance._was_created, True)
 
     def test_get_or_create_very_complex(self):
         """
@@ -140,6 +142,7 @@ class TestObjects(DBTestCase):
             .run_sync()
         )
         self.assertIsInstance(instance, Band)
+        self.assertEqual(instance._was_created, False)
 
         # When the row doesn't exist in the db:
         instance = (
@@ -152,6 +155,7 @@ class TestObjects(DBTestCase):
             .run_sync()
         )
         self.assertIsInstance(instance, Band)
+        self.assertEqual(instance._was_created, True)
 
         # The values in the > and < should be ignored, and the default should
         # be used for the column.


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/194

There was an oversight with `get_or_create` - complex where clauses don't work as expected.

Here's an example:

```python
Band.objects()
.get_or_create(
    (Band.name == "Pythonistas") & (Band.popularity == 1000)
)
.run_sync()
```

In this situation, if the row doesn't exist we want to create it with `Band.name = "Pythonistas"` and `Band.popularity = 1000`.

This now works. However, some complex where clauses aren't supportable (such as those containing OR).
