### PR TITLE
allow `all_columns` at the root, and `exclude`

### DIFF
--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -518,6 +518,39 @@ class Table(metaclass=TableMetaclass):
     # Classmethods
 
     @classmethod
+    def all_columns(
+        cls, exclude: t.List[t.Union[str, Column]] = []
+    ) -> t.List[Column]:
+        """
+        Just as we can use ``all_columns`` to retrieve all of the columns from
+        a related table, we can also use it at the root of our query to get
+        all of the columns for the root table. For example:
+
+        .. code-block:: python
+
+            await Band.select(
+                Band.all_columns(),
+                Band.manager.all_columns()
+            ).run()
+
+        This is mostly useful when the table has a lot of columns, and typing
+        them out by hand would be tedious.
+
+        :param exclude:
+            You can request all columns, except these.
+
+        """
+        excluded_column_names = [
+            i._meta.name if isinstance(i, Column) else i for i in exclude
+        ]
+
+        return [
+            i
+            for i in cls._meta.columns
+            if i._meta.name not in excluded_column_names
+        ]
+
+    @classmethod
     def ref(cls, column_name: str) -> Column:
         """
         Used to get a copy of a column from a table referenced by a

--- a/tests/columns/test_foreignkey.py
+++ b/tests/columns/test_foreignkey.py
@@ -204,3 +204,16 @@ class TestAllColumns(TestCase):
             all_columns[1]._meta.call_chain,
             Concert.band_1.manager.name._meta.call_chain,
         )
+
+    def test_all_columns_exclude(self):
+        """
+        Make sure you can exclude some columns.
+        """
+        self.assertEqual(
+            Band.manager.all_columns(exclude=["id"]), [Band.manager.name]
+        )
+
+        self.assertEqual(
+            Band.manager.all_columns(exclude=[Band.manager.id]),
+            [Band.manager.name],
+        )

--- a/tests/table/test_all_columns.py
+++ b/tests/table/test_all_columns.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+from tests.example_app.tables import Band
+
+
+class TestAllColumns(TestCase):
+    def test_all_columns(self):
+        self.assertEqual(
+            Band.all_columns(),
+            [Band.id, Band.name, Band.manager, Band.popularity],
+        )
+        self.assertEqual(Band.all_columns(), Band._meta.columns)
+
+    def test_all_columns_excluding(self):
+        self.assertEqual(
+            Band.all_columns(exclude=[Band.id]),
+            [Band.name, Band.manager, Band.popularity],
+        )
+
+        self.assertEqual(
+            Band.all_columns(exclude=["id"]),
+            [Band.name, Band.manager, Band.popularity],
+        )


### PR DESCRIPTION
You can now use `all_columns` at the root. For example:

```python
await Band.select(
    Band.all_columns(),
    Band.manager.all_columns()
).run()
```

You can also exclude certain columns if you like:

```python
await Band.select(
    Band.all_columns(exclude=[Band.id]),
    Band.manager.all_columns(exclude=[Band.manager.id])
).run()
```