### PR TITLE
added `to_dict`

### DIFF
--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -151,14 +151,15 @@ If you need to convert an object into a dictionary, you can do so using the
     >>> band.to_dict()
     {'id': 1, 'name': 'Pythonistas', 'manager': 1, 'popularity': 1000}
 
-You can override some of the column names if you like:
+If you only want a subset of the columns, or want to use aliases for some of
+the columns:
 
 .. code-block:: python
 
     band = Band.objects().first().run_sync()
 
-    >>> band.to_dict(Band.name.as_alias('title'))
-    {'id': 1, 'title': 'Pythonistas', 'manager': 1, 'popularity': 1000}
+    >>> band.to_dict(Band.id, Band.name.as_alias('title'))
+    {'id': 1, 'title': 'Pythonistas'}
 
 
 Query clauses

--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -138,6 +138,28 @@ Complex where clauses are supported, but only within reason. For example:
         defaults={'popularity': 100}
     ).run_sync()
 
+to_dict
+-------
+
+If you need to convert an object into a dictionary, you can do so using the
+``to_dict`` method.
+
+.. code-block:: python
+
+    band = Band.objects().first().run_sync()
+
+    >>> band.to_dict()
+    {'id': 1, 'name': 'Pythonistas', 'manager': 1, 'popularity': 1000}
+
+You can override some of the column names if you like:
+
+.. code-block:: python
+
+    band = Band.objects().first().run_sync()
+
+    >>> band.to_dict(Band.name.as_alias('title'))
+    {'id': 1, 'title': 'Pythonistas', 'manager': 1, 'popularity': 1000}
+
 
 Query clauses
 -------------

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -409,7 +409,7 @@ class Table(metaclass=TableMetaclass):
 
     def to_dict(self, *aliases: Column) -> t.Dict[str, t.Any]:
         """
-        A convenience menthod which returns a dictionary, mapping column names
+        A convenience method which returns a dictionary, mapping column names
         to values for this table instance.
 
         .. code-block::

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -407,6 +407,25 @@ class Table(metaclass=TableMetaclass):
             .first()
         )
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        """
+        A convenience menthod which returns a dictionary, mapping column names
+        to values for this table instance.
+
+        .. code-block::
+
+            instance = await Manager.objects().get(
+                Manager.name == 'Guido'
+            ).run()
+            >>> instance.to_dict()
+            {'id': 1, 'name': 'Guido'}
+
+        """
+        output = {}
+        for column in self._meta.columns:
+            output[column._meta.name] = getattr(self, column._meta.name)
+        return output
+
     def __setitem__(self, key: str, value: t.Any):
         setattr(self, key, value)
 

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -407,7 +407,7 @@ class Table(metaclass=TableMetaclass):
             .first()
         )
 
-    def to_dict(self, *aliases: Column) -> t.Dict[str, t.Any]:
+    def to_dict(self, *columns: Column) -> t.Dict[str, t.Any]:
         """
         A convenience method which returns a dictionary, mapping column names
         to values for this table instance.
@@ -421,21 +421,22 @@ class Table(metaclass=TableMetaclass):
             >>> instance.to_dict()
             {'id': 1, 'name': 'Guido'}
 
-        Aliases can be used to customise the names:
+        If the columns argument is provided, only those columns are included in
+        the output. It also works with column aliases.
 
         .. code-block::
 
-            >>> instance.to_dict(Manager.name.as_alias('title'))
+            >>> instance.to_dict(Manager.id, Manager.name.as_alias('title'))
             {'id': 1, 'title': 'Guido'}
 
         """
         alias_names = {
             column._meta.name: getattr(column, "alias", None)
-            for column in aliases
+            for column in columns
         }
 
         output = {}
-        for column in self._meta.columns:
+        for column in columns or self._meta.columns:
             output[
                 alias_names.get(column._meta.name) or column._meta.name
             ] = getattr(self, column._meta.name)

--- a/tests/table/instance/test_to_dict.py
+++ b/tests/table/instance/test_to_dict.py
@@ -12,3 +12,13 @@ class TestToDict(DBTestCase):
         instance = Manager.objects().first().run_sync()
         dictionary = instance.to_dict()
         self.assertEqual(dictionary, {"id": 1, "name": "Guido"})
+
+    def test_to_dict_aliases(self):
+        """
+        Make sure that `to_dict` works correctly with aliases.
+        """
+        self.insert_row()
+
+        instance = Manager.objects().first().run_sync()
+        dictionary = instance.to_dict(Manager.name.as_alias("title"))
+        self.assertEqual(dictionary, {"id": 1, "title": "Guido"})

--- a/tests/table/instance/test_to_dict.py
+++ b/tests/table/instance/test_to_dict.py
@@ -1,0 +1,14 @@
+from tests.base import DBTestCase
+from tests.example_app.tables import Manager
+
+
+class TestToDict(DBTestCase):
+    def test_to_dict(self):
+        """
+        Make sure that `to_dict` works correctly.
+        """
+        self.insert_row()
+
+        instance = Manager.objects().first().run_sync()
+        dictionary = instance.to_dict()
+        self.assertEqual(dictionary, {"id": 1, "name": "Guido"})

--- a/tests/table/instance/test_to_dict.py
+++ b/tests/table/instance/test_to_dict.py
@@ -13,6 +13,16 @@ class TestToDict(DBTestCase):
         dictionary = instance.to_dict()
         self.assertEqual(dictionary, {"id": 1, "name": "Guido"})
 
+    def test_filter_rows(self):
+        """
+        Make sure that `to_dict` works correctly with a subset of columns.
+        """
+        self.insert_row()
+
+        instance = Manager.objects().first().run_sync()
+        dictionary = instance.to_dict(Manager.name)
+        self.assertEqual(dictionary, {"name": "Guido"})
+
     def test_to_dict_aliases(self):
         """
         Make sure that `to_dict` works correctly with aliases.
@@ -20,5 +30,7 @@ class TestToDict(DBTestCase):
         self.insert_row()
 
         instance = Manager.objects().first().run_sync()
-        dictionary = instance.to_dict(Manager.name.as_alias("title"))
+        dictionary = instance.to_dict(
+            Manager.id, Manager.name.as_alias("title")
+        )
         self.assertEqual(dictionary, {"id": 1, "title": "Guido"})


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/200

Added a `to_dict` method.

If you just use `__dict__` , you get some non-column values. By using `to_dict` it's just the column values. Here's an example:

```python
class MyTable(Table):
    name = Varchar()

instance = MyTable.objects().first().run_sync()

>>> instance.__dict__
{'_exists_in_db': True, 'id': 1, 'name': 'foo'}

>>> instance.to_dict()
{'id': 1, 'name': 'foo'}
```

You can also use aliases to change the output keys:

```python
>>> instance.to_dict(MyTable.name.as_alias('title'))
{'id': 1, 'title': 'foo'}
```