### PR TITLE
Docker integration in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ htmlcov/
 prof/
 .env/
 .venv/
+.idea/
+.python-version

--- a/docs/src/piccolo/contributing/index.rst
+++ b/docs/src/piccolo/contributing/index.rst
@@ -15,9 +15,9 @@ Get the tests running
  * Install default dependencies: ``pip install -r requirements/requirements.txt``
  * Install development dependencies: ``pip install -r requirements/dev-requirements.txt``
  * Install test dependencies: ``pip install -r requirements/test-requirements.txt``
- * Setup Postgres
  * Run the automated code linting/formatting tools: ``./scripts/lint.sh``
  * Run the test suite with Postgres: ``./scripts/test-postgres.sh``
+    * This will launch a docker postgres container with a piccolo database in port 5432
  * Run the test suite with Sqlite: ``./scripts/test-sqlite.sh``
 
 Contributing to the docs

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -7,3 +7,4 @@ twine==3.1.1
 mypy==0.782
 pip-upgrader==1.4.15
 wheel==0.36.2
+pdbpp==0.10.3-

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -2,3 +2,5 @@ coveralls==2.2.0
 pytest-cov==2.10.1
 pytest==6.2.1
 python-dateutil==2.8.1
+docker==5.0.2
+faker==8.12.1

--- a/scripts/test-postgres.sh
+++ b/scripts/test-postgres.sh
@@ -5,4 +5,6 @@
 # To run a single test tests/test_foo.py::TestFoo::test_foo
 
 export PICCOLO_CONF="tests.postgres_conf"
+python -m tests.utils.setup --db_engine=postgres --action=spin_up
 python -m pytest --cov=piccolo --cov-report xml --cov-report html --cov-fail-under 85 -s $@
+python -m tests.utils.setup --db_engine=postgres --action=tear_down

--- a/tests/postgres_container.py
+++ b/tests/postgres_container.py
@@ -1,0 +1,123 @@
+import asyncio
+import logging
+import os
+from contextlib import suppress
+from typing import Union
+import socket
+
+import asyncpg  # type: ignore
+import docker  # type: ignore
+from docker.errors import APIError, NullResource  # type: ignore
+from docker.models.containers import Container  # type: ignore
+from faker import Faker
+
+PG_DOCKER_IMAGE_NAME = os.environ.get("PG_DOCKER_IMAGE_NAME", "postgres")
+
+fake = Faker()
+
+TEST_CONTAINER_IDENTIFIER = "7F71F5AB-E255-4E76-B650-3F1EE64B2E36"
+
+
+class TestPostgres:
+    def __init__(self):
+        self.docker_client = docker.client.from_env()
+        self.resource_postfix = fake.color_name().lower()
+        self.config = {
+            "host": os.environ.get("PG_HOST", "localhost"),
+            "port": os.environ.get("PG_PORT", 5432),
+            "user": os.environ.get("PG_USER", "postgres"),
+            "password": os.environ.get("PG_PASSWORD", fake.password()),
+            "database": os.environ.get("PG_DATABASE", "piccolo"),
+        }
+
+    @property
+    def port_is_free(self) -> bool:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = sock.connect_ex((self.config['host'], self.config['port']))
+        sock.close()
+        return result != 0
+
+    @property
+    def container(self) -> Union[Container, None]:
+        with suppress(NullResource):
+            return self.docker_client.containers.get(
+                container_id=self.container_name
+            )
+
+    @property
+    def container_name(self) -> str:
+        test_container = self.docker_client.containers.list(
+            filters={"label": f"test_container_identifier={TEST_CONTAINER_IDENTIFIER}"}
+        )
+        if len(test_container) == 1:
+            return test_container[0].name
+
+    async def create_piccolo_database(self) -> None:
+        """
+        Executes a query.
+        It waits until the database is ready first.
+        """
+        is_ready_exit_code = 1
+        while is_ready_exit_code != 0:
+            is_ready_exit_code = self.container.exec_run(
+                cmd="pg_isready"
+            ).exit_code
+            await asyncio.sleep(1)
+
+        connection = await asyncpg.connect(
+            host=self.config["host"],
+            port=self.config["port"],
+            user=self.config["user"],
+            password=self.config["password"],
+        )
+        query = f"create database {self.config['database']}"
+        await connection.execute(query=query)
+        await connection.close()
+
+    def spin_up(self):
+        if not self.port_is_free:
+            raise OSError(f"Something is already running in port {self.config['port']}.")
+        self.start_container()
+        asyncio.get_event_loop().run_until_complete(
+            self.create_piccolo_database()
+        )
+
+    def start_container(self) -> str:
+        """
+        Spins up a postgres docker container
+        """
+        try:
+            logging.info(f"Pulling {PG_DOCKER_IMAGE_NAME}")
+            self.docker_client.images.get(name=PG_DOCKER_IMAGE_NAME)
+            logging.info(
+                f"Starting container postgres-{self.resource_postfix}"
+            )
+
+            postgres_container = self.docker_client.containers.run(
+                image=PG_DOCKER_IMAGE_NAME,
+                ports={
+                    f"{self.config['port']}/tcp": f"{self.config['port']}/tcp"
+                },
+                name=f"postgres-{self.resource_postfix}",
+                hostname="postgres",
+                environment={
+                    "POSTGRES_PASSWORD": self.config["password"],
+                    "POSTGRES_HOST_AUTH_METHOD": "trust",
+                },
+                labels={"test_container_identifier": TEST_CONTAINER_IDENTIFIER},
+                detach=True,
+                auto_remove=True,
+            )
+        except APIError as error:
+            if error.status_code == 500:
+                raise APIError(f"Something is already running in port {self.config['port']}.")
+            else:
+                raise APIError(error)
+
+        return postgres_container.name
+
+    def tear_down(self) -> None:
+        try:
+            self.container.remove(force=True)
+        except AttributeError:
+            logging.warning("Nothing to tear down.")

