### PR TITLE
improve Postgres docs

### DIFF
--- a/docs/src/piccolo/getting_started/index.rst
+++ b/docs/src/piccolo/getting_started/index.rst
@@ -3,6 +3,7 @@ Getting Started
 
 .. toctree::
     :caption: Contents:
+    :maxdepth: 1
 
     ./what_is_piccolo
     ./database_support

--- a/docs/src/piccolo/getting_started/setup_postgres.rst
+++ b/docs/src/piccolo/getting_started/setup_postgres.rst
@@ -79,9 +79,7 @@ DEB packages are available for `Ubuntu <https://www.pgadmin.org/download/pgadmin
 Postgres version
 ****************
 
-Piccolo is currently tested against Postgres 9.6, 10.6, and 11.1 so it's
-recommended to use one of those. To check all supported versions, see the
-`Travis file <https://github.com/piccolo-orm/piccolo/blob/master/.travis.yml>`_.
+Piccolo is tested on most major Postgres versions (see the `GitHub Actions file <https://github.com/piccolo-orm/piccolo/blob/master/.github/workflows/tests.yaml>`_).
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The docs around supported Postgres versions were massively out of date, and referenced Travis CI (we now use GitHub Actions instead).