### PR TITLE
fix engine slots

### DIFF
--- a/piccolo/engine/base.py
+++ b/piccolo/engine/base.py
@@ -20,6 +20,9 @@ class Batch:
 
 
 class Engine(metaclass=ABCMeta):
+
+    __slots__ = ()
+
     def __init__(self):
         run_sync(self.check_version())
         run_sync(self.prep_database())

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -228,7 +228,13 @@ class PostgresEngine(Engine):
 
     """  # noqa: E501
 
-    __slots__ = ("config", "extensions", "pool", "transaction_connection")
+    __slots__ = (
+        "config",
+        "extensions",
+        "log_queries",
+        "pool",
+        "transaction_connection",
+    )
 
     engine_type = "postgres"
     min_version_number = 9.6

--- a/piccolo/engine/sqlite.py
+++ b/piccolo/engine/sqlite.py
@@ -343,7 +343,7 @@ class SQLiteEngine(Engine):
 
     """
 
-    __slots__ = ("connection_kwargs",)
+    __slots__ = ("connection_kwargs", "transaction_connection")
 
     engine_type = "sqlite"
     min_version_number = 3.25


### PR DESCRIPTION
The `PostgresEngine` and `SQLiteEngine` classes used slots, but they weren't actually doing anything, as the parent `Engine` class didn't have slots defined.

I was tempted to remove the slots entirely (as in this situation their benefit it negligible), but kept them for now.