### PR TITLE
Fixes for problematic column names

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -1552,7 +1552,9 @@ class JSONB(JSON):
         return instance
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        select_string = self._meta.get_full_name(just_alias=just_alias)
+        select_string = self._meta.get_full_name(
+            just_alias=just_alias, include_quotes=True
+        )
         if self.json_operator is None:
             return select_string
         else:
@@ -1720,7 +1722,9 @@ class Array(Column):
             raise ValueError("Only integers can be used for indexing.")
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        select_string = self._meta.get_full_name(just_alias=just_alias)
+        select_string = self._meta.get_full_name(
+            just_alias=just_alias, include_quotes=True
+        )
 
         if isinstance(self.index, int):
             return f"{select_string}[{self.index}]"

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -60,14 +60,14 @@ class RenameColumn(AlterColumnStatement):
 
     @property
     def ddl(self) -> str:
-        return f"RENAME COLUMN {self.column_name} TO {self.new_name}"
+        return f'RENAME COLUMN "{self.column_name}" TO "{self.new_name}"'
 
 
 @dataclass
 class DropColumn(AlterColumnStatement):
     @property
     def ddl(self) -> str:
-        return f"DROP COLUMN {self.column_name}"
+        return f'DROP COLUMN "{self.column_name}"'
 
 
 @dataclass
@@ -87,7 +87,7 @@ class AddColumn(AlterColumnStatement):
 class DropDefault(AlterColumnStatement):
     @property
     def ddl(self) -> str:
-        return f"ALTER COLUMN {self.column_name} DROP DEFAULT"
+        return f'ALTER COLUMN "{self.column_name}" DROP DEFAULT'
 
 
 @dataclass
@@ -111,7 +111,7 @@ class SetColumnType(AlterStatement):
 
         column_name = self.old_column._meta.db_column_name
         query = (
-            f"ALTER COLUMN {column_name} TYPE {self.new_column.column_type}"
+            f'ALTER COLUMN "{column_name}" TYPE {self.new_column.column_type}'
         )
         if self.using_expression is not None:
             query += f" USING {self.using_expression}"
@@ -128,7 +128,7 @@ class SetDefault(AlterColumnStatement):
     @property
     def ddl(self) -> str:
         sql_value = self.column.get_sql_value(self.value)
-        return f"ALTER COLUMN {self.column_name} SET DEFAULT {sql_value}"
+        return f'ALTER COLUMN "{self.column_name}" SET DEFAULT {sql_value}'
 
 
 @dataclass
@@ -140,7 +140,7 @@ class SetUnique(AlterColumnStatement):
     @property
     def ddl(self) -> str:
         if self.boolean:
