### PR TITLE
Add UUID type conversion and fix datetime comparison

### DIFF
--- a/piccolo/querystring.py
+++ b/piccolo/querystring.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime
 import typing as t
 from dataclasses import dataclass
-from string import Formatter
+from datetime import datetime
 from importlib.util import find_spec
+from string import Formatter
 
 if t.TYPE_CHECKING:
     from piccolo.table import Table
@@ -13,6 +13,7 @@ if find_spec("asyncpg"):
     from asyncpg.pgproto.pgproto import UUID
 else:
     from uuid import UUID
+
 
 @dataclass
 class Unquoted:

--- a/piccolo/querystring.py
+++ b/piccolo/querystring.py
@@ -9,10 +9,11 @@ from string import Formatter
 if t.TYPE_CHECKING:
     from piccolo.table import Table
 
+from uuid import UUID
 if find_spec("asyncpg"):
-    from asyncpg.pgproto.pgproto import UUID
+    from asyncpg.pgproto.pgproto import UUID as apgUUID
 else:
-    from uuid import UUID
+    apgUUID = UUID
 
 
 @dataclass
@@ -99,7 +100,7 @@ class QueryString:
             elif _type == datetime:
                 dt_string = arg.isoformat()
                 converted_args.append(f"'{dt_string}'")
-            elif _type == UUID:
+            elif _type == UUID or _type == apgUUID:
                 converted_args.append(f"'{arg}'")
             elif arg is None:
                 converted_args.append("null")

--- a/piccolo/querystring.py
+++ b/piccolo/querystring.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
-import datetime
+from datetime import datetime
 import typing as t
 from dataclasses import dataclass
 from string import Formatter
+from importlib.util import find_spec
 
 if t.TYPE_CHECKING:
     from piccolo.table import Table
 
+if find_spec("asyncpg"):
+    from asyncpg.pgproto.pgproto import UUID
+else:
+    from uuid import UUID
 
 @dataclass
 class Unquoted:
@@ -91,8 +96,10 @@ class QueryString:
             if _type == str:
                 converted_args.append(f"'{arg}'")
             elif _type == datetime:
-                dt_string = arg.isoformat().replace("T", " ")
+                dt_string = arg.isoformat()
                 converted_args.append(f"'{dt_string}'")
+            elif _type == UUID:
+                converted_args.append(f"'{arg}'")
             elif arg is None:
                 converted_args.append("null")
             else:

--- a/piccolo/querystring.py
+++ b/piccolo/querystring.py
@@ -10,6 +10,7 @@ if t.TYPE_CHECKING:
     from piccolo.table import Table
 
 from uuid import UUID
+
 if find_spec("asyncpg"):
     from asyncpg.pgproto.pgproto import UUID as apgUUID
 else:


### PR DESCRIPTION
Reference Issue #404 

## Motivation
The querystring builder is valuable when trying to write custom complex queries with `VALUES` however, certain values are not converted to sql compatible values properly. This results in `Table.raw(query).run()` failing. Changes here aspire to address this issue.

## Explanation
A couple of type check fixes. The `datetime` comparison in the `querystring` was comparing to the module not the class and wouldn't be picked up. Additionally, the `.replace("T", " ")` doesn't work with postgres as far as I can tell and I removed it.

There also needs to be a check on `UUID`. When being written to a query string the value should be wrapped in `''`.

I imagine something similar may need to be done with JSONB, Enum, etc. Maybe there could be some merging of usage with the `piccolo.utils.sql_values.convert_to_sql_value` function.

