### PR TITLE
improve ASGI home template

### DIFF
--- a/piccolo/apps/asgi/commands/templates/app/home/templates/home.html.jinja_raw
+++ b/piccolo/apps/asgi/commands/templates/app/home/templates/home.html.jinja_raw
@@ -8,7 +8,7 @@
         <section>
             <h2>Postgres</h2>
             <p>Make sure you create the database. See the <a href="https://piccolo-orm.readthedocs.io/en/latest/piccolo/getting_started/setup_postgres.html">docs</a> for guidance.</p>
-            <p>See <em>piccolo_conf.py</em> for the database settings.</p>
+            <p>See <code>piccolo_conf.py</code> for the database settings.</p>
         </section>
 
         <section>
@@ -26,7 +26,7 @@
 
         <section>
             <h2>Custom Tables</h2>
-            <p>An example table called <em>Task</em> exists in <em>tables.py</em>.</p>
+            <p>An example table called <code>Task</code> exists in <code>tables.py</code>.</p>
             <p>When you're ready, create a migration, and run it to add the table to the database:</p>
             <p class="code">
                 <span>piccolo migrations new home --auto</span>

--- a/piccolo/apps/asgi/commands/templates/app/static/main.css
+++ b/piccolo/apps/asgi/commands/templates/app/static/main.css
@@ -4,7 +4,8 @@ body, html {
 }
 
 body {
-    background-color: #f0f0f0;
+    background-color: #f0f7fd;
+    color: #2b475f;
     font-family: 'Open Sans', sans-serif;
 }
 
@@ -16,6 +17,7 @@ div.hero {
 
 a {
     color: #4C89C8;
+    text-decoration: none;
 }
 
 div.hero h1 {
@@ -36,20 +38,27 @@ div.content {
     max-width: 50rem;
     padding: 2rem;
     transform: translateY(-4rem);
+    box-shadow: 0px 1px 1px 1px rgb(0,0,0,0.05);
 }
 
-div.content h2 {
+div.content h2, div.content h3 {
     font-weight: normal;
-    border-bottom: 4px solid #f0f0f0;
+}
+
+div.content code {
+    padding: 2px 4px;
+    background-color: #f0f7fd;
+    border-radius: 0.2rem;
 }
 
 p.code {
-    background-color: #2b2b2b;
+    background-color: #233d58;
     color: white;
     font-family: monospace;
     padding: 1rem;
     margin: 0;
     display: block;
+    border-radius: 0.2rem;
 }
 
 p.code span {


### PR DESCRIPTION
When you use `piccolo asgi new`, then use `python main.py` it launches a welcome page which tells you how to get started.

I've made some subtle changes to the styles to make it a bit cleaner.

New:

<img width="926" alt="Screenshot 2021-11-29 at 12 54 19" src="https://user-images.githubusercontent.com/350976/143872637-b2832ccf-1d19-4a8e-8eff-10f50534c7c5.png">

Old:

<img width="930" alt="Screenshot 2021-11-29 at 12 59 45" src="https://user-images.githubusercontent.com/350976/143872642-aa259579-6420-4e17-bac4-2c93dc434b63.png">