-            return f"ADD UNIQUE ({self.column_name})"
+            return f'ADD UNIQUE ("{self.column_name}")'
         if isinstance(self.column, str):
             raise ValueError(
                 "Removing a unique constraint requires a Column instance "
@@ -161,9 +161,9 @@ class SetNull(AlterColumnStatement):
     @property
     def ddl(self) -> str:
         if self.boolean:
-            return f"ALTER COLUMN {self.column_name} DROP NOT NULL"
+            return f'ALTER COLUMN "{self.column_name}" DROP NOT NULL'
         else:
-            return f"ALTER COLUMN {self.column_name} SET NOT NULL"
+            return f'ALTER COLUMN "{self.column_name}" SET NOT NULL'
 
 
 @dataclass
@@ -175,7 +175,7 @@ class SetLength(AlterColumnStatement):
 
     @property
     def ddl(self) -> str:
-        return f"ALTER COLUMN {self.column_name} TYPE VARCHAR({self.length})"
+        return f'ALTER COLUMN "{self.column_name}" TYPE VARCHAR({self.length})'
 
 
 @dataclass
@@ -209,9 +209,9 @@ class AddForeignKeyConstraint(AlterStatement):
     @property
     def ddl(self) -> str:
         query = (
-            f"ADD CONSTRAINT {self.constraint_name} FOREIGN KEY "
-            f"({self.foreign_key_column_name}) REFERENCES "
-            f"{self.referenced_table_name} ({self.referenced_column_name})"
+            f'ADD CONSTRAINT "{self.constraint_name}" FOREIGN KEY '
+            f'("{self.foreign_key_column_name}") REFERENCES '
+            f'"{self.referenced_table_name}" ("{self.referenced_column_name}")'
         )
         if self.on_delete:
             query += f" ON DELETE {self.on_delete.value}"
@@ -231,12 +231,12 @@ class SetDigits(AlterColumnStatement):
     @property
     def ddl(self) -> str:
         if self.digits is None:
-            return f"ALTER COLUMN {self.column_name} TYPE {self.column_type}"
+            return f'ALTER COLUMN "{self.column_name}" TYPE {self.column_type}'
 
         precision = self.digits[0]
         scale = self.digits[1]
         return (
-            f"ALTER COLUMN {self.column_name} TYPE "
+            f'ALTER COLUMN "{self.column_name}" TYPE '
             f"{self.column_type}({precision}, {scale})"
         )
 

--- a/piccolo/query/methods/insert.py
+++ b/piccolo/query/methods/insert.py
@@ -39,7 +39,7 @@ class Insert(Query):
     def sqlite_querystrings(self) -> t.Sequence[QueryString]:
         base = f"INSERT INTO {self.table._meta.tablename}"
         columns = ",".join(
-            i._meta.db_column_name for i in self.table._meta.columns
+            f'"{i._meta.db_column_name}"' for i in self.table._meta.columns
         )
         values = ",".join("{}" for _ in self.add_delegate._add)
         query = f"{base} ({columns}) VALUES {values}"
@@ -58,7 +58,7 @@ class Insert(Query):
         columns = ",".join(
             f'"{i._meta.db_column_name}"' for i in self.table._meta.columns
         )
-        values = ",".join("{}" for i in self.add_delegate._add)
+        values = ",".join("{}" for _ in self.add_delegate._add)
         primary_key_name = self.table._meta.primary_key._meta.name
         query = (
             f"{base} ({columns}) VALUES {values} RETURNING {primary_key_name}"

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -58,7 +58,9 @@ class Avg(Selectable):
         self.alias = alias
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(just_alias=just_alias)
+        column_name = self.column._meta.get_full_name(
+            just_alias=just_alias, include_quotes=True
+        )
         return f"AVG({column_name}) AS {self.alias}"
 
 
@@ -98,7 +100,7 @@ class Count(Selectable):
             column_name = "*"
         else:
             column_name = self.column._meta.get_full_name(
-                just_alias=just_alias
+                just_alias=just_alias, include_quotes=True
             )
         return f"COUNT({column_name}) AS {self.alias}"
 
@@ -130,7 +132,9 @@ class Max(Selectable):
         self.alias = alias
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(just_alias=just_alias)
+        column_name = self.column._meta.get_full_name(
+            just_alias=just_alias, include_quotes=True
+        )
         return f"MAX({column_name}) AS {self.alias}"
 
 
@@ -159,7 +163,9 @@ class Min(Selectable):
         self.alias = alias
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(just_alias=just_alias)
+        column_name = self.column._meta.get_full_name(
+            just_alias=just_alias, include_quotes=True
+        )
         return f"MIN({column_name}) AS {self.alias}"
 
 
@@ -193,7 +199,9 @@ class Sum(Selectable):
         self.alias = alias
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(just_alias=just_alias)
+        column_name = self.column._meta.get_full_name(
+            just_alias=just_alias, include_quotes=True
+        )
         return f"SUM({column_name}) AS {self.alias}"
 
 

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -100,7 +100,7 @@ class Count(Selectable):
             column_name = self.column._meta.get_full_name(
                 just_alias=just_alias
             )
-        return f'COUNT("{column_name}") AS {self.alias}'
+        return f"COUNT({column_name}) AS {self.alias}"
 
 
 class Max(Selectable):
@@ -131,7 +131,7 @@ class Max(Selectable):
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)
-        return f'MAX("{column_name}") AS {self.alias}'
+        return f"MAX({column_name}) AS {self.alias}"
 
 
 class Min(Selectable):
@@ -160,7 +160,7 @@ class Min(Selectable):
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)
-        return f'MIN("{column_name}") AS {self.alias}'
+        return f"MIN({column_name}) AS {self.alias}"
 
 
 class Sum(Selectable):

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -32,11 +32,22 @@ def is_numeric_column(column: Column) -> bool:
 
 class Avg(Selectable):
     """
-    AVG() SQL function. Column type must be numeric to run the query.
+    ``AVG()`` SQL function. Column type must be numeric to run the query.
 
-    await Band.select(Avg(Band.popularity)).run() or with aliases
-    await Band.select(Avg(Band.popularity, alias="popularity_avg")).run()
-    await Band.select(Avg(Band.popularity).as_alias("popularity_avg")).run()
+    .. code-block:: python
+
+        await Band.select(Avg(Band.popularity)).run()
+
+        # We can use an alias. These two are equivalent:
+
+        await Band.select(
+            Avg(Band.popularity, alias="popularity_avg")
+        ).run()
+
+        await Band.select(
+            Avg(Band.popularity).as_alias("popularity_avg")
+        ).run()
+
     """
 
     def __init__(self, column: Column, alias: str = "avg"):
