### PR TITLE
Migration tests

### DIFF
--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -29,7 +29,14 @@ class SerialisedBuiltin:
         return hash(self.builtin.__name__)
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        """
+        We need to be careful here in case we're comparing it to something
+        unhashable, like a list.
+        """
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         return self.builtin.__name__
@@ -43,7 +50,10 @@ class SerialisedClassInstance:
         return self.instance.__hash__()
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         return repr_class_instance(self.instance)
@@ -58,7 +68,10 @@ class SerialisedColumnInstance:
         return self.instance.__hash__()
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         args = ", ".join(
@@ -78,7 +91,10 @@ class SerialisedEnumInstance:
         return hash(self.__repr__())
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         return f"{self.instance.__class__.__name__}.{self.instance.name}"
@@ -94,7 +110,10 @@ class SerialisedTableType:
         )
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         tablename = self.table_type._meta.tablename
@@ -126,7 +145,10 @@ class SerialisedEnumType:
         return hash(self.__repr__())
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         class_name = self.enum_type.__name__
@@ -142,7 +164,10 @@ class SerialisedCallable:
         return hash(self.callable_.__name__)
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         return self.callable_.__name__
@@ -156,7 +181,10 @@ class SerialisedUUID:
         return self.instance.int
 
     def __eq__(self, other):
-        return self.__hash__() == other.__hash__()
+        if getattr(other, "__hash__", None) is not None:
+            return self.__hash__() == other.__hash__()
+        else:
+            return False
 
     def __repr__(self):
         return f"UUID('{str(self.instance)}')"

--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -29,10 +29,6 @@ class SerialisedBuiltin:
         return hash(self.builtin.__name__)
 
     def __eq__(self, other):
-        """
-        We need to be careful here in case we're comparing it to something
-        unhashable, like a list.
-        """
         if getattr(other, "__hash__", None) is not None:
             return self.__hash__() == other.__hash__()
         else:

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -579,7 +579,9 @@ class Column(Selectable):
         elif isinstance(value, list):
             # Convert to the array syntax.
             output = (
-                "'{" + ", ".join([self.get_sql_value(i) for i in value]) + "}'"
+                "'{"
+                + ", ".join([str(self.get_sql_value(i)) for i in value])
+                + "}'"
             )
         else:
             output = value
@@ -591,7 +593,7 @@ class Column(Selectable):
         return self.__class__.__name__.upper()
 
     @property
-    def querystring(self) -> QueryString:
+    def ddl(self) -> str:
         """
         Used when creating tables.
         """
@@ -621,16 +623,9 @@ class Column(Selectable):
         if not self._meta.primary_key:
             default = self.get_default_value()
             sql_value = self.get_sql_value(value=default)
-            # Escape the value if it contains a pair of curly braces, otherwise
-            # an empty value will appear in the compiled querystring.
-            sql_value = (
-                sql_value.replace("{}", "{{}}")
-                if isinstance(sql_value, str)
-                else sql_value
-            )
             query += f" DEFAULT {sql_value}"
 
-        return QueryString(query)
+        return query
 
     def copy(self) -> Column:
         column: Column = copy.copy(self)
@@ -645,7 +640,7 @@ class Column(Selectable):
         return self.copy()
 
     def __str__(self):
-        return self.querystring.__str__()
+        return self.ddl.__str__()
 
     def __repr__(self):
         try:

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -579,7 +579,14 @@ class Column(Selectable):
             # Convert to the array syntax.
             output = (
                 "'{"
-                + ", ".join([str(self.get_sql_value(i)) for i in value])
+                + ", ".join(
+                    [
+                        f'"{i}"'
+                        if isinstance(i, str)
+                        else str(self.get_sql_value(i))
+                        for i in value
+                    ]
+                )
                 + "}'"
             )
         else:

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -32,7 +32,6 @@ from piccolo.columns.operators.comparison import (
     NotLike,
 )
 from piccolo.columns.reference import LazyTableReference
-from piccolo.querystring import QueryString
 from piccolo.utils.warnings import colored_warning
 
 if t.TYPE_CHECKING:  # pragma: no cover

--- a/piccolo/engine/base.py
+++ b/piccolo/engine/base.py
@@ -50,6 +50,10 @@ class Engine(metaclass=ABCMeta):
     async def run_querystring(self, querystring: QueryString, in_pool: bool):
         pass
 
