### PR TITLE
handle unrecognised column types when parsing default values

### DIFF
--- a/piccolo/apps/schema/commands/generate.py
+++ b/piccolo/apps/schema/commands/generate.py
@@ -347,9 +347,11 @@ COLUMN_DEFAULT_PARSER = {
 def get_column_default(
     column_type: t.Type[Column], column_default: str
 ) -> t.Any:
-    pat = COLUMN_DEFAULT_PARSER[column_type]
+    pat = COLUMN_DEFAULT_PARSER.get(column_type)
 
-    if pat is not None:
+    if pat is None:
+        return None
+    else:
         match = re.match(pat, column_default)
         if match is not None:
             value = match.groupdict()


### PR DESCRIPTION
When using ``piccolo schema generate`` and the column type isn't recognised by Piccolo, it would fail when trying to parse the column default.

Related to https://github.com/piccolo-orm/piccolo/issues/364