### PR TITLE
add table registry, and ability to refresh engine

### DIFF
--- a/piccolo/apps/tester/commands/run.py
+++ b/piccolo/apps/tester/commands/run.py
@@ -4,6 +4,8 @@ import os
 import sys
 import typing as t
 
+from piccolo.table import TABLE_REGISTRY
+
 
 class set_env_var:
     def __init__(self, var_name: str, temp_value: str):
@@ -49,6 +51,13 @@ def run_pytest(pytest_args: t.List[str]) -> int:  # pragma: no cover
     return pytest.main(pytest_args)
 
 
+def refresh_db():
+    for table_class in TABLE_REGISTRY:
+        # In case any table classes were imported before we set the
+        # environment variable.
+        table_class.refresh_db()
+
+
 def run(
     pytest_args: str = "", piccolo_conf: str = "piccolo_conf_test"
 ) -> None:
@@ -65,5 +74,6 @@ def run(
 
     """
     with set_env_var(var_name="PICCOLO_CONF", temp_value=piccolo_conf):
+        refresh_db()
         args = pytest_args.split(" ")
         sys.exit(run_pytest(args))

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -49,6 +49,9 @@ if t.TYPE_CHECKING:
 PROTECTED_TABLENAMES = ("user",)
 
 
+TABLE_REGISTRY: t.List[t.Type[Table]] = []
+
+
 @dataclass
 class TableMeta:
     """
@@ -94,6 +97,10 @@ class TableMeta:
             self._db = db
 
         return self._db
+
+    @db.setter
+    def db(self, value: Engine):
+        self._db = value
 
     def get_column_by_name(self, name: str) -> Column:
         """
@@ -282,6 +289,8 @@ class Table(metaclass=TableMetaclass):
             # auto completion.
             if is_table_class:
                 foreign_key_column.set_proxy_columns()
+
+        TABLE_REGISTRY.append(cls)
 
     def __init__(
         self,
@@ -498,6 +507,12 @@ class Table(metaclass=TableMetaclass):
         Creates a readable representation of the row.
         """
         return Readable(template="%s", columns=[cls._meta.primary_key])
+
+    ###########################################################################
+
+    @classmethod
+    def refresh_db(cls):
+        cls._meta.db = engine_finder()
 
     ###########################################################################
 

--- a/tests/apps/tester/commands/test_run.py
+++ b/tests/apps/tester/commands/test_run.py
@@ -66,8 +66,10 @@ class TestSetEnvVar(TestCase):
 
 class TestRun(TestCase):
     @patch("piccolo.apps.tester.commands.run.run_pytest")
-    def test_success(self, pytest: MagicMock):
+    @patch("piccolo.apps.tester.commands.run.refresh_db")
+    def test_success(self, refresh_db: MagicMock, pytest: MagicMock):
         with self.assertRaises(SystemExit):
             run(pytest_args="-s foo", piccolo_conf="my_piccolo_conf")
 
         pytest.assert_called_once_with(["-s", "foo"])
+        refresh_db.assert_called_once()


### PR DESCRIPTION
Added a global registry for all tables, so in certain situations we can force the tables to re-import the engine again.

This is useful in the test runner, as sometimes a table will be imported before we've had time to set the PICCOLO_CONF environment variable.