+    @abstractmethod
+    async def run_ddl(self, ddl: str, in_pool: bool = True):
+        pass
+
     async def check_version(self):
         """
         Warn if the database version isn't supported.

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -391,6 +391,19 @@ class PostgresEngine(Engine):
         else:
             return await self._run_in_new_connection(query, query_args)
 
+    async def run_ddl(self, ddl: str, in_pool: bool = True):
+        if self.log_queries:
+            print(ddl)
+
+        # If running inside a transaction:
+        connection = self.transaction_connection.get()
+        if connection:
+            return await connection.fetch(ddl)
+        elif in_pool and self.pool:
+            return await self._run_in_pool(ddl)
+        else:
+            return await self._run_in_new_connection(ddl)
+
     def atomic(self) -> Atomic:
         return Atomic(engine=self)
 

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from piccolo.engine.base import Batch, Engine
 from piccolo.engine.exceptions import TransactionError
-from piccolo.query.base import Query
+from piccolo.query.base import DDL, Query
 from piccolo.querystring import QueryString
 from piccolo.utils.lazy_loader import LazyLoader
 from piccolo.utils.sync import run_sync
@@ -100,11 +100,15 @@ class Atomic:
     async def _run_queries(self, connection):
         async with connection.transaction():
             for query in self.queries:
-                for querystring in query.querystrings:
-                    _query, args = querystring.compile_string(
-                        engine_type=self.engine.engine_type
-                    )
-                    await connection.execute(_query, *args)
+                if isinstance(query, Query):
+                    for querystring in query.querystrings:
+                        _query, args = querystring.compile_string(
+                            engine_type=self.engine.engine_type
+                        )
+                        await connection.execute(_query, *args)
+                elif isinstance(query, DDL):
+                    for ddl in query.ddl:
+                        await connection.execute(ddl)
 
         self.queries = []
 

--- a/piccolo/engine/sqlite.py
+++ b/piccolo/engine/sqlite.py
@@ -513,6 +513,23 @@ class SQLiteEngine(Engine):
             table=querystring.table,
         )
 
+    async def run_ddl(self, ddl: str, in_pool: bool = False):
+        """
+        Connection pools aren't currently supported - the argument is there
+        for consistency with other engines.
+        """
+        # If running inside a transaction:
+        connection = self.transaction_connection.get()
+        if connection:
+            return await self._run_in_existing_connection(
+                connection=connection,
+                query=ddl,
+            )
+
+        return await self._run_in_new_connection(
+            query=ddl,
+        )
+
     def atomic(self) -> Atomic:
         return Atomic(engine=self)
 

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -403,3 +403,6 @@ class DDL:
                 return run_sync(coroutine)
         else:
             return run_sync(coroutine)
+
+    def __str__(self) -> str:
+        return self.ddl.__str__()

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import typing as t
-from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 
 from piccolo.columns.base import Column
@@ -15,11 +14,10 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from piccolo.table import Table
 
 
-class AlterStatement(metaclass=ABCMeta):
+class AlterStatement:
     __slots__ = tuple()  # type: ignore
 
     @property
-    @abstractmethod
     def ddl(self) -> str:
         raise NotImplementedError()
 
@@ -241,9 +239,7 @@ class SetDigits(AlterColumnStatement):
                 f"{self.column_type}({precision}, {scale})"
             )
         else:
-            return (
-                f"ALTER COLUMN {self.column_name} TYPE {self.column_type}",
-            )
+            return f"ALTER COLUMN {self.column_name} TYPE {self.column_type}"
 
 
 @dataclass

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import typing as t
+from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 
 from piccolo.columns.base import Column
@@ -14,15 +15,16 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from piccolo.table import Table
 
 
-@dataclass
-class AlterStatement:
+class AlterStatement(metaclass=ABCMeta):
     __slots__ = tuple()  # type: ignore
 
+    @property
+    @abstractmethod
     def ddl(self) -> str:
         raise NotImplementedError()
 
     def __str__(self) -> str:
-        return self.querystring.__str__()
+        return self.ddl
 
 
 @dataclass
@@ -86,7 +88,7 @@ class AddColumn(AlterColumnStatement):
 @dataclass
 class DropDefault(AlterColumnStatement):
     @property
-    def querystring(self) -> str:
+    def ddl(self) -> str:
         return f"ALTER COLUMN {self.column_name} DROP DEFAULT"
 
 
@@ -138,7 +140,7 @@ class SetUnique(AlterColumnStatement):
     boolean: bool
 
     @property
-    def querystring(self) -> str:
+    def ddl(self) -> str:
         if self.boolean:
             return f"ADD UNIQUE ({self.column_name})"
         else:

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -524,7 +524,6 @@ class Alter(DDL):
 
         if self.engine_type == "sqlite":
             # Can only perform one alter statement at a time.
-            query += " {}"
             return [f"{query} {i}" for i in alterations]
 
         # Postgres can perform them all at once:

--- a/piccolo/query/methods/create_index.py
+++ b/piccolo/query/methods/create_index.py
@@ -4,14 +4,13 @@ import typing as t
 
 from piccolo.columns import Column
 from piccolo.columns.indexes import IndexMethod
-from piccolo.query.base import Query
-from piccolo.querystring import QueryString
+from piccolo.query.base import DDL
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from piccolo.table import Table
 
 
-class CreateIndex(Query):
+class CreateIndex(DDL):
     def __init__(
         self,
         table: t.Type[Table],
@@ -39,21 +38,21 @@ class CreateIndex(Query):
         return prefix
 
     @property
-    def postgres_querystrings(self) -> t.Sequence[QueryString]:
+    def postgres_ddl(self) -> t.Sequence[str]:
         column_names = self.column_names
         index_name = self.table._get_index_name(column_names)
         tablename = self.table._meta.tablename
         method_name = self.method.value
         column_names_str = ", ".join(column_names)
         return [
-            QueryString(
+            (
                 f"{self.prefix} {index_name} ON {tablename} USING "
                 f"{method_name} ({column_names_str})"
             )
         ]
 
     @property
-    def sqlite_querystrings(self) -> t.Sequence[QueryString]:
+    def sqlite_ddl(self) -> t.Sequence[str]:
         column_names = self.column_names
         index_name = self.table._get_index_name(column_names)
         tablename = self.table._meta.tablename
@@ -64,7 +63,7 @@ class CreateIndex(Query):
 
         column_names_str = ", ".join(column_names)
         return [
-            QueryString(
+            (
                 f"{self.prefix} {index_name} ON {tablename} "
                 f"({column_names_str})"
             )

--- a/tests/apps/migrations/auto/integration/test_migrations.py
+++ b/tests/apps/migrations/auto/integration/test_migrations.py
@@ -325,9 +325,9 @@ class TestMigrations(TestCase):
                     Array(base_column=Integer(), default=[1, 2, 3]),
                     Array(base_column=Integer(), default=array_default),
                     Array(base_column=Integer(), null=True, default=None),
-                    # Array(base_column=Integer(), null=False),
-                    # Array(base_column=Integer(), index=True),
-                    # Array(base_column=Integer(), index=False),
+                    Array(base_column=Integer(), null=False),
+                    Array(base_column=Integer(), index=True),
+                    Array(base_column=Integer(), index=False),
                 ]
             ]
         )

--- a/tests/apps/migrations/auto/integration/test_migrations.py
+++ b/tests/apps/migrations/auto/integration/test_migrations.py
@@ -73,8 +73,12 @@ def boolean_default():
     return True
 
 
-def array_default():
+def array_default_integer():
     return [4, 5, 6]
+
+
+def array_default_varchar():
+    return ['x', 'y', 'z']
 
 
 @postgres_only
@@ -318,18 +322,38 @@ class TestMigrations(TestCase):
             ]
         )
 
-    def test_array_column(self):
+    def test_array_column_integer(self):
         self._test_migrations(
             table_classes=[
                 self.table(column)
                 for column in [
                     Array(base_column=Integer()),
                     Array(base_column=Integer(), default=[1, 2, 3]),
-                    Array(base_column=Integer(), default=array_default),
+                    Array(
+                        base_column=Integer(), default=array_default_integer
+                    ),
                     Array(base_column=Integer(), null=True, default=None),
                     Array(base_column=Integer(), null=False),
                     Array(base_column=Integer(), index=True),
                     Array(base_column=Integer(), index=False),
+                ]
+            ]
+        )
+
+    def test_array_column_varchar(self):
+        self._test_migrations(
+            table_classes=[
+                self.table(column)
+                for column in [
+                    Array(base_column=Varchar()),
+                    Array(base_column=Varchar(), default=["a", "b", "c"]),
+                    Array(
+                        base_column=Varchar(), default=array_default_varchar
+                    ),
+                    Array(base_column=Varchar(), null=True, default=None),
+                    Array(base_column=Varchar(), null=False),
+                    Array(base_column=Varchar(), index=True),
+                    Array(base_column=Varchar(), index=False),
                 ]
             ]
         )

--- a/tests/apps/migrations/auto/integration/test_migrations.py
+++ b/tests/apps/migrations/auto/integration/test_migrations.py
@@ -16,6 +16,8 @@ from piccolo.apps.migrations.commands.new import (
 )
 from piccolo.apps.migrations.tables import Migration
 from piccolo.columns.column_types import (
+    JSON,
+    JSONB,
     UUID,
     Array,
     BigInt,
@@ -328,6 +330,41 @@ class TestMigrations(TestCase):
                     Array(base_column=Integer(), null=False),
                     Array(base_column=Integer(), index=True),
                     Array(base_column=Integer(), index=False),
+                ]
+            ]
+        )
+
+    ###########################################################################
+
+    # We deliberately don't test setting JSON or JSONB columns as indexes, as
+    # we know it'll fail.
+
+    def test_json_column(self):
+        self._test_migrations(
+            table_classes=[
+                self.table(column)
+                for column in [
+                    JSON(),
+                    JSON(default=["a", "b", "c"]),
+                    JSON(default={"name": "bob"}),
+                    JSON(default='{"name": "Sally"}'),
+                    JSON(null=True, default=None),
+                    JSON(null=False),
+                ]
+            ]
+        )
+
+    def test_jsonb_column(self):
+        self._test_migrations(
+            table_classes=[
+                self.table(column)
+                for column in [
+                    JSONB(),
+                    JSONB(default=["a", "b", "c"]),
+                    JSONB(default={"name": "bob"}),
+                    JSONB(default='{"name": "Sally"}'),
+                    JSONB(null=True, default=None),
+                    JSONB(null=False),
                 ]
             ]
         )

--- a/tests/apps/migrations/auto/integration/test_migrations.py
+++ b/tests/apps/migrations/auto/integration/test_migrations.py
@@ -17,6 +17,7 @@ from piccolo.apps.migrations.commands.new import (
 from piccolo.apps.migrations.tables import Migration
 from piccolo.columns.column_types import (
     UUID,
+    Array,
     BigInt,
     Boolean,
     Date,
@@ -68,6 +69,10 @@ def timedelta_default():
 
 def boolean_default():
     return True
+
+
+def array_default():
+    return [4, 5, 6]
 
 
 @postgres_only
@@ -307,6 +312,22 @@ class TestMigrations(TestCase):
                     Boolean(null=False),
                     Boolean(index=True),
                     Boolean(index=False),
+                ]
+            ]
+        )
+
+    def test_array_column(self):
+        self._test_migrations(
+            table_classes=[
+                self.table(column)
+                for column in [
+                    Array(base_column=Integer()),
+                    Array(base_column=Integer(), default=[1, 2, 3]),
+                    Array(base_column=Integer(), default=array_default),
+                    Array(base_column=Integer(), null=True, default=None),
+                    # Array(base_column=Integer(), null=False),
+                    # Array(base_column=Integer(), index=True),
+                    # Array(base_column=Integer(), index=False),
                 ]
             ]
         )

--- a/tests/table/test_create.py
+++ b/tests/table/test_create.py
@@ -42,10 +42,6 @@ class TestCreateWithIndexes(TestCase):
         query.run_sync()
 
         self.assertTrue(
-            query.querystrings[0]
-            .__str__()
-            .startswith("CREATE TABLE IF NOT EXISTS"),
-            query.querystrings[1]
-            .__str__()
-            .startswith("CREATE INDEX IF NOT EXISTS"),
+            query.ddl[0].__str__().startswith("CREATE TABLE IF NOT EXISTS"),
+            query.ddl[1].__str__().startswith("CREATE INDEX IF NOT EXISTS"),
         )


### PR DESCRIPTION
This is quite a large change due to ongoing issues with migrations containing `Array` and `JSON` columns.

In order to execute queries, Piccolo uses something called a `QueryString`. Here's an example:

```python
QueryString('SELECT * from band where name = {}', 'Pythonistas')
```

It keeps the arguments separate, as it's safer this way due to SQL injection.

You'll notice that the template contains curly braces as a placeholder, which is where the argument is to be inserted into the query.

The curly braces seem innocent enough, but are a huge pain when you want to do something like this:

```sql
ALTER TABLE my_table ADD COLUMN my_column json DEFAULT '{"name": "Sally"}'::json;
```
Notice how part of the query contains curly braces, which aren't intended as placeholders.

This situation only occurs when executing DDL statements (`CREATE`, `ALTER` etc.) which can't be parameterised anyway, so using `QueryString` didn't make much sense. It was causing issues, but for no benefit.

So ... this change introduces a ``DDL`` class, which is a form of query which doesn't use `QueryString` internally (which is safe to do as the DDL statements don't contain any user input).




