### PR TITLE
fix error message for `LazyTableReference`

### DIFF
--- a/piccolo/columns/reference.py
+++ b/piccolo/columns/reference.py
@@ -69,8 +69,8 @@ class LazyTableReference:
                 return table
             else:
                 raise ValueError(
-                    f"Can't find a Table subclass called {self.app_name} "
-                    f"in {self.module_path}"
+                    "Can't find a Table subclass called "
+                    f"{self.table_class_name} in {self.module_path}"
                 )
 
         raise ValueError("You must specify either app_name or module_path.")


### PR DESCRIPTION
Whilst debugging https://github.com/piccolo-orm/piccolo/issues/384 I realised there's a typo in `LazyTableReference` - it was printing out an incorrect error message.