### PR TITLE
Better schema generation

### DIFF
--- a/piccolo/apps/schema/commands/generate.py
+++ b/piccolo/apps/schema/commands/generate.py
@@ -121,14 +121,6 @@ class TableConstraints:
 class OutputSchema:
     """
     Represents the schema which will be printed out.
-
-    :param imports:
-        e.g. ["from piccolo.table import Table"]
-    :param warnings:
-        e.g. ["some_table.some_column unrecognised_type"]
-    :param tables:
-        e.g. ["class MyTable(Table): ..."]
-
     """
 
     def __init__(self):
@@ -178,6 +170,10 @@ async def get_contraints(
     :param table_class:
         Any Table subclass - just used to execute raw queries on the database.
 
+    :param tablename - name of the table
+
+    :param schema_name name of the schema
+
     """
     constraints = await table_class.raw(
         (
@@ -205,6 +201,9 @@ async def get_tablenames(
 
     :param table_class:
         Any Table subclass - just used to execute raw queries on the database.
+
+    :param schema_name:
+        name of the schema
     :returns:
         A list of tablenames for the given schema.
 

--- a/tests/example_apps/mega/piccolo_migrations/2021-09-20T21-23-25-698988.py
+++ b/tests/example_apps/mega/piccolo_migrations/2021-09-20T21-23-25-698988.py
@@ -1,26 +1,28 @@
-from piccolo.apps.migrations.auto import MigrationManager
 from decimal import Decimal
-from piccolo.columns.base import OnDelete
-from piccolo.columns.base import OnUpdate
-from piccolo.columns.column_types import BigInt
-from piccolo.columns.column_types import Boolean
-from piccolo.columns.column_types import Bytea
-from piccolo.columns.column_types import Date
-from piccolo.columns.column_types import DoublePrecision
-from piccolo.columns.column_types import ForeignKey
-from piccolo.columns.column_types import Integer
-from piccolo.columns.column_types import Interval
-from piccolo.columns.column_types import JSON
-from piccolo.columns.column_types import JSONB
-from piccolo.columns.column_types import Numeric
-from piccolo.columns.column_types import Real
-from piccolo.columns.column_types import Serial
-from piccolo.columns.column_types import SmallInt
-from piccolo.columns.column_types import Text
-from piccolo.columns.column_types import Timestamp
-from piccolo.columns.column_types import Timestamptz
-from piccolo.columns.column_types import UUID
-from piccolo.columns.column_types import Varchar
+
+from piccolo.apps.migrations.auto import MigrationManager
+from piccolo.columns.base import OnDelete, OnUpdate
+from piccolo.columns.column_types import (
+    JSON,
+    JSONB,
+    UUID,
+    BigInt,
+    Boolean,
+    Bytea,
+    Date,
+    DoublePrecision,
+    ForeignKey,
+    Integer,
+    Interval,
+    Numeric,
+    Real,
+    Serial,
+    SmallInt,
+    Text,
+    Timestamp,
+    Timestamptz,
+    Varchar,
+)
 from piccolo.columns.defaults.date import DateNow
 from piccolo.columns.defaults.interval import IntervalCustom
 from piccolo.columns.defaults.timestamp import TimestampNow


### PR DESCRIPTION
1. references from other schemas are supported.

2. now `schema generate` will recursively create reference tables.
For example:
Table `Schema1.A` references Table `Schema2.B`, and Table `Schema2.B` references Table `Schema2.C`. 
now, Table `Schema2.C`  will be created too.

I'm going to add the tests later. 