@@ -59,9 +70,21 @@ class Count(Selectable):
     column. If no column is specified, the count is for all rows, whether
     they have null values or not.
 
-    Band.select(Band.name, Count()).group_by(Band.name).run()
-    Band.select(Band.name, Count(alias="total")).group_by(Band.name).run()
-    Band.select(Band.name, Count().as_alias("total")).group_by(Band.name).run()
+    .. code-block:: python
+
+        Band.select(Band.name, Count()).group_by(Band.name).run()
+
+        # We can use an alias. These two are equivalent:
+
+        Band.select(
+            Band.name, Count(alias="total")
+        ).group_by(Band.name).run()
+
+        Band.select(
+            Band.name,
+            Count().as_alias("total")
+        ).group_by(Band.name).run()
+
     """
 
     def __init__(
@@ -77,16 +100,29 @@ class Count(Selectable):
             column_name = self.column._meta.get_full_name(
                 just_alias=just_alias
             )
-        return f"COUNT({column_name}) AS {self.alias}"
+        return f'COUNT("{column_name}") AS {self.alias}'
 
 
 class Max(Selectable):
     """
-    MAX() SQL function.
+    ``MAX()`` SQL function.
 
-    await Band.select(Max(Band.popularity)).run() or with aliases
-    await Band.select(Max(Band.popularity, alias="popularity_max")).run()
-    await Band.select(Max(Band.popularity).as_alias("popularity_max")).run()
+    .. code-block:: python
+
+        await Band.select(
+            Max(Band.popularity)
+        ).run()
+
+        # We can use an alias. These two are equivalent:
+
+        await Band.select(
+            Max(Band.popularity, alias="popularity_max")
+        ).run()
+
+        await Band.select(
+            Max(Band.popularity).as_alias("popularity_max")
+        ).run()
+
     """
 
     def __init__(self, column: Column, alias: str = "max"):
@@ -95,16 +131,27 @@ class Max(Selectable):
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)
-        return f"MAX({column_name}) AS {self.alias}"
+        return f'MAX("{column_name}") AS {self.alias}'
 
 
 class Min(Selectable):
     """
-    MIN() SQL function.
+    ``MIN()`` SQL function.
 
-    await Band.select(Min(Band.popularity)).run()
-    await Band.select(Min(Band.popularity, alias="popularity_min")).run()
-    await Band.select(Min(Band.popularity).as_alias("popularity_min")).run()
+    .. code-block:: python
+
+        await Band.select(Min(Band.popularity)).run()
+
+        # We can use an alias. These two are equivalent:
+
+        await Band.select(
+            Min(Band.popularity, alias="popularity_min")
+        ).run()
+
+        await Band.select(
+            Min(Band.popularity).as_alias("popularity_min")
+        ).run()
+
     """
 
     def __init__(self, column: Column, alias: str = "min"):
@@ -113,16 +160,29 @@ class Min(Selectable):
 
     def get_select_string(self, engine_type: str, just_alias=False) -> str:
         column_name = self.column._meta.get_full_name(just_alias=just_alias)
-        return f"MIN({column_name}) AS {self.alias}"
+        return f'MIN("{column_name}") AS {self.alias}'
 
 
 class Sum(Selectable):
     """
-    SUM() SQL function. Column type must be numeric to run the query.
+    ``SUM()`` SQL function. Column type must be numeric to run the query.
 
