### PR TITLE
fix minor docstring typos, such as missing language in `code-block`

### DIFF
--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -557,14 +557,14 @@ class Column(Selectable):
 
     def is_null(self) -> Where:
         """
-        Can be used instead of `MyTable.column != None`, because some linters
+        Can be used instead of ``MyTable.column != None``, because some linters
         don't like a comparison to None.
         """
         return Where(column=self, operator=IsNull)
 
     def is_not_null(self) -> Where:
         """
-        Can be used instead of `MyTable.column == None`, because some linters
+        Can be used instead of ``MyTable.column == None``, because some linters
         don't like a comparison to None.
         """
         return Where(column=self, operator=IsNotNull)
@@ -575,8 +575,10 @@ class Column(Selectable):
 
         For example:
 
-        >>> await Band.select(Band.name.as_alias('title')).run()
-        {'title': 'Pythonistas'}
+        .. code-block:: python
+
+            >>> await Band.select(Band.name.as_alias('title')).run()
+            {'title': 'Pythonistas'}
 
         """
         column = copy.deepcopy(self)

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -341,13 +341,15 @@ class Table(metaclass=TableMetaclass):
         """
         Used to fetch a Table instance, for the target of a foreign key.
 
-        band = await Band.objects().first().run()
-        manager = await band.get_related(Band.manager).run()
-        >>> print(manager.name)
-        'Guido'
+        .. code-block:: python
+
+            band = await Band.objects().first().run()
+            manager = await band.get_related(Band.manager).run()
+            >>> print(manager.name)
+            'Guido'
 
         It can only follow foreign keys one level currently.
-        i.e. Band.manager, but not Band.manager.x.y.z
+        i.e. ``Band.manager``, but not ``Band.manager.x.y.z``.
 
         """
         if isinstance(foreign_key, str):
@@ -383,7 +385,7 @@ class Table(metaclass=TableMetaclass):
         A convenience method which returns a dictionary, mapping column names
         to values for this table instance.
 
-        .. code-block::
+        .. code-block:: python
 
             instance = await Manager.objects().get(
                 Manager.name == 'Guido'
@@ -395,7 +397,7 @@ class Table(metaclass=TableMetaclass):
         If the columns argument is provided, only those columns are included in
         the output. It also works with column aliases.
 
-        .. code-block::
+        .. code-block:: python
 
             >>> instance.to_dict(Manager.id, Manager.name.as_alias('title'))
             {'id': 1, 'title': 'Guido'}

--- a/piccolo/utils/dictionary.py
+++ b/piccolo/utils/dictionary.py
@@ -10,7 +10,7 @@ def make_nested(dictionary: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
 
     This function puts any values from a related table into a sub dictionary.
 
-    .. code-block::
+    .. code-block:: python
 
         response = Band.select(Band.name, Band.manager.name).run_sync()
         >>> print(response)

--- a/piccolo/utils/objects.py
+++ b/piccolo/utils/objects.py
@@ -27,7 +27,7 @@ def make_nested_object(
 
     For example:
 
-    .. code-block::
+    .. code-block:: python
 
         band = make_nested(row, Band)
         >>> band

--- a/tests/columns/test_db_column_name.py
+++ b/tests/columns/test_db_column_name.py
@@ -13,7 +13,7 @@ class TestDBColumnName(DBTestCase):
     By using the ``db_column_name`` arg, the user can map a ``Column`` to a
     database column with a different name. For example:
 
-    .. code-block::
+    .. code-block:: python
 
         class MyTable(Table):
             class_ = Varchar(db_column_name='class')


### PR DESCRIPTION
Fixing some minor typos in docstrings - mostly `code-block` with a missing language.

For example `.. code-block::` instead of `.. code-block:: python`.