### PR TITLE
make the `value_type` dynamic for `ForeignKey`

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -1177,7 +1177,7 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
     @property
     def column_type(self):
         """
-        A ForeignKey column needs to have the same type as the primary key
+        A ``ForeignKey`` column needs to have the same type as the primary key
         column of the table being referenced.
         """
         referenced_table = self._foreign_key_meta.resolved_references
@@ -1186,6 +1186,15 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
             return Integer().column_type
         else:
             return pk_column.column_type
+
+    @property
+    def value_type(self):
+        """
+        The value type matches that of the primary key being referenced.
+        """
+        referenced_table = self._foreign_key_meta.resolved_references
+        pk_column = referenced_table._meta.primary_key
+        return pk_column.value_type
 
     def __init__(
         self,

--- a/tests/columns/test_foreignkey.py
+++ b/tests/columns/test_foreignkey.py
@@ -1,7 +1,14 @@
 import time
+import uuid
 from unittest import TestCase
 
-from piccolo.columns import Column, ForeignKey, LazyTableReference, Varchar
+from piccolo.columns import (
+    UUID,
+    Column,
+    ForeignKey,
+    LazyTableReference,
+    Varchar,
+)
 from piccolo.columns.base import OnDelete, OnUpdate
 from piccolo.table import Table
 from tests.base import postgres_only
@@ -44,6 +51,25 @@ class Band5(Table):
         on_delete=OnDelete.set_null,
         on_update=OnUpdate.set_null,
     )
+
+
+class ManagerUUID(Table):
+    pk = UUID(primary_key=True)
+
+
+class Band6(Table):
+    manager = ForeignKey(references=ManagerUUID)
+
+
+class TestValueType(TestCase):
+    """
+    The `value_type` of the `ForeignKey` should depend on the `PrimaryKey` of
+    the referenced table.
+    """
+
+    def test_value_type(self):
+        self.assertTrue(Band1.manager.value_type is int)
+        self.assertTrue(Band6.manager.value_type is uuid.UUID)
 
 
 class TestForeignKeyMeta(TestCase):


### PR DESCRIPTION
Each `Column` has a `value_type` which is basically the Python type it maps to.

It used to always be `int` for `ForeignKey`, but this is wrong, as it depends on the primary key being referred to (i.e. if it's referencing a table where a `UUID` is the primary key, then the column must also be of type `uuid`).

