### PR TITLE
`create_pydantic_model` can now accept a tuple for the `nested` arg

### DIFF
--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -236,7 +236,7 @@ def create_pydantic_model(
             ):
                 _type = create_pydantic_model(
                     table=column._foreign_key_meta.resolved_references,
-                    nested=True,
+                    nested=nested,
                     include_default_columns=include_default_columns,
                     include_readable=include_readable,
                     all_optional=all_optional,

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -436,7 +436,7 @@ class TestNestedModel(TestCase):
 
         CountryModel = ManagerModel.__fields__["country"].type_
         self.assertTrue(issubclass(CountryModel, pydantic.BaseModel))
-        self.assertEqual([i for i in ManagerModel.__fields__.keys()], ["name"])
+        self.assertEqual([i for i in CountryModel.__fields__.keys()], ["name"])
 
     def test_cascaded_args(self):
         """


### PR DESCRIPTION
We added the `nested` argument to `create_pydantic_model`. If `True` then each `ForeignKey` column is converted into a nested Pydantic model. It's a really cool feature, but in large, complex schemas you need more control.

This PR lets you specify a tuple of `ForeignKey` columns instead, and only those (and any intermediates) are converted.

```python

class Manager(Table):
    name = Varchar(length=50)


class Band(Table):
    name = Varchar()
    manager = ForeignKey(Manager)
    popularity = Integer()


class Venue(Table):
    name = Varchar()


class Concert(Table):
    band_1 = ForeignKey(Band)
    band_2 = ForeignKey(Band)
    venue = ForeignKey(Venue)

model = create_pydantic_model(Concert, nested=(Concert.band_1.manager, Concert.venue))
```

Which gives us:

```
model.band_1 -> sub model
model.band_1.manager -> sub sub model
model.band_2 -> int
model.venue -> sub model
```


