### PR TITLE
include_columns now supports related tables

### DIFF
--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -245,7 +245,7 @@ def create_pydantic_model(
         elif isinstance(column, (JSON, JSONB)):
             field = pydantic.Field(format="json", extra=extra, **params)
         elif isinstance(column, Secret):
-            field = pydantic.Field(extra={"secret": True, **extra})
+            field = pydantic.Field(extra={"secret": True, **extra}, **params)
         else:
             field = pydantic.Field(extra=extra, **params)
 

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -328,10 +328,10 @@ class TestIncludeColumns(TestCase):
         """
 
         class Manager(Table):
-            name = Varchar(length=10)
+            name = Varchar()
 
         class Band(Table):
-            name = Varchar(length=10)
+            name = Varchar()
             manager = ForeignKey(Manager)
 
         pydantic_model = create_pydantic_model(
@@ -339,6 +339,13 @@ class TestIncludeColumns(TestCase):
         )
 
         self.assertIsNotNone(pydantic_model.__fields__.get("manager.name"))
+
+        # Make sure it can be instantiated:
+        model_instance = pydantic_model(
+            **{"name": "Pythonistas", "manager.name": "Guido"}
+        )
+        self.assertEqual(getattr(model_instance, "name"), "Pythonistas")
+        self.assertEqual(getattr(model_instance, "manager.name"), "Guido")
 
 
 class TestNestedModel(TestCase):

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -346,6 +346,10 @@ class TestIncludeColumns(TestCase):
         )
         self.assertEqual(getattr(model_instance, "name"), "Pythonistas")
         self.assertEqual(getattr(model_instance, "manager.name"), "Guido")
+        self.assertEqual(
+            model_instance.dict(),
+            {"name": "Pythonistas", "manager.name": "Guido"},
+        )
 
 
 class TestNestedModel(TestCase):


### PR DESCRIPTION
We recently added `include_columns` as an option to `create_pydantic_model`.

It lets you specify a subset of the Table columns to appear in the Pydantic model. For example:

```python
model = create_pydantic_model(Band, include_columns=(Band.name,))
```

With this PR, you can now include columns from related tables:

```python
model = create_pydantic_model(Band, include_columns=(Band.name, Band.manager.name))
```

To use this:

```python
model_instance = pydantic_model(
    **{"name": "Pythonistas", "manager.name": "Guido"}
)
>>> getattr(model_instance, "name")
"Pythonistas"
>>> getattr(model_instance, "manager.name")
"Guido"
```

It has been added so we can support column filtering in `PiccoloCRUD`: https://github.com/piccolo-orm/piccolo_api/issues/97

```
/tables/band?__visible_fields=name,manager.name
```