--- a/tests/testing/test_postgres_container.py
+++ b/tests/testing/test_postgres_container.py
@@ -1,18 +1,19 @@
-from tests.postgres_container import TestPostgres, TEST_CONTAINER_IDENTIFIER
-import docker
+import docker  # type: ignore
+
+from tests.postgres_container import CONTAINER_IDENTIFIER, TestPostgres
 
 
 def test_container_status():
     test_postgres = TestPostgres()
     client = docker.client.from_env()
     container_list = client.containers.list(
-            filters={"label": f"test_container_identifier={TEST_CONTAINER_IDENTIFIER}"}
-        )
+        filters={"label": f"test_container_identifier={CONTAINER_IDENTIFIER}"}
+    )
     assert len(container_list) == 1
 
     test_postgres.tear_down()
 
     container_list = client.containers.list(
-            filters={"label": f"test_container_identifier={TEST_CONTAINER_IDENTIFIER}"}
-        )
+        filters={"label": f"test_container_identifier={CONTAINER_IDENTIFIER}"}
+    )
     assert len(container_list) == 0

--- a/tests/testing/test_postgres_container.py
+++ b/tests/testing/test_postgres_container.py
@@ -1,0 +1,18 @@
+from tests.postgres_container import TestPostgres, TEST_CONTAINER_IDENTIFIER
+import docker
+
+
+def test_container_status():
+    test_postgres = TestPostgres()
+    client = docker.client.from_env()
+    container_list = client.containers.list(
+            filters={"label": f"test_container_identifier={TEST_CONTAINER_IDENTIFIER}"}
+        )
+    assert len(container_list) == 1
+
+    test_postgres.tear_down()
+
+    container_list = client.containers.list(
+            filters={"label": f"test_container_identifier={TEST_CONTAINER_IDENTIFIER}"}
+        )
+    assert len(container_list) == 0

--- a/tests/utils/setup.py
+++ b/tests/utils/setup.py
@@ -1,0 +1,19 @@
+import click
+
+from tests.postgres_container import TestPostgres
+
+
+@click.command()
+@click.option("--db_engine", help="One of: postgres|sqlite")
+@click.option("--action", help="One of: spin_up|tear_down")
+def setup(db_engine: str, action: str):
+    if db_engine == "postgres":
+        postgres = TestPostgres()
+        do = getattr(postgres, action)
+        do()
+    else:
+        return NotImplementedError
+
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
A small docker integration for the postgres tests for early feedback in case you're interested in this kind of thing.

Make sure nothing occupies port 5432 and run the usual `/scripts/test-postgres.sh`

Let me know if this is useful at all or rubbish.

If you want to see this running outside the tests

```
python -m tests.utils.setup --db_engine=postgres --action=spin_up
```
OR 

```
python -m tests.utils.setup --db_engine=postgres --action=tear_down
```