### PR TITLE
make lint.sh formatters fail build

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,8 +4,9 @@ The scripts follow GitHub's ["Scripts to Rule Them All"](https://github.com/gith
 
 Call them from the root of the project, e.g. `./scripts/lint.sh`.
 
-* `scripts/lint.sh` - Run the automated code linting/formatting tools.
-* `scripts/piccolo.sh` - Run the Piccolo CLI on the example project in the `tests` folder.
-* `scripts/release.sh` - Publish package to PyPI.
-* `scripts/test-postgres.sh` - Run the test suite with Postgres.
-* `scripts/test-sqlite.sh` - Run the test suite with SQLite.
+- `scripts/format.sh` - Format the code to the required standards.
+- `scripts/lint.sh` - Run the automated code linting/formatting tools.
+- `scripts/piccolo.sh` - Run the Piccolo CLI on the example project in the `tests` folder.
+- `scripts/release.sh` - Publish package to PyPI.
+- `scripts/test-postgres.sh` - Run the test suite with Postgres.
+- `scripts/test-sqlite.sh` - Run the test suite with SQLite.

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+SOURCES="piccolo tests"
+
+echo "Running isort..."
+isort $SOURCES
+echo "-----"
+
+echo "Running black..."
+black $SOURCES

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
+set -e
 
 SOURCES="piccolo tests"
 
-isort $SOURCES
-black $SOURCES
+echo "Running isort..."
+isort --check $SOURCES
+echo "-----"
+
+echo "Running black..."
+black --check $SOURCES
+echo "-----"
+
+echo "Running flake8..."
 flake8 $SOURCES
+echo "-----"
+
+echo "Running mypy..."
 mypy $SOURCES
+echo "-----"
+
+echo "All passed!"


### PR DESCRIPTION
When running GitHub Actions, I noticed that the build wouldn't fail if `black` or `isort` found a formatting issue.

This has now been modified, and a separate `format.sh` file has been added.