### PR TITLE
fix table creation ordering

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import typing as t
 from dataclasses import dataclass, field
+from functools import cmp_to_key
 
 from piccolo.apps.migrations.auto.diffable_table import DiffableTable
 from piccolo.apps.migrations.auto.operations import (
@@ -115,6 +116,37 @@ class AlterColumnCollection:
     @property
     def table_class_names(self) -> t.List[str]:
         return list(set([i.table_class_name for i in self.alter_columns]))
+
+
+def _compare_tables(table_a: t.Type[Table], table_b: t.Type[Table]) -> int:
+    """
+    A comparison function, for sorting Table classes, based on their foreign
+    keys.
+    """
+    for fk_column in table_a._meta.foreign_key_columns:
+        references = fk_column._foreign_key_meta.resolved_references
+        if references._meta.tablename == table_b._meta.tablename:
+            return 1
+        else:
+            for _fk_column in references._meta.foreign_key_columns:
+                _references = _fk_column._foreign_key_meta.resolved_references
+                if _compare_tables(
+                    _references,
+                    table_b,
+                ):
+                    return 1
+
+    return -1
+
+
+def sort_table_classes(
+    table_classes: t.List[t.Type[Table]],
+) -> t.List[t.Type[Table]]:
+    """
+    Sort the table classes based on their foreign keys, so they can be created
+    in the correct order.
+    """
+    return sorted(table_classes, key=cmp_to_key(_compare_tables))
 
 
 @dataclass
@@ -563,25 +595,29 @@ class MigrationManager:
                 ).run()
 
     async def _run_add_tables(self, backwards=False):
-        if backwards:
-            for add_table in self.add_tables:
-                await add_table.to_table_class().alter().drop_table(
-                    cascade=True
-                ).run()
-        else:
-            for add_table in self.add_tables:
-                add_columns: t.List[
-                    AddColumnClass
-                ] = self.add_columns.for_table_class_name(add_table.class_name)
-                _Table: t.Type[Table] = create_table_class(
-                    class_name=add_table.class_name,
-                    class_kwargs={"tablename": add_table.tablename},
-                    class_members={
-                        add_column.column._meta.name: add_column.column
-                        for add_column in add_columns
-                    },
-                )
+        table_classes: t.List[t.Type[Table]] = []
+        for add_table in self.add_tables:
+            add_columns: t.List[
+                AddColumnClass
+            ] = self.add_columns.for_table_class_name(add_table.class_name)
+            _Table: t.Type[Table] = create_table_class(
+                class_name=add_table.class_name,
+                class_kwargs={"tablename": add_table.tablename},
+                class_members={
+                    add_column.column._meta.name: add_column.column
+                    for add_column in add_columns
+                },
+            )
+            table_classes.append(_Table)
 
+        # Sort by foreign key, so they're created in the right order.
+        sorted_table_classes = sort_table_classes(table_classes)
+
+        if backwards:
+            for _Table in reversed(sorted_table_classes):
+                await _Table.alter().drop_table(cascade=True).run()
+        else:
+            for _Table in sorted_table_classes:
                 await _Table.create_table().run()
 
     async def _run_add_columns(self, backwards=False):

--- a/tests/apps/migrations/auto/test_migration_manager.py
+++ b/tests/apps/migrations/auto/test_migration_manager.py
@@ -1,7 +1,11 @@
 import asyncio
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from piccolo.apps.migrations.auto import MigrationManager
+from piccolo.apps.migrations.auto.migration_manager import (
+    MigrationManager,
+    sort_table_classes,
+)
 from piccolo.apps.migrations.commands.base import BaseMigrationManager
 from piccolo.columns import Text, Varchar
 from piccolo.columns.base import OnDelete, OnUpdate
@@ -9,9 +13,26 @@ from piccolo.columns.column_types import ForeignKey
 from piccolo.conf.apps import AppConfig
 from piccolo.utils.lazy_loader import LazyLoader
 from tests.base import DBTestCase, postgres_only, set_mock_return_value
-from tests.example_app.tables import Manager
+from tests.example_app.tables import Band, Concert, Manager, Venue
 
 asyncpg = LazyLoader("asyncpg", globals(), "asyncpg")
+
+
+class TestSortTableClasses(TestCase):
+    def test_sort_table_classes(self):
+        self.assertEqual(sort_table_classes([Manager, Band]), [Manager, Band])
+        self.assertEqual(sort_table_classes([Band, Manager]), [Manager, Band])
+
+        sorted_tables = sort_table_classes([Manager, Venue, Concert, Band])
+        self.assertTrue(
+            sorted_tables.index(Manager) < sorted_tables.index(Band)
+        )
+        self.assertTrue(
+            sorted_tables.index(Venue) < sorted_tables.index(Concert)
+        )
+        self.assertTrue(
+            sorted_tables.index(Band) < sorted_tables.index(Concert)
+        )
 
 
 class TestMigrationManager(DBTestCase):

--- a/tests/example_app/piccolo_migrations/2020-12-17T18-44-30.py
+++ b/tests/example_app/piccolo_migrations/2020-12-17T18-44-30.py
@@ -14,8 +14,8 @@ VERSION = "0.14.7"
 async def forwards():
     manager = MigrationManager(migration_id=ID, app_name="example_app")
 
-    manager.add_table("Manager", tablename="manager")
     manager.add_table("Band", tablename="band")
+    manager.add_table("Manager", tablename="manager")
 
     manager.add_column(
         table_class_name="Band",


### PR DESCRIPTION
There was a regression when we added the ability to choose custom primary keys.

Before this change, new tables were created in two steps - first all of the new tables were created with just their primary keys, and then all of the additional columns were added.

This meant that the order of table creation didn't matter, as when adding the foreign key columns, the referenced tables already existed.

We had to change this behaviour, so new tables were created in a single step along with their columns, so we knew whether to create a default primary key or not.

What I didn't realise at the time is migrations can now fail if the tables are created in the wrong order.

This change adds a custom sort function, which tries to create tables in the correct order, based on their foreign keys.
