### PR TITLE
added `exclude_imported` option to `table_finder`

### DIFF
--- a/piccolo/apps/asgi/commands/templates/app/home/piccolo_app.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/home/piccolo_app.py.jinja
@@ -16,7 +16,7 @@ APP_CONFIG = AppConfig(
     migrations_folder_path=os.path.join(
         CURRENT_DIRECTORY, "piccolo_migrations"
     ),
-    table_classes=table_finder(modules=["home.tables"]),
+    table_classes=table_finder(modules=["home.tables"], exclude_imported=True),
     migration_dependencies=[],
     commands=[],
 )

--- a/tests/conf/example.py
+++ b/tests/conf/example.py
@@ -1,0 +1,12 @@
+"""
+This file is used by test_apps.py to make sure we can exclude imported
+``Table`` subclasses when using ``table_finder``.
+"""
+from piccolo.apps.user.tables import BaseUser
+from piccolo.columns.column_types import ForeignKey, Varchar
+from piccolo.table import Table
+
+
+class Musician(Table):
+    name = Varchar()
+    user = ForeignKey(BaseUser)

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -177,6 +177,31 @@ class TestTableFinder(TestCase):
             ],
         )
 
+    def test_exclude_imported(self):
+        """
+        Make sure we can excluded imported Tables.
+        """
+        filtered_tables = table_finder(
+            modules=["tests.conf.example"],
+            exclude_imported=True,
+        )
+
+        self.assertEqual(
+            [i.__name__ for i in filtered_tables],
+            ["Musician"],
+        )
+
+        # Now try without filtering:
+        all_tables = table_finder(
+            modules=["tests.conf.example"],
+            exclude_imported=False,
+        )
+
+        self.assertEqual(
+            sorted([i.__name__ for i in all_tables]),
+            ["BaseUser", "Musician"],
+        )
+
 
 class TestFinder(TestCase):
     def test_get_table_classes(self):


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/390

When using `table_finder` to register `Table` subclasses with `AppConfig` (for auto migrations), you would sometimes encounter situations like this, where you import ``Table`` subclasses from other files:

```python
from piccolo.apps.user.tables import BaseUser # <- This
from piccolo.columns.column_types import ForeignKey, Varchar
from piccolo.table import Table


class Musician(Table):
    name = Varchar()
    user = ForeignKey(BaseUser)

```

If we just wanted to import ``Musician`` and not ``BaseUser``, then the existing solution was to use tags:

```python
class Musician(Table, tags=['music']):
    name = Varchar()
    user = ForeignKey(BaseUser)
```

And then in ``piccolo_app.py``:

```python
APP_CONFIG = AppConfig(
    ...
    table_classes=table_finder(['music.tables'], include_tags=['music']),
)
```

It works OK, but means adding tags to all of your ``Table`` subclasses. Tags are still supported, but the new solution is to use ``exclude_imported``:

```python
APP_CONFIG = AppConfig(
    ...
    table_classes=table_finder(['music.tables'], exclude_imported=True),
)
```

It's set to ``False`` by default, to maintain backwards compatibility. But it's set to ``True`` in the template generated by ``piccolo asgi new`` so new users will have it switched on.
