### PR TITLE
initial prototype for returning clause

### DIFF
--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -337,3 +337,15 @@ class GroupByDelegate:
 
     def group_by(self, *columns: Column):
         self._group_by = GroupBy(columns=columns)
+
+
+@dataclass
+class ReturningDelegate:
+    """
+    Used to specify which columns to return from a query.
+    """
+
+    _returning: t.List[Column] = field(default_factory=list)
+
+    def returning(self, *columns: Column):
+        self._returning = list(columns)

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -547,13 +547,15 @@ class Table(metaclass=TableMetaclass):
         return _reference_column
 
     @classmethod
-    def insert(cls, *rows: "Table") -> Insert:
+    def insert(
+        cls, *rows: "Table", returning: t.Optional[t.List[Column]] = None
+    ) -> Insert:
         """
         await Band.insert(
             Band(name="Pythonistas", popularity=500, manager=1)
         ).run()
         """
-        query = Insert(table=cls)
+        query = Insert(table=cls, returning=returning)
         if rows:
             query.add(*rows)
         return query

--- a/tests/table/test_insert.py
+++ b/tests/table/test_insert.py
@@ -1,5 +1,5 @@
-from ..base import DBTestCase
-from ..example_app.tables import Band, Manager
+from tests.base import DBTestCase, postgres_only
+from tests.example_app.tables import Band, Manager
 
 
 class TestInsert(DBTestCase):
@@ -12,6 +12,15 @@ class TestInsert(DBTestCase):
         names = [i["name"] for i in response]
 
         self.assertTrue("Rustaceans" in names)
+
+    @postgres_only
+    def test_insert_returning(self):
+        response = Band.insert(
+            Band(name="Rustaceans", popularity=100),
+            returning=[Band.id, Band.name],
+        ).run_sync()
+
+        self.assertEqual(response, [{"id": 1, "name": "Rustaceans"}])
 
     def test_add(self):
         self.insert_rows()


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/171

As pointed out in the above issue, there's no way to customise what the insert method returns.

We currently just return the primary key for the inserted rows.

```python
>>> Manager.insert(Manager(name="Bob"), Manager(name="Sally")).run_sync()
[{'id': 3}, {'id': 4}]
```

Being able to customise what gets returned is a nice usability improvement, and in some cases could save another SELECT query.

For example:

```python
>>> Manager.insert(Manager(name="Bob"), Manager(name="Sally"), returning=[Manager.id, Manager.name]).run_sync()
[{'id': 3, 'name': 'Bob'}, {'id': 4, 'name': 'Sally'}]
```

The implementation is fairly straightforward with Postgres, but SQLite only supports the RETURNING clause in fairly recent versions (>= 3.35.0), so needs more consideration:

https://www.sqlite.org/lang_returning.html

We could also potentially add a `returns_objects` argument, which would returns the new rows as Table instances instead of a list of dictionaries.

