### PR TITLE
Nested model fix

### DIFF
--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -512,7 +512,20 @@ class TestNestedModel(TestCase):
 
         #######################################################################
         # Test with `model_name` arg
-        # TODO
+
+        MyConcertModel = create_pydantic_model(
+            Concert,
+            nested=(Concert.band_1.manager,),
+            model_name="MyConcertModel",
+        )
+
+        BandModel = MyConcertModel.__fields__["band_1"].type_
+        self.assertEqual(BandModel.__qualname__, "MyConcertModel.band_1")
+
+        ManagerModel = BandModel.__fields__["manager"].type_
+        self.assertEqual(
+            ManagerModel.__qualname__, "MyConcertModel.band_1.manager"
+        )
 
     def test_cascaded_args(self):
         """

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -451,6 +451,7 @@ class TestNestedModel(TestCase):
         self.assertEqual(
             [i for i in ManagerModel.__fields__.keys()], ["name", "country"]
         )
+        self.assertEqual(ManagerModel.__qualname__, "Band.manager")
 
         AssistantManagerType = BandModel.__fields__["assistant_manager"].type_
         self.assertTrue(AssistantManagerType is int)
@@ -467,6 +468,7 @@ class TestNestedModel(TestCase):
         self.assertEqual(
             [i for i in ManagerModel.__fields__.keys()], ["name", "country"]
         )
+        self.assertEqual(ManagerModel.__qualname__, "Band.manager")
 
         AssistantManagerType = BandModel.__fields__["assistant_manager"].type_
         self.assertTrue(AssistantManagerType is int)
@@ -474,6 +476,7 @@ class TestNestedModel(TestCase):
         CountryModel = ManagerModel.__fields__["country"].type_
         self.assertTrue(issubclass(CountryModel, pydantic.BaseModel))
         self.assertEqual([i for i in CountryModel.__fields__.keys()], ["name"])
+        self.assertEqual(CountryModel.__qualname__, "Band.manager.country")
 
         #######################################################################
         # Test three levels deep
@@ -491,6 +494,7 @@ class TestNestedModel(TestCase):
             [i for i in BandModel.__fields__.keys()],
             ["name", "manager", "assistant_manager"],
         )
+        self.assertEqual(BandModel.__qualname__, "Concert.band_1")
 
         ManagerModel = BandModel.__fields__["manager"].type_
         self.assertTrue(issubclass(ManagerModel, pydantic.BaseModel))
@@ -498,12 +502,17 @@ class TestNestedModel(TestCase):
             [i for i in ManagerModel.__fields__.keys()],
             ["name", "country"],
         )
+        self.assertEqual(ManagerModel.__qualname__, "Concert.band_1.manager")
 
         AssistantManagerType = BandModel.__fields__["assistant_manager"].type_
         self.assertTrue(AssistantManagerType is int)
 
         CountryModel = ManagerModel.__fields__["country"].type_
         self.assertTrue(CountryModel is int)
+
+        #######################################################################
+        # Test with `model_name` arg
+        # TODO
 
     def test_cascaded_args(self):
         """


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo_api/issues/129

`create_pydantic_model` has the ability to create nested models. For example:

```python
create_pydantic_model(Band, nested=(Band.manager,))
```

In the above example, `Band` has a sub model called `Manager`.

It was discovered by @wmshort that there's a bug where Pydantic sometimes can't uniquely identify these sub models. The solution is to set the `__qualname__` of the sub model. In the above example, the `Manager` sub model now has a  `__qualname__` of `Band.manager`.

To learn more about `__qualname__`, see [PEP 3155](https://www.python.org/dev/peps/pep-3155/).

## Design decisions

One decision I wasn't sure about was what to use for the `__name__` attribute of these submodels.

If `__qualname__` is `Band.manager`, then `__name__` should be `manager`. However, if we do this we can end up with loads of models called 'manager', and in the Swagger docs of FastAPI / BlackSheep etc it's not very user friendly.

<img width="669" alt="Screenshot 2022-01-10 at 12 51 52" src="https://user-images.githubusercontent.com/350976/148769472-2bb21b75-1625-4406-a423-e16ef6170316.png">

So at the moment, I've set `__name__` to be the same as `__qualname__`, so they are uniquely identifiable in the Swagger docs (i.e. it will show `Band.manager` instead of `Manager`.


