### PR TITLE
`_get_related_readable` fix

### DIFF
--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -575,13 +575,20 @@ class Table(metaclass=TableMetaclass):
             column._foreign_key_meta.resolved_references.get_readable()
         )
 
-        columns = [getattr(column, i._meta.name) for i in readable.columns]
+        output_columns = []
+
+        for readable_column in readable.columns:
+            output_column = column
+            for fk in readable_column._meta.call_chain:
+                output_column = getattr(column, fk._meta.name)
+            output_column = getattr(output_column, readable_column._meta.name)
+            output_columns.append(output_column)
 
         output_name = f"{column._meta.name}_readable"
 
         return Readable(
             template=readable.template,
-            columns=columns,
+            columns=output_columns,
             output_name=output_name,
         )
 

--- a/tests/example_apps/music/tables.py
+++ b/tests/example_apps/music/tables.py
@@ -29,6 +29,10 @@ class Band(Table):
     manager = ForeignKey(Manager, null=True)
     popularity = Integer(default=0)
 
+    @classmethod
+    def get_readable(cls) -> Readable:
+        return Readable(template="%s", columns=[cls.name])
+
 
 ###############################################################################
 # More complex
@@ -38,11 +42,27 @@ class Venue(Table):
     name = Varchar(length=100)
     capacity = Integer(default=0, secret=True)
 
+    @classmethod
+    def get_readable(cls) -> Readable:
+        return Readable(template="%s", columns=[cls.name])
+
 
 class Concert(Table):
     band_1 = ForeignKey(Band)
     band_2 = ForeignKey(Band)
     venue = ForeignKey(Venue)
+
+    @classmethod
+    def get_readable(cls) -> Readable:
+        return Readable(
+            template="%s and %s at %s, capacity %s",
+            columns=[
+                cls.band_1.name,
+                cls.band_2.name,
+                cls.venue.name,
+                cls.venue.capacity,
+            ],
+        )
 
 
 class Ticket(Table):

--- a/tests/table/instance/test_get_related_readable.py
+++ b/tests/table/instance/test_get_related_readable.py
@@ -1,22 +1,82 @@
-from tests.base import DBTestCase
-from tests.example_apps.music.tables import Band
+import decimal
+from unittest import TestCase
+
+from piccolo.table import create_tables, drop_tables
+from tests.example_apps.music.tables import (
+    Band,
+    Concert,
+    Manager,
+    Ticket,
+    Venue,
+)
+
+TABLES = [Band, Concert, Manager, Venue, Ticket]
 
 
-class TestGetRelatedReadable(DBTestCase):
+class TestGetRelatedReadable(TestCase):
+    def setUp(self):
+        create_tables(*TABLES)
+
+        manager_1 = Manager.objects().create(name="Guido").run_sync()
+        manager_2 = Manager.objects().create(name="Graydon").run_sync()
+
+        band_1 = (
+            Band.objects()
+            .create(name="Pythonistas", manager=manager_1)
+            .run_sync()
+        )
+        band_2 = (
+            Band.objects()
+            .create(name="Rustaceans", manager=manager_2)
+            .run_sync()
+        )
+        venue = (
+            Venue.objects()
+            .create(name="Royal Albert Hall", capacity=5900)
+            .run_sync()
+        )
+        concert = (
+            Concert.objects()
+            .create(venue=venue, band_1=band_1, band_2=band_2)
+            .run_sync()
+        )
+        Ticket.objects().create(
+            price=decimal.Decimal(50.0), concert=concert
+        ).run_sync()
+
+    def tearDown(self):
+        drop_tables(*TABLES)
+
     def test_get_related_readable(self):
         """
         Make sure you can get the `Readable` representation for related object
         from another object instance.
         """
-        self.insert_row()
-
         response = Band.select(
             Band.name, Band._get_related_readable(Band.manager)
         ).run_sync()
 
         self.assertEqual(
-            response, [{"name": "Pythonistas", "manager_readable": "Guido"}]
+            response,
+            [
+                {"name": "Pythonistas", "manager_readable": "Guido"},
+                {"manager_readable": "Graydon", "name": "Rustaceans"},
+            ],
         )
 
-        # TODO Need to make sure it can go two levels deep ...
-        # e.g. Concert._get_related_readable(Concert.band_1.manager)
+        # Now try something much more complex.
+        response = Ticket.select(
+            Ticket.id, Ticket._get_related_readable(Ticket.concert)
+        ).run_sync()
+        self.assertEqual(
+            response,
+            [
+                {
+                    "id": 1,
+                    "concert_readable": (
+                        "Pythonistas and Rustaceans at Royal Albert Hall, "
+                        "capacity 5900"
+                    ),
+                }
+            ],
+        )


### PR DESCRIPTION
We have a feature called [`Readable`](https://piccolo-orm.readthedocs.io/en/latest/piccolo/schema/advanced.html#readable). So when representing a row in Piccolo Admin, rather than just showing the ID, the user can specify something much more user friendly.

In Piccolo, we generate these readable values in the database, which is more efficient than calling a string method on each row using Python.

In one of my apps I found it was possible to cause a 500 error when having a really complex readable value. This is what the PR fixes.