### PR TITLE
make sure `get_or_create` works correctly with joins

### DIFF
--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -48,7 +48,10 @@ class GetOrCreate:
             )
         elif isinstance(self.where, And):
             for column, value in self.where.get_column_values().items():
-                setattr(instance, column._meta.name, value)
+                if len(column._meta.call_chain) == 0:
+                    # Make sure we only set the value if the column belongs
+                    # to this table.
+                    setattr(instance, column._meta.name, value)
 
         for column, value in self.defaults.items():
             if isinstance(column, str):

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -160,3 +160,23 @@ class TestObjects(DBTestCase):
         # The values in the > and < should be ignored, and the default should
         # be used for the column.
         self.assertEqual(instance.popularity, 0)
+
+    def test_get_or_create_with_joins(self):
+        """
+        Make sure that that `get_or_create` creates rows correctly when using
+        joins.
+        """
+        instance = (
+            Band.objects()
+            .get_or_create(
+                (Band.name == "My new band")
+                & (Band.manager.name == "Excellent manager")
+            )
+            .run_sync()
+        )
+        self.assertIsInstance(instance, Band)
+        self.assertEqual(instance._was_created, True)
+
+        # We want to make sure the band name isn't 'Excellent manager' by
+        # mistake.
+        self.assertEqual(Band.name, "My new band")


### PR DESCRIPTION
Making sure that `get_or_create` works correctly when joins are involved. For example:

```python
instance = (
    Band.objects()
    .get_or_create(
        (Band.name == "My new band")
        & (Band.manager.name == "Excellent manager")
    )
    .run_sync()
)
```

There are two columns involved here, both with the same name (but one is on a separate table). This update makes sure the correct values are set.
