### PR TITLE
added max recursion depth, and can include/exclude columns from related tables

### DIFF
--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -85,6 +85,8 @@ def create_pydantic_model(
     all_optional: bool = False,
     model_name: t.Optional[str] = None,
     deserialize_json: bool = False,
+    recursion_depth: int = 0,
+    max_recursion_depth: int = 5,
     **schema_extra_kwargs,
 ) -> t.Type[pydantic.BaseModel]:
     """
@@ -121,6 +123,10 @@ def create_pydantic_model(
         By default, the values of any Piccolo ``JSON`` or ``JSONB`` columns are
         returned as strings. By setting this parameter to True, they will be
         returned as objects.
+    :recursion_depth:
+        Not to be set by the user - used internally to track recursion.
+    :max_recursion_depth:
+        If using nested models, this specifies the max amount of recursion.
     :param schema_extra_kwargs:
         This can be used to add additional fields to the schema. This is
         very useful when using Pydantic's JSON Schema features. For example:
@@ -141,51 +147,61 @@ def create_pydantic_model(
             "same time."
         )
 
-    if exclude_columns:
-        if not validate_columns(columns=exclude_columns, table=table):
-            raise ValueError(
-                f"`exclude_columns` are invalid: ({exclude_columns!r})"
-            )
+    if recursion_depth == 0:
+        if exclude_columns:
+            if not validate_columns(columns=exclude_columns, table=table):
+                raise ValueError(
+                    f"`exclude_columns` are invalid: {exclude_columns!r}"
+                )
 
-    if include_columns:
-        if not validate_columns(columns=include_columns, table=table):
-            raise ValueError(
-                f"`include_columns` are invalid: ({include_columns!r})"
-            )
+        if include_columns:
+            if not validate_columns(columns=include_columns, table=table):
+                raise ValueError(
+                    f"`include_columns` are invalid: {include_columns!r}"
+                )
 
     ###########################################################################
 
     columns: t.Dict[str, t.Any] = {}
     validators: t.Dict[str, classmethod] = {}
-    piccolo_columns = (
-        include_columns
-        if include_columns
-        else tuple(
-            table._meta.columns
-            if include_default_columns
-            else table._meta.non_default_columns
-        )
+
+    piccolo_columns = tuple(
+        table._meta.columns
+        if include_default_columns
+        else table._meta.non_default_columns
     )
 
-    for column in piccolo_columns:
-        # normal __contains__ checks __eq__ as well which returns ``Where``
-        # instance which always evaluates to ``True``
-        if exclude_columns and any(column is obj for obj in exclude_columns):
-            continue
-
-        column_name = (
-            ".".join(
-                [i._meta.name for i in column._meta.call_chain]
-                + [column._meta.name]
+    if include_columns:
+        include_columns_plus_ancestors = [
+            i
+            for i in itertools.chain(
+                include_columns, *[i._meta.call_chain for i in include_columns]
             )
-            if column._meta.call_chain
-            else column._meta.name
+        ]
+        piccolo_columns = tuple(
+            i
+            for i in piccolo_columns
+            if any(
+                i._equals(include_column)
+                for include_column in include_columns_plus_ancestors
+            )
         )
+
+    if exclude_columns:
+        piccolo_columns = tuple(
+            i
+            for i in piccolo_columns
+            if not any(
+                i._equals(exclude_column) for exclude_column in exclude_columns
+            )
+        )
+
+    for column in piccolo_columns:
+        column_name = column._meta.name
 
         is_optional = True if all_optional else not column._meta.required
 
         #######################################################################
-
         # Work out the column type
 
         if isinstance(column, (Decimal, Numeric)):
@@ -225,22 +241,29 @@ def create_pydantic_model(
         }
 
         if isinstance(column, ForeignKey):
-            if (nested is True) or (
-                isinstance(nested, tuple)
-                and any(
-                    column._equals(i)
-                    for i in itertools.chain(
-                        nested, *[i._meta.call_chain for i in nested]
+            if recursion_depth < max_recursion_depth and (
+                (nested is True)
+                or (
+                    isinstance(nested, tuple)
+                    and any(
+                        column._equals(i)
+                        for i in itertools.chain(
+                            nested, *[i._meta.call_chain for i in nested]
+                        )
                     )
                 )
             ):
                 _type = create_pydantic_model(
                     table=column._foreign_key_meta.resolved_references,
                     nested=nested,
+                    include_columns=include_columns,
+                    exclude_columns=exclude_columns,
                     include_default_columns=include_default_columns,
                     include_readable=include_readable,
                     all_optional=all_optional,
                     deserialize_json=deserialize_json,
+                    recursion_depth=recursion_depth + 1,
+                    max_recursion_depth=max_recursion_depth,
                 )
 
             tablename = (

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -206,7 +206,7 @@ class TestJSONColumn(TestCase):
         )
 
 
-class TestExcludeColumn(TestCase):
+class TestExcludeColumns(TestCase):
     def test_all(self):
         class Computer(Table):
             CPU = Varchar()
@@ -289,6 +289,33 @@ class TestExcludeColumn(TestCase):
         with self.assertRaises(ValueError):
             create_pydantic_model(Computer, exclude_columns=(Computer2.CPU,))
 
+    def test_exclude_nested(self):
+        class Manager(Table):
+            name = Varchar()
+            phone_number = Integer()
+
+        class Band(Table):
+            name = Varchar()
+            manager = ForeignKey(Manager)
+            popularity = Integer()
+
+        pydantic_model = create_pydantic_model(
+            table=Band,
+            exclude_columns=(
+                Band.popularity,
+                Band.manager.phone_number,
+            ),
+            nested=(Band.manager,),
+        )
+
+        model_instance = pydantic_model(
+            name="Pythonistas", manager={"name": "Guido"}
+        )
+        self.assertEqual(
+            model_instance.dict(),
+            {"name": "Pythonistas", "manager": {"name": "Guido"}},
+        )
+
 
 class TestIncludeColumns(TestCase):
     def test_include(self):
@@ -322,40 +349,42 @@ class TestIncludeColumns(TestCase):
                 include_columns=(Band.name,),
             )
 
-    def test_join(self):
+    def test_nested(self):
         """
         Make sure that columns on related tables work.
         """
 
         class Manager(Table):
             name = Varchar()
+            phone_number = Integer()
 
         class Band(Table):
             name = Varchar()
             manager = ForeignKey(Manager)
+            popularity = Integer()
 
         pydantic_model = create_pydantic_model(
-            table=Band, include_columns=(Band.name, Band.manager.name)
+            table=Band,
+            include_columns=(
+                Band.name,
+                Band.manager.name,
+            ),
+            nested=(Band.manager,),
         )
 
-        self.assertIsNotNone(pydantic_model.__fields__.get("manager.name"))
-
-        # Make sure it can be instantiated:
         model_instance = pydantic_model(
-            **{"name": "Pythonistas", "manager.name": "Guido"}
+            name="Pythonistas", manager={"name": "Guido"}
         )
-        self.assertEqual(getattr(model_instance, "name"), "Pythonistas")
-        self.assertEqual(getattr(model_instance, "manager.name"), "Guido")
         self.assertEqual(
             model_instance.dict(),
-            {"name": "Pythonistas", "manager.name": "Guido"},
+            {"name": "Pythonistas", "manager": {"name": "Guido"}},
         )
 
 
 class TestNestedModel(TestCase):
     def test_true(self):
         """
