### PR TITLE
added `pip install piccolo[all]` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,21 +72,27 @@ await b.remove().run()
 
 Installing with PostgreSQL driver:
 
-```
+```bash
 pip install 'piccolo[postgres]'
 ```
 
 Installing with SQLite driver:
 
-```
+```bash
 pip install 'piccolo[sqlite]'
+```
+
+Installing with all optional dependencies (easiest):
+
+```bash
+pip install 'piccolo[all]'
 ```
 
 ## Building a web app?
 
 Let Piccolo scaffold you an ASGI web app, using Piccolo as the ORM:
 
-```
+```bash
 piccolo asgi new
 ```
 
@@ -98,4 +104,6 @@ We have a handy page which shows the equivalent of [common Django queries in Pic
 
 ## Documentation
 
-See [Read the docs](https://piccolo-orm.readthedocs.io/en/latest/piccolo/getting_started/index.html).
+Our documentation is on [Read the docs](https://piccolo-orm.readthedocs.io/en/latest/piccolo/getting_started/index.html).
+
+We also have some great [tutorial videos on YouTube](https://www.youtube.com/channel/UCE7x5nm1Iy9KDfXPNrNQ5lA).

--- a/docs/src/piccolo/getting_started/installing_piccolo.rst
+++ b/docs/src/piccolo/getting_started/installing_piccolo.rst
@@ -34,3 +34,7 @@ Now install piccolo, ideally inside a `virtualenv <https://docs.python-guide.org
     # If using Piccolo with Uvicorn, Uvicorn will set uvloop as
     # default event loop if installed
     pip install 'piccolo[uvloop]'
+
+    # If you just want Piccolo with all of it's functionality, you might prefer
+    # to use this:
+    pip install 'piccolo[all]'

--- a/docs/src/piccolo/getting_started/installing_piccolo.rst
+++ b/docs/src/piccolo/getting_started/installing_piccolo.rst
@@ -30,9 +30,9 @@ Now install piccolo, ideally inside a `virtualenv <https://docs.python-guide.org
     # Optional: orjson for improved JSON serialisation performance
     pip install 'piccolo[orjson]'
 
-    # Optional: uvloop as default event loop instead of asyncio
-    # If using Piccolo with Uvicorn, Uvicorn will set uvloop as
-    # default event loop if installed
+    # Optional: uvloop as the default event loop instead of asyncio
+    # If using Piccolo with Uvicorn, Uvicorn will set uvloop as the default
+    # event loop if installed
     pip install 'piccolo[uvloop]'
 
     # If you just want Piccolo with all of it's functionality, you might prefer

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import itertools
 import os
-from typing import List
+import typing as t
+
 from setuptools import find_packages, setup
 
 from piccolo import __VERSION__ as VERSION
-
 
 directory = os.path.abspath(os.path.dirname(__file__))
 
@@ -17,7 +18,7 @@ with open(os.path.join(directory, "README.md")) as f:
     LONG_DESCRIPTION = f.read()
 
 
-def parse_requirement(req_path: str) -> List[str]:
+def parse_requirement(req_path: str) -> t.List[str]:
     """
     Parse requirement file.
     Example:
@@ -31,7 +32,7 @@ def parse_requirement(req_path: str) -> List[str]:
         return [i.strip() for i in contents.strip().split("\n")]
 
 
-def extras_require():
+def extras_require() -> t.Dict[str, t.List[str]]:
     """
     Parse requirements in requirements/extras directory
     """
@@ -40,6 +41,10 @@ def extras_require():
         extra_requirements[extra] = parse_requirement(
             os.path.join("extras", extra + ".txt")
         )
+
+    extra_requirements["all"] = [
+        i for i in itertools.chain.from_iterable(extra_requirements.values())
+    ]
 
     return extra_requirements
 


### PR DESCRIPTION
Piccolo has a bunch of optional requirements now - most of the time you just want to install them all.

You can now do so using:

```
pip install 'piccolo[all]'
```

For the fully featured version, with all bells and whistles.