-    await Band.select(Sum(Band.popularity)).run()
-    await Band.select(Sum(Band.popularity, alias="popularity_sum")).run()
-    await Band.select(Sum(Band.popularity).as_alias("popularity_sum")).run()
+    .. code-block:: python
+
+        await Band.select(
+            Sum(Band.popularity)
+        ).run()
+
+        # We can use an alias. These two are equivalent:
+
+        await Band.select(
+            Sum(Band.popularity, alias="popularity_sum")
+        ).run()
+
+        await Band.select(
+            Sum(Band.popularity).as_alias("popularity_sum")
+        ).run()
+
     """
 
     def __init__(self, column: Column, alias: str = "sum"):

--- a/piccolo/query/methods/update.py
+++ b/piccolo/query/methods/update.py
@@ -49,7 +49,7 @@ class Update(Query):
         self.validate()
 
         columns_str = ", ".join(
-            f"{col._meta.db_column_name} = {{}}"
+            f'"{col._meta.db_column_name}" = {{}}'
             for col, _ in self.values_delegate._values.items()
         )
 

--- a/tests/columns/test_combination.py
+++ b/tests/columns/test_combination.py
@@ -7,22 +7,24 @@ class TestWhere(unittest.TestCase):
     def test_equals(self):
         _where = Band.name == "Pythonistas"
         sql = _where.__str__()
-        self.assertEqual(sql, "band.name = 'Pythonistas'")
+        self.assertEqual(sql, '"band"."name" = \'Pythonistas\'')
 
     def test_not_equal(self):
         _where = Band.name != "CSharps"
         sql = _where.__str__()
-        self.assertEqual(sql, "band.name != 'CSharps'")
+        self.assertEqual(sql, '"band"."name" != \'CSharps\'')
 
     def test_like(self):
         _where = Band.name.like("Python%")
         sql = _where.__str__()
-        self.assertEqual(sql, "band.name LIKE 'Python%'")
+        self.assertEqual(sql, '"band"."name" LIKE \'Python%\'')
 
     def test_is_in(self):
         _where = Band.name.is_in(["Pythonistas", "Rustaceans"])
         sql = _where.__str__()
-        self.assertEqual(sql, "band.name IN ('Pythonistas', 'Rustaceans')")
+        self.assertEqual(
+            sql, "\"band\".\"name\" IN ('Pythonistas', 'Rustaceans')"
+        )
 
         with self.assertRaises(ValueError):
             Band.name.is_in([])
@@ -30,7 +32,7 @@ class TestWhere(unittest.TestCase):
     def test_not_in(self):
         _where = Band.name.not_in(["CSharps"])
         sql = _where.__str__()
-        self.assertEqual(sql, "band.name NOT IN ('CSharps')")
+        self.assertEqual(sql, '"band"."name" NOT IN (\'CSharps\')')
 
         with self.assertRaises(ValueError):
             Band.name.not_in([])

--- a/tests/columns/test_reserved_column_names.py
+++ b/tests/columns/test_reserved_column_names.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+
+from piccolo.columns.column_types import Integer, Varchar
+from piccolo.table import Table
+
+
+class Concert(Table):
+    """
+    ``order`` is a problematic name, as it clashes with a reserved SQL keyword:
+
+    https://www.postgresql.org/docs/current/sql-keywords-appendix.html
+
+    """
+
+    name = Varchar()
+    order = Integer()
+
+
+class TestReservedColumnNames(TestCase):
+    """
+    Make sure the table works as expected, even though it has a problematic
+    column name.
+    """
+
+    def setUp(self):
+        Concert.create_table().run_sync()
+
+    def tearDown(self):
+        Concert.alter().drop_table().run_sync()
+
+    def test_common_operations(self):
+        # Save / Insert
+        concert = Concert(name="Royal Albert Hall", order=1)
+        concert.save().run_sync()
+        self.assertEqual(
+            Concert.select(Concert.order).run_sync(),
+            [{"order": 1}],
+        )
+
+        # Save / Update
+        concert.order = 2
+        concert.save().run_sync()
+        self.assertEqual(
+            Concert.select(Concert.order).run_sync(),
+            [{"order": 2}],
+        )
+
+        # Update
+        Concert.update({Concert.order: 3}).run_sync()
+        self.assertEqual(
+            Concert.select(Concert.order).run_sync(),
+            [{"order": 3}],
+        )
+
+        # Delete
+        Concert.delete().where(Concert.order == 3).run_sync()
+        self.assertEqual(
+            Concert.select(Concert.order).run_sync(),
+            [],
+        )

--- a/tests/engine/test_nested_transaction.py
+++ b/tests/engine/test_nested_transaction.py
@@ -7,7 +7,7 @@ from piccolo.engine.sqlite import SQLiteEngine
 from piccolo.table import Table
 from tests.example_apps.music.tables import Manager
 
-from ..base import DBTestCase, sqlite_only
+from tests.base import DBTestCase, sqlite_only
 
 ENGINE_1 = SQLiteEngine(path="engine1.sqlite")
 ENGINE_2 = SQLiteEngine(path="engine2.sqlite")

--- a/tests/engine/test_nested_transaction.py
+++ b/tests/engine/test_nested_transaction.py
@@ -5,9 +5,8 @@ from piccolo.columns.column_types import Varchar
 from piccolo.engine.exceptions import TransactionError
 from piccolo.engine.sqlite import SQLiteEngine
 from piccolo.table import Table
-from tests.example_apps.music.tables import Manager
-
 from tests.base import DBTestCase, sqlite_only
+from tests.example_apps.music.tables import Manager
 
 ENGINE_1 = SQLiteEngine(path="engine1.sqlite")
 ENGINE_2 = SQLiteEngine(path="engine2.sqlite")

--- a/tests/engine/test_pool.py
+++ b/tests/engine/test_pool.py
@@ -6,9 +6,8 @@ from unittest.mock import MagicMock, call, patch
 
 from piccolo.engine.postgres import PostgresEngine
 from piccolo.engine.sqlite import SQLiteEngine
-from tests.example_apps.music.tables import Manager
-
 from tests.base import DBTestCase, postgres_only, sqlite_only
+from tests.example_apps.music.tables import Manager
 
 
 @postgres_only

--- a/tests/engine/test_pool.py
+++ b/tests/engine/test_pool.py
@@ -8,7 +8,7 @@ from piccolo.engine.postgres import PostgresEngine
 from piccolo.engine.sqlite import SQLiteEngine
 from tests.example_apps.music.tables import Manager
 
-from ..base import DBTestCase, postgres_only, sqlite_only
+from tests.base import DBTestCase, postgres_only, sqlite_only
 
 
 @postgres_only

--- a/tests/table/test_batch.py
+++ b/tests/table/test_batch.py
@@ -3,7 +3,7 @@ import math
 
 from tests.example_apps.music.tables import Manager
 
-from ..base import DBTestCase
+from tests.base import DBTestCase
 
 
 class TestBatchSelect(DBTestCase):

--- a/tests/table/test_batch.py
+++ b/tests/table/test_batch.py
@@ -1,9 +1,8 @@
 import asyncio
 import math
 
-from tests.example_apps.music.tables import Manager
-
 from tests.base import DBTestCase
+from tests.example_apps.music.tables import Manager
 
 
 class TestBatchSelect(DBTestCase):

--- a/tests/table/test_count.py
+++ b/tests/table/test_count.py
@@ -1,6 +1,5 @@
-from tests.example_apps.music.tables import Band
-
 from tests.base import DBTestCase
+from tests.example_apps.music.tables import Band
 
 
 class TestCount(DBTestCase):

--- a/tests/table/test_count.py
+++ b/tests/table/test_count.py
@@ -1,6 +1,6 @@
 from tests.example_apps.music.tables import Band
 
-from ..base import DBTestCase
+from tests.base import DBTestCase
 
 
 class TestCount(DBTestCase):

--- a/tests/table/test_delete.py
+++ b/tests/table/test_delete.py
@@ -1,7 +1,7 @@
 from piccolo.query.methods.delete import DeletionError
 from tests.example_apps.music.tables import Band
 
-from ..base import DBTestCase
+from tests.base import DBTestCase
 
 
 class TestDelete(DBTestCase):

--- a/tests/table/test_delete.py
+++ b/tests/table/test_delete.py
@@ -1,7 +1,6 @@
 from piccolo.query.methods.delete import DeletionError
-from tests.example_apps.music.tables import Band
-
 from tests.base import DBTestCase
+from tests.example_apps.music.tables import Band
 
 
 class TestDelete(DBTestCase):

--- a/tests/table/test_exists.py
+++ b/tests/table/test_exists.py
@@ -1,6 +1,5 @@
-from tests.example_apps.music.tables import Band
-
 from tests.base import DBTestCase
+from tests.example_apps.music.tables import Band
 
 
 class TestExists(DBTestCase):

--- a/tests/table/test_exists.py
+++ b/tests/table/test_exists.py
@@ -1,6 +1,6 @@
 from tests.example_apps.music.tables import Band
 
-from ..base import DBTestCase
+from tests.base import DBTestCase
 
 
 class TestExists(DBTestCase):

--- a/tests/table/test_indexes.py
+++ b/tests/table/test_indexes.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from tests.example_apps.music.tables import Manager
 
-from ..base import DBTestCase
+from tests.base import DBTestCase
 
 
 class TestIndexes(DBTestCase):

--- a/tests/table/test_indexes.py
+++ b/tests/table/test_indexes.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
 
-from tests.example_apps.music.tables import Manager
-
 from tests.base import DBTestCase
+from tests.example_apps.music.tables import Manager
 
 
 class TestIndexes(DBTestCase):

--- a/tests/table/test_insert.py
+++ b/tests/table/test_insert.py
@@ -1,6 +1,5 @@
-from tests.example_apps.music.tables import Band, Manager
-
 from tests.base import DBTestCase
+from tests.example_apps.music.tables import Band, Manager
 
 
 class TestInsert(DBTestCase):

--- a/tests/table/test_insert.py
+++ b/tests/table/test_insert.py
@@ -1,6 +1,6 @@
 from tests.example_apps.music.tables import Band, Manager
 
-from ..base import DBTestCase
+from tests.base import DBTestCase
 
 
 class TestInsert(DBTestCase):

--- a/tests/table/test_raw.py
+++ b/tests/table/test_raw.py
@@ -1,6 +1,6 @@
 from tests.example_apps.music.tables import Band
 
-from ..base import DBTestCase
+from tests.base import DBTestCase
 
 
 class TestRaw(DBTestCase):

--- a/tests/table/test_raw.py
+++ b/tests/table/test_raw.py
@@ -1,6 +1,5 @@
-from tests.example_apps.music.tables import Band
-
 from tests.base import DBTestCase
+from tests.example_apps.music.tables import Band
 
 
 class TestRaw(DBTestCase):

--- a/tests/table/test_repr.py
+++ b/tests/table/test_repr.py
@@ -1,6 +1,5 @@
-from tests.example_apps.music.tables import Manager
-
 from tests.base import DBTestCase, postgres_only, sqlite_only
+from tests.example_apps.music.tables import Manager
 
 
 class TestTableRepr(DBTestCase):

--- a/tests/table/test_repr.py
+++ b/tests/table/test_repr.py
@@ -1,6 +1,6 @@
 from tests.example_apps.music.tables import Manager
 
-from ..base import DBTestCase, postgres_only, sqlite_only
+from tests.base import DBTestCase, postgres_only, sqlite_only
 
 
 class TestTableRepr(DBTestCase):

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -5,7 +5,7 @@ from piccolo.columns.combination import WhereRaw
 from piccolo.query.methods.select import Avg, Count, Max, Min, Sum
 from tests.example_apps.music.tables import Band, Concert, Manager, Venue
 
-from ..base import DBTestCase, postgres_only, sqlite_only
+from tests.base import DBTestCase, postgres_only, sqlite_only
 
 
 class TestSelect(DBTestCase):

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -3,9 +3,8 @@ from unittest import TestCase
 from piccolo.apps.user.tables import BaseUser
 from piccolo.columns.combination import WhereRaw
 from piccolo.query.methods.select import Avg, Count, Max, Min, Sum
-from tests.example_apps.music.tables import Band, Concert, Manager, Venue
-
 from tests.base import DBTestCase, postgres_only, sqlite_only
+from tests.example_apps.music.tables import Band, Concert, Manager, Venue
 
 
 class TestSelect(DBTestCase):

--- a/tests/table/test_update.py
+++ b/tests/table/test_update.py
@@ -1,6 +1,5 @@
+from tests.base import DBTestCase
 from tests.example_apps.music.tables import Band, Poster
-
-from ..base import DBTestCase
 
 
 class TestUpdate(DBTestCase):


### PR DESCRIPTION
Some queries would fail if a column name clashed with a reserved Postgres keyword.

I encountered this in one of my own apps with a column called `order`. I could create the table OK, and it worked in most situations, but some migrations would fail.

This PR adds extra tests, and wraps column names in quotes in more situations.

It also does a bit of general cleanup of docstrings and imports.