-        Make sure all foreign key columns are convered to nested models, when
+        Make sure all foreign key columns are converted to nested models, when
         `nested=True`.
         """
 
@@ -497,8 +526,6 @@ class TestNestedModel(TestCase):
             table=Band, nested=True, include_default_columns=True
         )
 
-        #######################################################################
-
         ManagerModel = BandModel.__fields__["manager"].type_
         self.assertTrue(issubclass(ManagerModel, pydantic.BaseModel))
         self.assertEqual(
@@ -506,13 +533,50 @@ class TestNestedModel(TestCase):
             ["id", "name", "country"],
         )
 
-        #######################################################################
-
         CountryModel = ManagerModel.__fields__["country"].type_
         self.assertTrue(issubclass(CountryModel, pydantic.BaseModel))
         self.assertEqual(
             [i for i in CountryModel.__fields__.keys()], ["id", "name"]
         )
+
+
+class TestRecursionDepth(TestCase):
+    def test_max(self):
+        class Country(Table):
+            name = Varchar()
+
+        class Manager(Table):
+            name = Varchar()
+            country = ForeignKey(Country)
+
+        class Band(Table):
+            name = Varchar()
+            manager = ForeignKey(Manager)
+            assistant_manager = ForeignKey(Manager)
+
+        class Venue(Table):
+            name = Varchar()
+
+        class Concert(Table):
+            band = ForeignKey(Band)
+            venue = ForeignKey(Venue)
+
+        ConcertModel = create_pydantic_model(
+            table=Concert, nested=True, max_recursion_depth=2
+        )
+
+        VenueModel = ConcertModel.__fields__["venue"].type_
+        self.assertTrue(issubclass(VenueModel, pydantic.BaseModel))
+
+        BandModel = ConcertModel.__fields__["band"].type_
+        self.assertTrue(issubclass(BandModel, pydantic.BaseModel))
+
+        ManagerModel = BandModel.__fields__["manager"].type_
+        self.assertTrue(issubclass(ManagerModel, pydantic.BaseModel))
+
+        # We should have hit the recursion depth:
+        CountryModel = ManagerModel.__fields__["country"].type_
+        self.assertTrue(CountryModel is int)
 
 
 class TestDBColumnName(TestCase):


### PR DESCRIPTION
Some more improvements to `create_pydantic_model`.

## max_recursion_depth

There's now a `max_recursion_depth` argument.

```python
create_pydantic_model(Band, max_recursion_depth=3, nested=True)
```

Otherwise if you have a massive schema, the recursion could get out of control.

## include_columns and exclude_columns improvements

You can now exclude and include columns from related tables.

```python
create_pydantic_model(Band, include_columns=(Band.name, Band.manager.name,), nested=(Band.manager,))
```

Likewise:

```python
create_pydantic_model(Band, exclude_columns=(Band.manager.phone_number,), nested=(Band.manager,))
```

This functionality is generally useful, but in particular is needed for https://github.com/piccolo-orm/piccolo_api/pull/98