### PR TITLE
`all_columns` fix

### DIFF
--- a/docs/src/piccolo/query_types/select.rst
+++ b/docs/src/piccolo/query_types/select.rst
@@ -61,8 +61,9 @@ The joins can go several layers deep.
     >>> Concert.select(Concert.id, Concert.band_1.manager.name).run_sync()
     [{'id': 1, 'band_1.manager.name': 'Guido'}]
 
-If you want all of the columns from a related table, there's a useful shortcut
-which saves you from typing them all out:
+If you want all of the columns from a related table you can use
+``all_columns``, which is a useful shortcut which saves you from typing them
+all out:
 
 .. code-block:: python
 
@@ -71,6 +72,10 @@ which saves you from typing them all out:
         {'name': 'Pythonistas', 'manager.id': 1, 'manager.name': 'Guido'},
         {'name': 'Rustaceans', 'manager.id': 2, 'manager.name': 'Graydon'}
     ]
+
+    # In Piccolo > 0.41.0 you no longer need to explicitly unpack ``all_columns``.
+    # This is equivalent:
+    >>> Band.select(Band.name, Band.manager.all_columns()).run_sync()
 
 You can also get the response as nested dictionaries, which can be very useful:
 

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -137,7 +137,7 @@ class ColumnMeta:
     _table: t.Optional[t.Type[Table]] = None
 
     # Used by Foreign Keys:
-    call_chain: t.List["ForeignKey"] = field(default_factory=lambda: [])
+    call_chain: t.List["ForeignKey"] = field(default_factory=list)
     table_alias: t.Optional[str] = None
 
     @property

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -1220,6 +1220,22 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
         column._foreign_key_meta = self._foreign_key_meta.copy()
         return column
 
+    def all_columns(self):
+        """
+        Allow a user to access all of the columns on the related table.
+
+        For example:
+
+        Band.select(Band.name, *Band.manager.all_columns()).run_sync()
+
+        """
+        _fk_meta = object.__getattribute__(self, "_foreign_key_meta")
+
+        return [
+            getattr(self, column._meta.name)
+            for column in _fk_meta.resolved_references._meta.columns
+        ]
+
     def set_proxy_columns(self):
         """
         In order to allow a fluent interface, where tables can be traversed
@@ -1232,22 +1248,6 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
             _column: Column = column.copy()
             setattr(self, _column._meta.name, _column)
             _fk_meta.proxy_columns.append(_column)
-
-        def all_columns():
-            """
-            Allow a user to access all of the columns on the related table.
-
-            For example:
-
-            Band.select(Band.name, *Band.manager.all_columns()).run_sync()
-
-            """
-            return [
-                getattr(self, column._meta.name)
-                for column in _fk_meta.resolved_references._meta.columns
-            ]
-
-        setattr(self, "all_columns", all_columns)
 
     def __getattribute__(self, name: str):
         """

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -237,8 +237,22 @@ class ColumnsDelegate:
 
     selected_columns: t.Sequence[Selectable] = field(default_factory=list)
 
-    def columns(self, *columns: Selectable):
-        combined = list(self.selected_columns) + list(columns)
+    def columns(self, *columns: t.Union[Selectable, t.List[Selectable]]):
+        """
+        :param columns:
+            We accept ``Selectable`` and ``List[Selectable]`` here, in case
+            someone passes in a list by accident when using ``all_columns()``,
+            in which case we flatten the list.
+
+        """
+        _columns = []
+        for column in columns:
+            if isinstance(column, list):
+                _columns.extend(column)
+            else:
+                _columns.append(column)
+
+        combined = list(self.selected_columns) + _columns
         self.selected_columns = combined
 
     def remove_secret_columns(self):

--- a/tests/query/test_mixins.py
+++ b/tests/query/test_mixins.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+
+from piccolo.query.mixins import ColumnsDelegate
+from tests.example_app.tables import Band
+
+
+class TestColumnsDelegate(TestCase):
+    def test_list_unpacking(self):
+        """
+        The ``ColumnsDelegate`` should unpack a list of columns if passed in by
+        mistake, without the user unpacking them explicitly.
+
+        .. code-block:: python
+
+            # These two should both work the same:
+            await Band.select([Band.id, Band.name]).run()
+            await Band.select(Band.id, Band.name).run()
+
+        """
+        columns_delegate = ColumnsDelegate()
+
+        columns_delegate.columns([Band.name])
+        self.assertEqual(columns_delegate.selected_columns, [Band.name])
+
+        columns_delegate.columns([Band.id])
+        self.assertEqual(
+            columns_delegate.selected_columns, [Band.name, Band.id]
+        )

--- a/tests/table/test_delete.py
+++ b/tests/table/test_delete.py
@@ -11,7 +11,6 @@ class TestDelete(DBTestCase):
         Band.delete().where(Band.name == "CSharps").run_sync()
 
         response = Band.count().where(Band.name == "CSharps").run_sync()
-        print(f"response = {response}")
 
         self.assertEqual(response, 0)
 

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -32,9 +32,6 @@ class TestObjects(DBTestCase):
         """
         self.insert_rows()
         response = Band.objects().order_by(Band.name).offset(1).run_sync()
-
-        print(f"response = {response}")
-
         self.assertEqual(
             [i.name for i in response], ["Pythonistas", "Rustaceans"]
         )
@@ -53,8 +50,6 @@ class TestObjects(DBTestCase):
         query = query.limit(5)
 
         response = query.run_sync()
-
-        print(f"response = {response}")
 
         self.assertEqual(
             [i.name for i in response], ["Pythonistas", "Rustaceans"]

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -13,7 +13,6 @@ class TestSelect(DBTestCase):
         self.insert_row()
 
         response = Band.select().run_sync()
-        print(f"response = {response}")
 
         self.assertDictEqual(
             response[0],
@@ -24,7 +23,6 @@ class TestSelect(DBTestCase):
         self.insert_row()
 
         response = Band.select(Band.name).run_sync()
-        print(f"response = {response}")
 
         self.assertDictEqual(response[0], {"name": "Pythonistas"})
 


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/209

There was a bug where if ``all_columns`` was used two or more levels deep, it would fail.

Here's an example:

```python
Concert.select(
    Concert.venue.name,
    *Concert.band_1.manager.all_columns()
).run_sync()
```

Also, the ``ColumnsDelegate`` has now been tweaked, so unpacking of ``all_columns`` is optional.

```python
# This now works the same as the code above (we have omitted the *)
Concert.select(
    Concert.venue.name,
    Concert.band_1.manager.all_columns()
).run_sync()
```



