### PR TITLE
added `Column._equals` method

### DIFF
--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -116,13 +116,32 @@ class TestChoices(TestCase):
 
 
 class TestEquals(TestCase):
+    def test_non_column(self):
+        """
+        Make sure non-column values don't match.
+        """
+        for value in (1, "abc", None):
+            self.assertFalse(Manager.name._equals(value))
+
     def test_equals(self):
+        """
+        Test basic usage.
+        """
         self.assertTrue(Manager.name._equals(Manager.name))
 
+    def test_same_name(self):
+        """
+        Make sure that columns with the same name, but on different tables,
+        don't match.
+        """
         self.assertFalse(Manager.name._equals(Band.name))
 
+    def test_including_joins(self):
+        """
+        Make sure `including_joins` arg works correctly.
+        """
         self.assertTrue(Band.manager.name._equals(Manager.name))
 
         self.assertFalse(
-            Manager.name._equals(Band.manager.name, including_joins=True)
+            Band.manager.name._equals(Manager.name, including_joins=True)
         )

--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -119,6 +119,8 @@ class TestEquals(TestCase):
     def test_equals(self):
         self.assertTrue(Manager.name._equals(Manager.name))
 
+        self.assertFalse(Manager.name._equals(Band.name))
+
         self.assertTrue(Band.manager.name._equals(Manager.name))
 
         self.assertFalse(

--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from piccolo.columns.choices import Choice
 from piccolo.columns.column_types import Integer, Varchar
 from piccolo.table import Table
+from tests.example_apps.music.tables import Band, Manager
 
 
 class MyTable(Table):
@@ -111,4 +112,15 @@ class TestChoices(TestCase):
                 "mr": {"display_name": "Mr.", "value": 1},
                 "mrs": {"display_name": "Mrs.", "value": 2},
             },
+        )
+
+
+class TestEquals(TestCase):
+    def test_equals(self):
+        self.assertTrue(Manager.name._equals(Manager.name))
+
+        self.assertTrue(Band.manager.name._equals(Manager.name))
+
+        self.assertFalse(
+            Manager.name._equals(Band.manager.name, including_joins=True)
         )


### PR DESCRIPTION
Added an `_equals` method to `Column`.

There wasn't a centralised piece of logic for comparing columns, which is why it was added.
