### PR TITLE
add sqlite connection pool warning to Engine

### DIFF
--- a/piccolo/engine/base.py
+++ b/piccolo/engine/base.py
@@ -89,18 +89,21 @@ class Engine(metaclass=ABCMeta):
             )
             colored_warning(message, stacklevel=3)
 
-    async def start_connection_pool(self):
-        """
-        The database driver doesn't implement connection pooling.
-        """
+    def _connection_pool_warning(self):
         message = (
             f"Connection pooling is not supported for {self.engine_type}."
         )
         logger.warning(message)
         colored_warning(message, stacklevel=3)
 
+    async def start_connection_pool(self):
+        """
+        The database driver doesn't implement connection pooling.
+        """
+        self._connection_pool_warning()
+
     async def close_connection_pool(self):
         """
         The database driver doesn't implement connection pooling.
         """
-        pass
+        self._connection_pool_warning()

--- a/piccolo/engine/base.py
+++ b/piccolo/engine/base.py
@@ -88,3 +88,19 @@ class Engine(metaclass=ABCMeta):
                 "Piccolo docs."
             )
             colored_warning(message, stacklevel=3)
+
+    async def start_connection_pool(self):
+        """
+        The database driver doesn't implement connection pooling.
+        """
+        message = (
+            f"Connection pooling is not supported for {self.engine_type}."
+        )
+        logger.warning(message)
+        colored_warning(message, stacklevel=3)
+
+    async def close_connection_pool(self):
+        """
+        The database driver doesn't implement connection pooling.
+        """
+        pass

--- a/tests/engine/test_pool.py
+++ b/tests/engine/test_pool.py
@@ -1,9 +1,10 @@
 import asyncio
 
 from piccolo.engine.postgres import PostgresEngine
+from piccolo.engine.sqlite import SQLiteEngine
 from tests.example_apps.music.tables import Manager
 
-from ..base import DBTestCase, postgres_only
+from ..base import DBTestCase, postgres_only, sqlite_only
 
 
 @postgres_only
@@ -77,4 +78,16 @@ class TestPoolProxyMethods(DBTestCase):
         There are some proxy methods, due to some old typos. Make sure they
         work, to ensure backwards compatibility.
         """
+        asyncio.run(self._create_pool())
+
+
+@sqlite_only
+class TestConnectionPoolWarning(DBTestCase):
+    async def _create_pool(self):
+        engine: SQLiteEngine = SQLiteEngine(path="engine1.sqlite")
+        await engine.start_connection_pool()
+
+        await engine.close_connection_pool()
+
+    def test_proxy_methods(self):
         asyncio.run(self._create_pool())


### PR DESCRIPTION
Partly solves: https://github.com/piccolo-orm/pymdb/issues/1