### PR TITLE
add conftest.py to ASGI template, which complains if using pytest directly

### DIFF
--- a/piccolo/apps/asgi/commands/templates/app/README.md.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/README.md.jinja
@@ -1,0 +1,21 @@
+# {{ project_identifier }}
+
+## Setup
+
+### Install requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+### Getting started guide
+
+```bash
+python main.py
+```
+
+### Running tests
+
+```bash
+piccolo tester run
+```

--- a/piccolo/apps/asgi/commands/templates/app/conftest.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/conftest.py.jinja
@@ -1,0 +1,17 @@
+import os
+import sys
+
+from piccolo.utils.warnings import colored_warning
+
+
+def pytest_configure(*args):
+    if os.environ.get("PICCOLO_TEST_RUNNER") != "True":
+        colored_warning(
+            "\n\n"
+            "We recommend running Piccolo tests using the "
+            "`piccolo tester run` command, which wraps Pytest, and makes "
+            "sure the test database is being used. "
+            "To stop this warning, modify conftest.py."
+            "\n\n"
+        )
+        sys.exit(1)

--- a/piccolo/apps/asgi/commands/templates/app/piccolo_conf_test.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/piccolo_conf_test.py.jinja
@@ -1,0 +1,12 @@
+from piccolo_conf import *  # noqa
+
+
+DB = PostgresEngine(
+    config={
+        "database": "{{ project_identifier }}_test",
+        "user": "postgres",
+        "password": "",
+        "host": "localhost",
+        "port": 5432,
+    }
+)

--- a/piccolo/apps/tester/commands/run.py
+++ b/piccolo/apps/tester/commands/run.py
@@ -64,6 +64,9 @@ def run(
     """
     Run your unit test suite using Pytest.
 
+    While running, it sets the ``PICCOLO_TEST_RUNNER`` environment variable to
+    ``'True'``, in case any other code needs to be aware of this.
+
     :param piccolo_conf:
         The piccolo_conf module to use when running your tests. This will
         contain the database settings you want to use. For example
@@ -76,4 +79,6 @@ def run(
     with set_env_var(var_name="PICCOLO_CONF", temp_value=piccolo_conf):
         refresh_db()
         args = pytest_args.split(" ")
-        sys.exit(run_pytest(args))
+
+        with set_env_var(var_name="PICCOLO_TEST_RUNNER", temp_value="True"):
+            sys.exit(run_pytest(args))


### PR DESCRIPTION
A solution to https://github.com/piccolo-orm/piccolo/issues/332

When using `piccolo asgi new`, a `conftest.py` file is added which warns the user that it's better to use `piccolo tester run` than `pytest` directly.

There may be a better solution in the future, but this is a fairly low impact change, which does the job for now.