### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: ['3.7', '3.8', '3.9', '3.10']
 
         steps:
             - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: ['3.7', '3.8', '3.9', '3.10']
                 postgres-version: [9.6, 10, 11, 12, 13, 14]
 
         # Service containers to run with `container-job`
@@ -87,7 +87,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: ['3.7', '3.8', '3.9', '3.10']
 
         steps:
             - uses: actions/checkout@v2

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,4 +1,4 @@
 coveralls==2.2.0
 pytest-cov==2.10.1
-pytest==6.2.1
+pytest==6.2.5
 python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Framework :: AsyncIO",
         "Typing :: Typed",


### PR DESCRIPTION
Closes #299 

Updated pytest version from 6.2.1 to 6.2.5 due to bug described [here](https://github.com/pytest-dev/pytest/issues/8546) in older versions of pytest.

The tests run fine locally, but fingers crossed for Github Actions.