### PR TITLE
Fix numeric bug

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -890,14 +890,14 @@ class Numeric(Column):
             return "NUMERIC"
 
     @property
-    def precision(self):
+    def precision(self) -> t.Optional[int]:
         """
         The total number of digits allowed.
         """
         return self.digits[0] if self.digits is not None else None
 
     @property
-    def scale(self):
+    def scale(self) -> t.Optional[int]:
         """
         The number of digits after the decimal point.
         """

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -894,14 +894,14 @@ class Numeric(Column):
         """
         The total number of digits allowed.
         """
-        return self.digits[0]
+        return self.digits[0] if self.digits is not None else None
 
     @property
     def scale(self):
         """
         The number of digits after the decimal point.
         """
-        return self.digits[1]
+        return self.digits[1] if self.digits is not None else None
 
     def __init__(
         self,

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -45,6 +45,17 @@ class TestNumericColumn(TestCase):
 
         pydantic_model(box_office=decimal.Decimal("1.0"))
 
+    def test_numeric_without_digits(self):
+        class Movie(Table):
+            box_office = Numeric()
+
+        try:
+            create_pydantic_model(table=Movie)
+        except TypeError:
+            self.fail(f'Creating numeric field without digits failed in pydantic model.')
+        else:
+            self.assertTrue(True)
+
 
 class TestSecretColumn(TestCase):
     def test_secret_param(self):
@@ -93,7 +104,6 @@ class TestColumnHelpText(TestCase):
     """
 
     def test_help_text_present(self):
-
         help_text = "In millions of US dollars."
 
         class Movie(Table):
@@ -115,7 +125,6 @@ class TestTableHelpText(TestCase):
     """
 
     def test_help_text_present(self):
-
         help_text = "Movies which were released in cinemas."
 
         class Movie(Table, help_text=help_text):

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -52,7 +52,10 @@ class TestNumericColumn(TestCase):
         try:
             create_pydantic_model(table=Movie)
         except TypeError:
-            self.fail(f'Creating numeric field without digits failed in pydantic model.')
+            self.fail(
+                "Creating numeric field without"
+                " digits failed in pydantic model."
+            )
         else:
             self.assertTrue(True)
 


### PR DESCRIPTION

fixed the bug discussed in #232. 
if precision and scale are not set for the Numeric Field, 'None'  will be returned.