### PR TITLE
make docs async first

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,23 @@ await Band.select(
     Band.name
 ).where(
     Band.popularity > 100
-).run()
+)
 
 # Join:
 await Band.select(
     Band.name,
     Band.manager.name
-).run()
+)
 
 # Delete:
 await Band.delete().where(
     Band.popularity < 1000
-).run()
+)
 
 # Update:
 await Band.update({Band.popularity: 10000}).where(
     Band.name == 'Pythonistas'
-).run()
+)
 ```
 
 Or like a typical ORM:
@@ -57,15 +57,15 @@ Or like a typical ORM:
 ```python
 # To create a new object:
 b = Band(name='C-Sharps', popularity=100)
-await b.save().run()
+await b.save()
 
 # To fetch an object from the database, and update it:
-b = await Band.objects().get(Band.name == 'Pythonistas').run()
+b = await Band.objects().get(Band.name == 'Pythonistas')
 b.popularity = 10000
-await b.save().run()
+await b.save()
 
 # To delete:
-await b.remove().run()
+await b.remove()
 ```
 
 ## Installation

--- a/docs/src/piccolo/getting_started/index.rst
+++ b/docs/src/piccolo/getting_started/index.rst
@@ -10,5 +10,5 @@ Getting Started
     ./installing_piccolo
     ./playground
     ./setup_postgres
-    ./sync_and_async
     ./example_schema
+    ./sync_and_async

--- a/docs/src/piccolo/getting_started/playground.rst
+++ b/docs/src/piccolo/getting_started/playground.rst
@@ -52,10 +52,10 @@ Give these queries a go:
 
 .. code-block:: python
 
-    Band.select().run_sync()
-    Band.objects().run_sync()
-    Band.select(Band.name).run_sync()
-    Band.select(Band.name, Band.manager.name).run_sync()
+    await Band.select()
+    await Band.objects()
+    await Band.select(Band.name)
+    await Band.select(Band.name, Band.manager.name)
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/getting_started/sync_and_async.rst
+++ b/docs/src/piccolo/getting_started/sync_and_async.rst
@@ -3,81 +3,58 @@
 Sync and Async
 ==============
 
-One of the main motivations for making Piccolo was the lack of options for
-ORMs which support asyncio.
+One of the motivations for making Piccolo was the lack of ORMs and query
+builders which support asyncio.
 
-However, you can use Piccolo in synchronous apps as well, whether that be a
-WSGI web app, or a data science script.
-
--------------------------------------------------------------------------------
-
-Sync example
-------------
-
-.. code-block:: python
-
-    from my_schema import Band
-
-
-    def main():
-        print(Band.select().run_sync())
-
-
-    if __name__ == '__main__':
-        main()
+Piccolo is designed to be async first. However, you can use Piccolo in
+synchronous apps as well, whether that be a WSGI web app, or a data science
+script.
 
 -------------------------------------------------------------------------------
 
 Async example
 -------------
 
-.. code-block:: python
-
-    import asyncio
-    from my_schema import Band
-
-
-    async def main():
-        print(await Band.select().run())
-
-
-    if __name__ == '__main__':
-        asyncio.run(main())
-
-Direct await
-~~~~~~~~~~~~
-
-You can directly await a query if you prefer. For example:
+You can await a query to run it:
 
 .. code-block:: python
 
-    >>> await Band.select()
-    [{'id': 1, 'name': 'Pythonistas', 'manager': 1, 'popularity': 1000},
-    {'id': 2, 'name': 'Rustaceans', 'manager': 2, 'popularity': 500}]
+    >>> await Band.select(Band.name)
+    [{'name': 'Pythonistas'}]
 
-By convention, we await the ``run`` method (``await Band.select().run()``), but
-you can use this shorter form if you prefer.
+If you need more control over how the query is executed, you can await the
+``run`` method of a query:
+
+.. code-block:: python
+
+    >>> await Band.select(Band.name).run(in_pool=False)
+    [{'name': 'Pythonistas'}]
+
+
+Using the async version is useful for applications which require high
+throughput. Piccolo makes building an ASGI web app really simple - see
+:ref:`ASGICommand`.
 
 -------------------------------------------------------------------------------
 
-Which to use?
--------------
+Sync example
+------------
 
-A lot of the time, using the sync version works perfectly fine. Many of the
-examples use the sync version.
+This lets you execute a query in an application which isn't using asyncio:
 
-Using the async version is useful for web applications which require high
-throughput, based on `ASGI frameworks <https://piccolo-orm.com/blog/introduction-to-asgi>`_.
-Piccolo makes building an ASGI web app really simple - see :ref:`ASGICommand`.
+.. code-block:: python
+
+    >>> Band.select(Band.name).run_sync()
+    [{'name': 'Pythonistas'}]
 
 -------------------------------------------------------------------------------
 
 Explicit
 --------
 
-By using ``run`` and ``run_sync``, it makes it very explicit when a query is
+By using ``await`` and ``run_sync``, it makes it very explicit when a query is
 actually being executed.
 
-Until you execute one of those methods, you can chain as many methods onto your
+Until you execute ``await`` or ``run_sync``, you can chain as many methods onto your
 query as you like, safe in the knowledge that no database queries are being
 made.

--- a/docs/src/piccolo/query_clauses/batch.rst
+++ b/docs/src/piccolo/query_clauses/batch.rst
@@ -20,10 +20,6 @@ responses.
         async for _batch in batch:
             print(_batch)
 
-.. note:: ``batch`` is one of the few query clauses which doesn't require
-    .run() to be used after it in order to execute. ``batch`` effectively
-    replaces ``run``.
-
 There's currently no synchronous version. However, it's easy enough to achieve:
 
 .. code-block:: python

--- a/docs/src/piccolo/query_clauses/distinct.rst
+++ b/docs/src/piccolo/query_clauses/distinct.rst
@@ -9,7 +9,7 @@ You can use ``distinct`` clauses with the following queries:
 
 .. code-block:: python
 
-    >>> Band.select(Band.name).distinct().run_sync()
+    >>> await Band.select(Band.name).distinct()
     [{'title': 'Pythonistas'}]
 
 This is equivalent to ``SELECT DISTINCT name FROM band`` in SQL.

--- a/docs/src/piccolo/query_clauses/first.rst
+++ b/docs/src/piccolo/query_clauses/first.rst
@@ -12,14 +12,14 @@ Rather than returning a list of results, just the first result is returned.
 
 .. code-block:: python
 
-    >>> Band.select().first().run_sync()
+    >>> await Band.select().first()
     {'name': 'Pythonistas', 'manager': 1, 'popularity': 1000, 'id': 1}
 
 Likewise, with objects:
 
 .. code-block:: python
 
-    >>> Band.objects().first().run_sync()
-    <Band at 0x10fdef1d0>
+    >>> await Band.objects().first()
+    <Band: 1>
 
 If no match is found, then ``None`` is returned instead.

--- a/docs/src/piccolo/query_clauses/group_by.rst
+++ b/docs/src/piccolo/query_clauses/group_by.rst
@@ -21,12 +21,12 @@ In the following query, we get a count of the number of bands per manager:
 
     >>> from piccolo.query.methods.select import Count
 
-    >>> Band.select(
+    >>> await Band.select(
     >>>     Band.manager.name,
     >>>     Count(Band.manager)
     >>> ).group_by(
     >>>     Band.manager
-    >>> ).run_sync()
+    >>> )
 
     [
         {"manager.name": "Graydon", "count": 1},

--- a/docs/src/piccolo/query_clauses/limit.rst
+++ b/docs/src/piccolo/query_clauses/limit.rst
@@ -13,10 +13,10 @@ number you ask for.
 
 .. code-block:: python
 
-    Band.select().limit(2).run_sync()
+    await Band.select().limit(2)
 
 Likewise, with objects:
 
 .. code-block:: python
 
-    Band.objects().limit(2).run_sync()
+    await Band.objects().limit(2)

--- a/docs/src/piccolo/query_clauses/offset.rst
+++ b/docs/src/piccolo/query_clauses/offset.rst
@@ -15,12 +15,12 @@ otherwise the results returned could be different each time.
 
 .. code-block:: python
 
-    >>> Band.select(Band.name).offset(1).order_by(Band.name).run_sync()
+    >>> await Band.select(Band.name).offset(1).order_by(Band.name)
     [{'name': 'Pythonistas'}, {'name': 'Rustaceans'}]
 
 Likewise, with objects:
 
 .. code-block:: python
 
-    >>> Band.objects().offset(1).order_by(Band.name).run_sync()
+    >>> await Band.objects().offset(1).order_by(Band.name)
     [Band2, Band3]

--- a/docs/src/piccolo/query_clauses/order_by.rst
+++ b/docs/src/piccolo/query_clauses/order_by.rst
@@ -12,24 +12,24 @@ To order the results by a certain column (ascending):
 
 .. code-block:: python
 
-    Band.select().order_by(
+    await Band.select().order_by(
         Band.name
-    ).run_sync()
+    )
 
 To order by descending:
 
 .. code-block:: python
 
-    Band.select().order_by(
+    await Band.select().order_by(
         Band.name,
         ascending=False
-    ).run_sync()
+    )
 
 You can order by multiple columns, and even use joins:
 
 .. code-block:: python
 
-    Band.select().order_by(
+    await Band.select().order_by(
         Band.name,
         Band.manager.name
-    ).run_sync()
+    )

--- a/docs/src/piccolo/query_clauses/output.rst
+++ b/docs/src/piccolo/query_clauses/output.rst
@@ -20,8 +20,8 @@ To return the data as a JSON string:
 
 .. code-block:: python
 
-    >>> Band.select().output(as_json=True).run_sync()
-    '[{"name":"Pythonistas","manager":1,"popularity":1000,"id":1},{"name":"Rustaceans","manager":2,"popularity":500,"id":2}]'
+    >>> await Band.select(Band.name).output(as_json=True)
+    '[{"name":"Pythonistas"}]'
 
 Piccolo can use `orjson <https://github.com/ijl/orjson>`_ for JSON serialisation,
 which is blazing fast, and can handle most Python types, including dates,
@@ -36,7 +36,7 @@ If you're just querying a single column from a database table, you can use
 
 .. code-block:: python
 
-    >>> Band.select(Band.id).output(as_list=True).run_sync()
+    >>> await Band.select(Band.id).output(as_list=True)
     [1, 2]
 
 nested
@@ -46,7 +46,7 @@ Output any data from related tables in nested dictionaries.
 
 .. code-block:: python
 
-    >>> Band.select(Band.name, Band.manager.name).first().output(nested=True).run_sync()
+    >>> await Band.select(Band.name, Band.manager.name).first().output(nested=True)
     {'name': 'Pythonistas', 'manager': {'name': 'Guido'}}
 
 -------------------------------------------------------------------------------
@@ -62,9 +62,9 @@ values automatically.
 
 .. code-block:: python
 
-    >>> RecordingStudio.select().output(load_json=True).run_sync()
+    >>> await RecordingStudio.select().output(load_json=True)
     [{'id': 1, 'name': 'Abbey Road', 'facilities': {'restaurant': True, 'mixing_desk': True}}]
 
-    >>> studio = RecordingStudio.objects().first().output(load_json=True).run_sync()
+    >>> studio = await RecordingStudio.objects().first().output(load_json=True)
     >>> studio.facilities
     {'restaurant': True, 'mixing_desk': True}

--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -20,15 +20,15 @@ Equal / Not Equal
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         Band.name == 'Pythonistas'
-    ).run_sync()
+    )
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         Band.name != 'Rustaceans'
-    ).run_sync()
+    )
 
 .. hint:: With ``Boolean`` columns, some linters will complain if you write
     ``SomeTable.some_column == True`` (because it's more Pythonic to do
@@ -45,9 +45,9 @@ You can use the ``<, >, <=, >=`` operators, which work as you expect.
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         Band.popularity >= 100
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -58,21 +58,21 @@ The percentage operator is required to designate where the match should occur.
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         Band.name.like('Py%')  # Matches the start of the string
-    ).run_sync()
+    )
 
-    Band.select().where(
+    await Band.select().where(
         Band.name.like('%istas')  # Matches the end of the string
-    ).run_sync()
+    )
 
-    Band.select().where(
+    await Band.select().where(
         Band.name.like('%is%')  # Matches anywhere in string
-    ).run_sync()
+    )
 
-    Band.select().where(
+    await Band.select().where(
         Band.name.like('Pythonistas')  # Matches the entire string
-    ).run_sync()
+    )
 
 ``ilike`` is identical, except it's Postgres specific and case insensitive.
 
@@ -85,9 +85,9 @@ Usage is the same as ``like`` excepts it excludes matching rows.
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         Band.name.not_like('Py%')
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -96,15 +96,15 @@ is_in / not_in
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         Band.name.is_in(['Pythonistas'])
-    ).run_sync()
+    )
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         Band.name.not_in(['Rustaceans'])
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -117,28 +117,28 @@ with None:
 .. code-block:: python
 
     # Fetch all bands with a manager
-    Band.select().where(
+    await Band.select().where(
         Band.manager != None
-    ).run_sync()
+    )
 
     # Fetch all bands without a manager
-    Band.select().where(
+    await Band.select().where(
         Band.manager == None
-    ).run_sync()
+    )
 
 To avoid the linter errors, you can use `is_null` and `is_not_null` instead.
 
 .. code-block:: python
 
     # Fetch all bands with a manager
-    Band.select().where(
+    await Band.select().where(
         Band.manager.is_not_null()
-    ).run_sync()
+    )
 
     # Fetch all bands without a manager
-    Band.select().where(
+    await Band.select().where(
         Band.manager.is_null()
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -149,13 +149,13 @@ You can make complex ``where`` queries using ``&`` for AND, and ``|`` for OR.
 
 .. code-block:: python
 
-    Band.select().where(
+    await Band.select().where(
         (Band.popularity >= 100) & (Band.popularity < 1000)
-    ).run_sync()
+    )
 
-    Band.select().where(
+    await Band.select().where(
         (Band.popularity >= 100) | (Band.name ==  'Pythonistas')
-    ).run_sync()
+    )
 
 You can make really complex ``where`` clauses if you so choose - just be
 careful to include brackets in the correct place.
@@ -169,28 +169,28 @@ Using multiple ``where`` clauses is equivalent to an AND.
 .. code-block:: python
 
     # These are equivalent:
-    Band.select().where(
+    await Band.select().where(
         (Band.popularity >= 100) & (Band.popularity < 1000)
-    ).run_sync()
+    )
 
-    Band.select().where(
+    await Band.select().where(
         Band.popularity >= 100
     ).where(
         Band.popularity < 1000
-    ).run_sync()
+    )
 
 Also, multiple arguments inside ``where`` clause is equivalent to an AND.
 
 .. code-block:: python
 
     # These are equivalent:
-    Band.select().where(
+    await Band.select().where(
         (Band.popularity >= 100) & (Band.popularity < 1000)
-    ).run_sync()
+    )
 
-    Band.select().where(
+    await Band.select().where(
         Band.popularity >= 100, Band.popularity < 1000
-    ).run_sync()
+    )
 
 Using And / Or directly
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -202,12 +202,12 @@ Rather than using the ``|`` and ``&`` characters, you can use the ``And`` and
 
     from piccolo.columns.combination import And, Or
 
-    Band.select().where(
+    await Band.select().where(
         Or(
             And(Band.popularity >= 100, Band.popularity < 1000),
             Band.name == 'Pythonistas'
         )
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -220,9 +220,9 @@ In certain situations you may want to have raw SQL in your where clause.
 
     from piccolo.columns.combination import WhereRaw
 
-    Band.select().where(
+    await Band.select().where(
         WhereRaw("name = 'Pythonistas'")
-    ).run_sync()
+    )
 
 It's important to parameterise your SQL statements if the values come from an
 untrusted source, otherwise it could lead to a SQL injection attack.
@@ -233,9 +233,9 @@ untrusted source, otherwise it could lead to a SQL injection attack.
 
     value = "Could be dangerous"
 
-    Band.select().where(
+    await Band.select().where(
         WhereRaw("name = {}", value)
-    ).run_sync()
+    )
 
 ``WhereRaw`` can be combined into complex queries, just as you'd expect:
 
@@ -243,6 +243,6 @@ untrusted source, otherwise it could lead to a SQL injection attack.
 
     from piccolo.columns.combination import WhereRaw
 
-    Band.select().where(
+    await Band.select().where(
         WhereRaw("name = 'Pythonistas'") | (Band.popularity > 1000)
-    ).run_sync()
+    )

--- a/docs/src/piccolo/query_types/alter.rst
+++ b/docs/src/piccolo/query_types/alter.rst
@@ -16,7 +16,7 @@ Used to add a column to an existing table.
 
 .. code-block:: python
 
-    Band.alter().add_column('members', Integer()).run_sync()
+    await Band.alter().add_column('members', Integer())
 
 -------------------------------------------------------------------------------
 
@@ -27,7 +27,7 @@ Used to drop an existing column.
 
 .. code-block:: python
 
-    Band.alter().drop_column('popularity').run_sync()
+    await Band.alter().drop_column('popularity')
 
 -------------------------------------------------------------------------------
 
@@ -38,7 +38,7 @@ Used to drop the table - use with caution!
 
 .. code-block:: python
 
-    Band.alter().drop_table().run_sync()
+    await Band.alter().drop_table()
 
 If you have several tables which you want to drop, you can use ``drop_tables``
 instead. It will drop them in the correct order.
@@ -58,7 +58,7 @@ Used to rename an existing column.
 
 .. code-block:: python
 
-    Band.alter().rename_column(Band.popularity, 'rating').run_sync()
+    await Band.alter().rename_column(Band.popularity, 'rating')
 
 -------------------------------------------------------------------------------
 
@@ -70,10 +70,10 @@ Set whether a column is nullable or not.
 .. code-block:: python
 
     # To make a row nullable:
-    Band.alter().set_null(Band.name, True).run_sync()
+    await Band.alter().set_null(Band.name, True)
 
     # To stop a row being nullable:
-    Band.alter().set_null(Band.name, False).run_sync()
+    await Band.alter().set_null(Band.name, False)
 
 -------------------------------------------------------------------------------
 
@@ -85,7 +85,7 @@ Used to change whether a column is unique or not.
 .. code-block:: python
 
     # To make a row unique:
-    Band.alter().set_unique(Band.name, True).run_sync()
+    await Band.alter().set_unique(Band.name, True)
 
     # To stop a row being unique:
-    Band.alter().set_unique(Band.name, False).run_sync()
+    await Band.alter().set_unique(Band.name, False)

--- a/docs/src/piccolo/query_types/create_table.rst
+++ b/docs/src/piccolo/query_types/create_table.rst
@@ -9,7 +9,7 @@ This creates the table and columns in the database.
 
 .. code-block:: python
 
-    >>> Band.create_table().run_sync()
+    >>> await Band.create_table()
     []
 
 
@@ -17,7 +17,7 @@ To prevent an error from being raised if the table already exists:
 
 .. code-block:: python
 
-    >>> Band.create_table(if_not_exists=True).run_sync()
+    >>> await Band.create_table(if_not_exists=True)
     []
 
 Also, you can create multiple tables at once.
@@ -25,7 +25,7 @@ Also, you can create multiple tables at once.
 This function will automatically sort tables based on their foreign keys so they're created in the right order:
 
 .. code-block:: python
-    
-    >>> from piccolo.table import create_tables 
+
+    >>> from piccolo.table import create_tables
     >>> create_tables(Band, Manager, if_not_exists=True)
-   
+

--- a/docs/src/piccolo/query_types/delete.rst
+++ b/docs/src/piccolo/query_types/delete.rst
@@ -7,7 +7,7 @@ This deletes any matching rows from the table.
 
 .. code-block:: python
 
-    >>> Band.delete().where(Band.name == 'Rustaceans').run_sync()
+    >>> await Band.delete().where(Band.name == 'Rustaceans')
     []
 
 -------------------------------------------------------------------------------
@@ -21,11 +21,11 @@ the data from a table.
 
 .. code-block:: python
 
-    >>> Band.delete().run_sync()
+    >>> await Band.delete()
     Raises: DeletionError
 
     # Works fine:
-    >>> Band.delete(force=True).run_sync()
+    >>> await Band.delete(force=True)
     []
 
 -------------------------------------------------------------------------------

--- a/docs/src/piccolo/query_types/exists.rst
+++ b/docs/src/piccolo/query_types/exists.rst
@@ -7,7 +7,7 @@ This checks whether any rows exist which match the criteria.
 
 .. code-block:: python
 
-    >>> Band.exists().where(Band.name == 'Pythonistas').run_sync()
+    >>> await Band.exists().where(Band.name == 'Pythonistas')
     True
 
 -------------------------------------------------------------------------------

--- a/docs/src/piccolo/query_types/insert.rst
+++ b/docs/src/piccolo/query_types/insert.rst
@@ -7,17 +7,17 @@ This is used to insert rows into the table.
 
 .. code-block:: python
 
-    >>> Band.insert(Band(name="Pythonistas")).run_sync()
+    >>> await Band.insert(Band(name="Pythonistas"))
     [{'id': 3}]
 
 We can insert multiple rows in one go:
 
 .. code-block:: python
 
-    Band.insert(
+    await Band.insert(
         Band(name="Darts"),
         Band(name="Gophers")
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -28,8 +28,8 @@ You can also compose it as follows:
 
 .. code-block:: python
 
-    Band.insert().add(
+    await Band.insert().add(
         Band(name="Darts")
     ).add(
         Band(name="Gophers")
-    ).run_sync()
+    )

--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -20,28 +20,28 @@ To get all objects:
 
 .. code-block:: python
 
-    >>> Band.objects().run_sync()
+    >>> await Band.objects()
     [<Band: 1>, <Band: 2>]
 
 To get certain rows:
 
 .. code-block:: python
 
-    >>> Band.objects().where(Band.name == 'Pythonistas').run_sync()
+    >>> await Band.objects().where(Band.name == 'Pythonistas')
     [<Band: 1>]
 
 To get a single row (or ``None`` if it doesn't exist):
 
 .. code-block:: python
 
-    >>> Band.objects().get(Band.name == 'Pythonistas').run_sync()
+    >>> await Band.objects().get(Band.name == 'Pythonistas')
     <Band: 1>
 
 To get the first row:
 
 .. code-block:: python
 
-    >>> Band.objects().first().run_sync()
+    >>> await Band.objects().first()
     <Band: 1>
 
 You'll notice that the API is similar to :ref:`Select` - except it returns all
@@ -55,13 +55,13 @@ Creating objects
 .. code-block:: python
 
     >>> band = Band(name="C-Sharps", popularity=100)
-    >>> band.save().run_sync()
+    >>> await band.save()
 
 This can also be done like this:
 
 .. code-block:: python
 
-    >>> band = Band.objects().create(name="C-Sharps", popularity=100).run_sync()
+    >>> band = await Band.objects().create(name="C-Sharps", popularity=100)
 
 -------------------------------------------------------------------------------
 
@@ -72,17 +72,17 @@ Objects have a ``save`` method, which is convenient for updating values:
 
 .. code-block:: python
 
-    band = Band.objects().where(
+    band = await Band.objects().where(
         Band.name == 'Pythonistas'
-    ).first().run_sync()
+    ).first()
 
     band.popularity = 100000
 
     # This saves all values back to the database.
-    band.save().run_sync()
+    await band.save()
 
     # Or specify specific columns to save:
-    band.save([Band.popularity]).run_sync()
+    await band.save([Band.popularity])
 
 -------------------------------------------------------------------------------
 
@@ -93,11 +93,11 @@ Similarly, we can delete objects, using the ``remove`` method.
 
 .. code-block:: python
 
-    band = Band.objects().where(
+    band = await Band.objects().where(
         Band.name == 'Pythonistas'
-    ).first().run_sync()
+    ).first()
 
-    band.remove().run_sync()
+    await band.remove()
 
 -------------------------------------------------------------------------------
 
@@ -112,11 +112,11 @@ to fetch the related row as an object, you can do so using ``get_related``.
 
 .. code-block:: python
 
-    band = Band.objects().where(
+    band = await Band.objects().where(
         Band.name == 'Pythonistas'
-    ).first().run_sync()
+    ).first()
 
-    manager = band.get_related(Band.manager).run_sync()
+    manager = await band.get_related(Band.manager)
     >>> manager
     <Manager: 1>
     >>> manager.name
@@ -131,9 +131,9 @@ refer to the related rows you want to load.
 
 .. code-block:: python
 
-    band = Band.objects(Band.manager).where(
+    band = await Band.objects(Band.manager).where(
         Band.name == 'Pythonistas'
-    ).first().run_sync()
+    ).first()
 
     >>> band.manager
     <Manager: 1>
@@ -145,9 +145,9 @@ prefetch them all you can do so using ``all_related``.
 
 .. code-block:: python
 
-    ticket = Ticket.objects(
+    ticket = await Ticket.objects(
         Ticket.concert.all_related()
-    ).first().run_sync()
+    ).first()
 
     # Any intermediate objects will also be loaded:
     >>> ticket.concert
@@ -172,13 +172,13 @@ can use the ``prefetch`` clause if you prefer.
 .. code-block:: python
 
     # These are equivalent:
-    ticket = Ticket.objects(
+    ticket = await Ticket.objects(
         Ticket.concert.all_related()
-    ).first().run_sync()
+    ).first()
 
-    ticket = Ticket.objects().prefetch(
+    ticket = await Ticket.objects().prefetch(
         Ticket.concert.all_related()
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -190,22 +190,22 @@ or create a new one with the ``defaults`` arguments:
 
 .. code-block:: python
 
-    band = Band.objects().get_or_create(
+    band = await Band.objects().get_or_create(
         Band.name == 'Pythonistas', defaults={Band.popularity: 100}
-    ).run_sync()
+    )
 
     # Or using string column names
-    band = Band.objects().get_or_create(
+    band = await Band.objects().get_or_create(
         Band.name == 'Pythonistas', defaults={'popularity': 100}
-    ).run_sync()
+    )
 
 You can find out if an existing row was found, or if a new row was created:
 
 .. code-block:: python
 
-    band = Band.objects.get_or_create(
+    band = await Band.objects.get_or_create(
         Band.name == 'Pythonistas'
-    ).run_sync()
+    )
     band._was_created  # True if it was created, otherwise False if it was already in the db
 
 Complex where clauses are supported, but only within reason. For example:
@@ -213,16 +213,16 @@ Complex where clauses are supported, but only within reason. For example:
 .. code-block:: python
 
     # This works OK:
-    band = Band.objects().get_or_create(
+    band = await Band.objects().get_or_create(
         (Band.name == 'Pythonistas') & (Band.popularity == 1000),
-    ).run_sync()
+    )
 
     # This is problematic, as it's unclear what the name should be if we
     # need to create the row:
-    band = Band.objects().get_or_create(
+    band = await Band.objects().get_or_create(
         (Band.name == 'Pythonistas') | (Band.name == 'Rustaceans'),
         defaults={'popularity': 100}
-    ).run_sync()
+    )
 
 -------------------------------------------------------------------------------
 
@@ -234,7 +234,7 @@ If you need to convert an object into a dictionary, you can do so using the
 
 .. code-block:: python
 
-    band = Band.objects().first().run_sync()
+    band = await Band.objects().first()
 
     >>> band.to_dict()
     {'id': 1, 'name': 'Pythonistas', 'manager': 1, 'popularity': 1000}
@@ -244,7 +244,7 @@ the columns:
 
 .. code-block:: python
 
-    band = Band.objects().first().run_sync()
+    band = await Band.objects().first()
 
     >>> band.to_dict(Band.id, Band.name.as_alias('title'))
     {'id': 1, 'title': 'Pythonistas'}
@@ -262,27 +262,27 @@ See :ref:`batch`.
 limit
 ~~~~~
 
-See  :ref:`limit`.
+See :ref:`limit`.
 
 offset
 ~~~~~~
 
-See  :ref:`offset`.
+See :ref:`offset`.
 
 first
 ~~~~~
 
-See  :ref:`first`.
+See :ref:`first`.
 
 order_by
 ~~~~~~~~
 
-See  :ref:`order_by`.
+See :ref:`order_by`.
 
 output
 ~~~~~~
 
-See  :ref:`output`.
+See :ref:`output`.
 
 where
 ~~~~~

--- a/docs/src/piccolo/query_types/raw.rst
+++ b/docs/src/piccolo/query_types/raw.rst
@@ -7,16 +7,15 @@ Should you need to, you can execute raw SQL.
 
 .. code-block:: python
 
-    >>> Band.raw('select * from band').run_sync()
-    [{'name': 'Pythonistas', 'manager': 1, 'popularity': 1000, 'id': 1},
-        {'name': 'Rustaceans', 'manager': 2, 'popularity': 500, 'id': 2}]
+    >>> await Band.raw('select name from band').run_sync()
+    [{'name': 'Pythonistas'}]
 
 It's recommended that you parameterise any values. Use curly braces ``{}`` as
 placeholders:
 
 .. code-block:: python
 
-    >>> Band.raw('select * from band where name = {}', 'Pythonistas').run_sync()
+    >>> await Band.raw('select * from band where name = {}', 'Pythonistas')
     [{'name': 'Pythonistas', 'manager': 1, 'popularity': 1000, 'id': 1}]
 
 .. warning:: Be careful to avoid SQL injection attacks. Don't add any user submitted data into your SQL strings, unless it's parameterised.

--- a/docs/src/piccolo/query_types/select.rst
+++ b/docs/src/piccolo/query_types/select.rst
@@ -9,7 +9,7 @@ To get all rows:
 
 .. code-block:: python
 
-    >>> Band.select().run_sync()
+    >>> await Band.select()
     [{'id': 1, 'name': 'Pythonistas', 'manager': 1, 'popularity': 1000},
      {'id': 2, 'name': 'Rustaceans', 'manager': 2, 'popularity': 500}]
 
@@ -17,7 +17,7 @@ To get certain columns:
 
 .. code-block:: python
 
-    >>> Band.select(Band.name).run_sync()
+    >>> await Band.select(Band.name)
     [{'name': 'Rustaceans'}, {'name': 'Pythonistas'}]
 
 Or use an alias to make it shorter:
@@ -25,7 +25,7 @@ Or use an alias to make it shorter:
 .. code-block:: python
 
     >>> b = Band
-    >>> b.select(b.name).run_sync()
+    >>> await b.select(b.name)
     [{'id': 1, 'name': 'Pythonistas', 'manager': 1, 'popularity': 1000},
      {'id': 2, 'name': 'Rustaceans', 'manager': 2, 'popularity': 500}]
 
@@ -40,7 +40,7 @@ By using ``as_alias``, the name of the row can be overriden in the response.
 
 .. code-block:: python
 
-    >>> Band.select(Band.name.as_alias('title')).run_sync()
+    >>> await Band.select(Band.name.as_alias('title'))
     [{'title': 'Rustaceans'}, {'title': 'Pythonistas'}]
 
 This is equivalent to ``SELECT name AS title FROM band`` in SQL.
@@ -54,7 +54,7 @@ One of the most powerful things about ``select`` is it's support for joins.
 
 .. code-block:: python
 
-    >>> Band.select(Band.name, Band.manager.name).run_sync()
+    >>> await Band.select(Band.name, Band.manager.name)
     [
         {'name': 'Pythonistas', 'manager.name': 'Guido'},
         {'name': 'Rustaceans', 'manager.name': 'Graydon'}
@@ -65,7 +65,7 @@ The joins can go several layers deep.
 
 .. code-block:: python
 
-    >>> Concert.select(Concert.id, Concert.band_1.manager.name).run_sync()
+    >>> await Concert.select(Concert.id, Concert.band_1.manager.name)
     [{'id': 1, 'band_1.manager.name': 'Guido'}]
 
 all_columns
@@ -77,7 +77,7 @@ all out:
 
 .. code-block:: python
 
-    >>> Band.select(Band.name, Band.manager.all_columns()).run_sync()
+    >>> await Band.select(Band.name, Band.manager.all_columns())
     [
         {'name': 'Pythonistas', 'manager.id': 1, 'manager.name': 'Guido'},
         {'name': 'Rustaceans', 'manager.id': 2, 'manager.name': 'Graydon'}
@@ -89,17 +89,17 @@ equivalent to the code above:
 
 .. code-block:: python
 
-    >>> Band.select(Band.name, *Band.manager.all_columns()).run_sync()
+    >>> await Band.select(Band.name, *Band.manager.all_columns())
 
 
 You can exclude some columns if you like:
 
 .. code-block:: python
 
-    >>> Band.select(
+    >>> await Band.select(
     >>>     Band.name,
     >>>     Band.manager.all_columns(exclude=[Band.manager.id)
-    >>> ).run_sync()
+    >>> )
     [
         {'name': 'Pythonistas', 'manager.name': 'Guido'},
         {'name': 'Rustaceans', 'manager.name': 'Graydon'}
@@ -110,10 +110,10 @@ Strings are supported too if you prefer:
 
 .. code-block:: python
 
-    >>> Band.select(
+    >>> await Band.select(
     >>>     Band.name,
     >>>     Band.manager.all_columns(exclude=['id'])
-    >>> ).run_sync()
+    >>> )
     [
         {'name': 'Pythonistas', 'manager.name': 'Guido'},
         {'name': 'Rustaceans', 'manager.name': 'Graydon'}
@@ -124,10 +124,10 @@ you have lots of columns. It works identically to related tables:
 
 .. code-block:: python
 
-    >>> Band.select(
+    >>> await Band.select(
     >>>     Band.all_columns(exclude=[Band.id]),
     >>>     Band.manager.all_columns(exclude=[Band.manager.id])
-    >>> ).run_sync()
+    >>> )
     [
         {'name': 'Pythonistas', 'popularity': 1000, 'manager.name': 'Guido'},
         {'name': 'Rustaceans', 'popularity': 500, 'manager.name': 'Graydon'}
@@ -140,7 +140,7 @@ You can also get the response as nested dictionaries, which can be very useful:
 
 .. code-block:: python
 
-    >>> Band.select(Band.name, Band.manager.all_columns()).output(nested=True).run_sync()
+    >>> await Band.select(Band.name, Band.manager.all_columns()).output(nested=True)
     [
         {'name': 'Pythonistas', 'manager': {'id': 1, 'name': 'Guido'}},
         {'name': 'Rustaceans', 'manager': {'id': 2, 'manager.name': 'Graydon'}}
@@ -157,10 +157,10 @@ convenient.
 
 .. code-block:: python
 
-    Band.select('name').run_sync()
+    await Band.select('name')
 
     # For joins:
-    Band.select('manager.name').run_sync()
+    await Band.select('manager.name')
 
 -------------------------------------------------------------------------------
 
@@ -174,7 +174,7 @@ Returns the number of rows which match the query:
 
 .. code-block:: python
 
-    >>> Band.count().where(Band.name == 'Pythonistas').run_sync()
+    >>> await Band.count().where(Band.name == 'Pythonistas')
     1
 
 Avg
@@ -185,7 +185,7 @@ Returns the average for a given column:
 .. code-block:: python
 
     >>> from piccolo.query import Avg
-    >>> response = Band.select(Avg(Band.popularity)).first().run_sync()
+    >>> response = await Band.select(Avg(Band.popularity)).first()
     >>> response["avg"]
     750.0
 
@@ -197,7 +197,7 @@ Returns the sum for a given column:
 .. code-block:: python
 
     >>> from piccolo.query import Sum
-    >>> response = Band.select(Sum(Band.popularity)).first().run_sync()
+    >>> response = await Band.select(Sum(Band.popularity)).first()
     >>> response["sum"]
     1500
 
@@ -209,7 +209,7 @@ Returns the maximum for a given column:
 .. code-block:: python
 
     >>> from piccolo.query import Max
-    >>> response = Band.select(Max(Band.popularity)).first().run_sync()
+    >>> response = await Band.select(Max(Band.popularity)).first()
     >>> response["max"]
     1000
 
@@ -221,19 +221,19 @@ Returns the minimum for a given column:
 .. code-block:: python
 
     >>> from piccolo.query import Min
-    >>> response = Band.select(Min(Band.popularity)).first().run_sync()
+    >>> response = await Band.select(Min(Band.popularity)).first()
     >>> response["min"]
     500
 
 Additional features
 ~~~~~~~~~~~~~~~~~~~
 
-You also can chain multiple different aggregate functions in one query:
+You also can have multiple different aggregate functions in one query:
 
 .. code-block:: python
 
     >>> from piccolo.query import Avg, Sum
-    >>> response = Band.select(Avg(Band.popularity), Sum(Band.popularity)).first().run_sync()
+    >>> response = await Band.select(Avg(Band.popularity), Sum(Band.popularity)).first()
     >>> response
     {"avg": 750.0, "sum": 1500}
 
@@ -241,13 +241,8 @@ And can use aliases for aggregate functions like this:
 
 .. code-block:: python
 
-    >>> from piccolo.query import Avg
-    >>> response = Band.select(Avg(Band.popularity, alias="popularity_avg")).first().run_sync()
-    >>> response["popularity_avg"]
-    750.0
-
     # Alternatively, you can use the `as_alias` method.
-    >>> response = Band.select(Avg(Band.popularity).as_alias("popularity_avg")).first().run_sync()
+    >>> response = await Band.select(Avg(Band.popularity).as_alias("popularity_avg")).first()
     >>> response["popularity_avg"]
     750.0
 
@@ -269,7 +264,7 @@ By default all columns are returned from the queried table.
 .. code-block:: python
 
     # Equivalent to SELECT * from band
-    Band.select().run_sync()
+    await Band.select()
 
 To restrict the returned columns, either pass in the columns into the
 ``select`` method, or use the ``columns`` method.
@@ -277,51 +272,51 @@ To restrict the returned columns, either pass in the columns into the
 .. code-block:: python
 
     # Equivalent to SELECT name from band
-    Band.select(Band.name).run_sync()
+    await Band.select(Band.name)
 
     # Or alternatively:
-    Band.select().columns(Band.name).run_sync()
+    await Band.select().columns(Band.name)
 
 The ``columns`` method is additive, meaning you can chain it to add additional
 columns.
 
 .. code-block:: python
 
-    Band.select().columns(Band.name).columns(Band.manager).run_sync()
+    await Band.select().columns(Band.name).columns(Band.manager)
 
     # Or just define it one go:
-    Band.select().columns(Band.name, Band.manager).run_sync()
+    await Band.select().columns(Band.name, Band.manager)
 
 
 first
 ~~~~~
 
-See  :ref:`first`.
+See :ref:`first`.
 
 group_by
 ~~~~~~~~
 
-See  :ref:`group_by`.
+See :ref:`group_by`.
 
 limit
 ~~~~~
 
-See  :ref:`limit`.
+See :ref:`limit`.
 
 offset
 ~~~~~~
 
-See  :ref:`offset`.
+See :ref:`offset`.
 
 distinct
 ~~~~~~~~
 
-See  :ref:`distinct`.
+See :ref:`distinct`.
 
 order_by
 ~~~~~~~~
 
-See  :ref:`order_by`.
+See :ref:`order_by`.
 
 output
 ~~~~~~
@@ -331,4 +326,4 @@ See :ref:`output`.
 where
 ~~~~~
 
-See  :ref:`where`.
+See :ref:`where`.

--- a/docs/src/piccolo/query_types/update.rst
+++ b/docs/src/piccolo/query_types/update.rst
@@ -7,11 +7,11 @@ This is used to update any rows in the table which match the criteria.
 
 .. code-block:: python
 
-    >>> Band.update({
+    >>> await Band.update({
     >>>     Band.name: 'Pythonistas 2'
     >>> }).where(
     >>>     Band.name == 'Pythonistas'
-    >>> ).run_sync()
+    >>> )
     []
 
 As well as replacing values with new ones, you can also modify existing values, for
@@ -30,29 +30,29 @@ You can add / subtract / multiply / divide values:
 .. code-block:: python
 
     # Add 100 to the popularity of each band:
-    Band.update({
+    await Band.update({
         Band.popularity: Band.popularity + 100
-    }).run_sync()
+    })
 
     # Decrease the popularity of each band by 100.
-    Band.update({
+    await Band.update({
         Band.popularity: Band.popularity - 100
-    }).run_sync()
+    })
 
     # Multiply the popularity of each band by 10.
-    Band.update({
+    await Band.update({
         Band.popularity: Band.popularity * 10
-    }).run_sync()
+    })
 
     # Divide the popularity of each band by 10.
-    Band.update({
+    await Band.update({
         Band.popularity: Band.popularity / 10
-    }).run_sync()
+    })
 
     # You can also use the operators in reverse:
-    Band.update({
+    await Band.update({
         Band.popularity: 2000 - Band.popularity
-    }).run_sync()
+    })
 
 Varchar / Text columns
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -62,19 +62,19 @@ You can concatenate values:
 .. code-block:: python
 
     # Append "!!!" to each band name.
-    Band.update({
+    await Band.update({
         Band.name: Band.name + "!!!"
-    }).run_sync()
+    })
 
     # Concatenate the values in each column:
-    Band.update({
+    await Band.update({
         Band.name: Band.name + Band.name
-    }).run_sync()
+    })
 
     # Prepend "!!!" to each band name.
-    Band.update({
+    await Band.update({
         Band.popularity: "!!!" + Band.popularity
-    }).run_sync()
+    })
 
 
 You can currently only combine two values together at a time.

--- a/docs/src/piccolo/schema/advanced.rst
+++ b/docs/src/piccolo/schema/advanced.rst
@@ -32,7 +32,7 @@ tooling - you can also use it your own queries.
 
 .. code-block:: python
 
-    Band.select(Band.get_readable()).run_sync()
+    await Band.select(Band.get_readable())
 
 Here is an example of a more complex ``Readable``.
 
@@ -111,9 +111,9 @@ We can then use the ``Enum`` in our queries.
 
 .. code-block:: python
 
-    >>> Shirt(size=Shirt.Size.large).save().run_sync()
+    >>> await Shirt(size=Shirt.Size.large).save()
 
-    >>> Shirt.select().run_sync()
+    >>> await Shirt.select()
     [{'id': 1, 'size': 'l'}]
 
 Note how the value stored in the database is the ``Enum`` value (in this case ``'l'``).
@@ -123,12 +123,12 @@ where a query requires a value.
 
 .. code-block:: python
 
-    >>> Shirt.insert(
+    >>> await Shirt.insert(
     >>>     Shirt(size=Shirt.Size.small),
     >>>     Shirt(size=Shirt.Size.medium)
-    >>> ).run_sync()
+    >>> )
 
-    >>> Shirt.select().where(Shirt.size == Shirt.Size.small).run_sync()
+    >>> await Shirt.select().where(Shirt.size == Shirt.Size.small)
     [{'id': 1, 'size': 's'}]
 
 Advantages
@@ -184,7 +184,7 @@ Then you can use them like your normal ``Table`` classes:
 
 .. code-block:: python
 
-    >>> Band.select().run_sync()
+    >>> await Band.select()
     [{'id': 1, 'name': 'Pythonistas', 'manager': 1}, ...]
 
 

--- a/docs/src/piccolo/schema/column_types.rst
+++ b/docs/src/piccolo/schema/column_types.rst
@@ -204,23 +204,23 @@ a subset of the JSON data, and for filtering in a where clause.
     class Booking(Table):
         data = JSONB()
 
-    Booking.create_table().run_sync()
+    await Booking.create_table()
 
     # Example data:
-    Booking.insert(
+    await Booking.insert(
         Booking(data='{"name": "Alison"}'),
         Booking(data='{"name": "Bob"}')
-    ).run_sync()
+    )
 
     # Example queries
-    >>> Booking.select(
+    >>> await Booking.select(
     >>>     Booking.id, Booking.data.arrow('name').as_alias('name')
-    >>> ).run_sync()
+    >>> )
     [{'id': 1, 'name': '"Alison"'}, {'id': 2, 'name': '"Bob"'}]
 
-    >>> Booking.select(Booking.id).where(
+    >>> await Booking.select(Booking.id).where(
     >>>     Booking.data.arrow('name') == '"Alison"'
-    >>> ).run_sync()
+    >>> )
     [{'id': 1}]
 
 -------------------------------------------------------------------------------

--- a/docs/src/piccolo/serialization/index.rst
+++ b/docs/src/piccolo/serialization/index.rst
@@ -40,14 +40,12 @@ We can then create model instances from data we fetch from the database:
 .. code-block:: python
 
     # If using objects:
-    model = BandModel(
-        **Band.objects().get(Band.name == 'Pythonistas').run_sync().to_dict()
-    )
+    band = await Band.objects().get(Band.name == 'Pythonistas')
+    model = BandModel(**band.to_dict())
 
     # If using select:
-    model = BandModel(
-        **Band.select().where(Band.name == 'Pythonistas').first().run_sync()
-    )
+    band = await Band.select().where(Band.name == 'Pythonistas').first()
+    model = BandModel(**band)
 
     >>> model.name
     'Pythonistas'
@@ -103,21 +101,19 @@ To populate a nested Pydantic model with data from the database:
 .. code-block:: python
 
     # If using objects:
-    model = BandModel(
-        **Band.objects(Band.manager).get(Band.name == 'Pythonistas').run_sync().to_dict()
-    )
+    band = await Band.objects(Band.manager).get(Band.name == 'Pythonistas')
+    model = BandModel(**band.to_dict())
 
     # If using select:
-    model = BandModel(
-        **Band.select(
-            Band.all_columns(),
-            Band.manager.all_columns()
-        ).where(
-            Band.name == 'Pythonistas'
-        ).first().output(
-            nested=True
-        ).run_sync()
+    band = await Band.select(
+        Band.all_columns(),
+        Band.manager.all_columns()
+    ).where(
+        Band.name == 'Pythonistas'
+    ).first().output(
+        nested=True
     )
+    model = BandModel(**band)
 
     >>> model.manager.name
     'Guido'

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -385,7 +385,7 @@ class Column(Selectable):
             class MyTable(Table):
                 class_ = Varchar(db_column_name="class")
 
-            >>> MyTable.select(MyTable.class_).run_sync()
+            >>> await MyTable.select(MyTable.class_)
             [{'id': 1, 'class': 'test'}]
 
         This is an advanced feature which you should only need in niche
@@ -402,7 +402,7 @@ class Column(Selectable):
                 name = Varchar()
                 net_worth = Integer(secret=True)
 
-            >>> Property.select(exclude_secrets=True).run_sync()
+            >>> await Band.select(exclude_secrets=True)
             [{'name': 'Pythonistas'}]
 
     """
@@ -598,7 +598,7 @@ class Column(Selectable):
 
         .. code-block:: python
 
-            Band.select().where(Band.name == 'Pythonistas').run_sync()
+            await Band.select().where(Band.name == 'Pythonistas')
 
         But this means that comparisons such as this can give unexpected
         results:

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -173,10 +173,10 @@ class Varchar(Column):
             name = Varchar(length=100)
 
         # Create
-        >>> Band(name='Pythonistas').save().run_sync()
+        >>> await Band(name='Pythonistas').save()
 
         # Query
-        >>> Band.select(Band.name).run_sync()
+        >>> await Band.select(Band.name)
         {'name': 'Pythonistas'}
 
     :param length:
@@ -283,10 +283,10 @@ class Text(Column):
             name = Text()
 
         # Create
-        >>> Band(name='Pythonistas').save().run_sync()
+        >>> await Band(name='Pythonistas').save()
 
         # Query
-        >>> Band.select(Band.name).run_sync()
+        >>> await Band.select(Band.name)
         {'name': 'Pythonistas'}
 
     """
@@ -354,10 +354,10 @@ class UUID(Column):
             uuid = UUID()
 
         # Create
-        >>> DiscountCode(code=uuid.uuid4()).save().run_sync()
+        >>> await DiscountCode(code=uuid.uuid4()).save()
 
         # Query
-        >>> DiscountCode.select(DiscountCode.code).run_sync()
+        >>> await DiscountCode.select(DiscountCode.code)
         {'code': UUID('09c4c17d-af68-4ce7-9955-73dcd892e462')}
 
     """
@@ -416,10 +416,10 @@ class Integer(Column):
             popularity = Integer()
 
         # Create
-        >>> Band(popularity=1000).save().run_sync()
+        >>> await Band(popularity=1000).save()
 
         # Query
-        >>> Band.select(Band.popularity).run_sync()
+        >>> await Band.select(Band.popularity)
         {'popularity': 1000}
 
     """
@@ -540,10 +540,10 @@ class BigInt(Integer):
             value = BigInt()
 
         # Create
-        >>> Band(popularity=1000000).save().run_sync()
+        >>> await Band(popularity=1000000).save()
 
         # Query
-        >>> Band.select(Band.popularity).run_sync()
+        >>> await Band.select(Band.popularity)
         {'popularity': 1000000}
 
     """
@@ -588,10 +588,10 @@ class SmallInt(Integer):
             value = SmallInt()
 
         # Create
-        >>> Band(popularity=1000).save().run_sync()
+        >>> await Band(popularity=1000).save()
 
         # Query
-        >>> Band.select(Band.popularity).run_sync()
+        >>> await Band.select(Band.popularity)
         {'popularity': 1000}
 
     """
@@ -754,12 +754,12 @@ class Timestamp(Column):
             starts = Timestamp()
 
         # Create
-        >>> Concert(
+        >>> await Concert(
         >>>    starts=datetime.datetime(year=2050, month=1, day=1)
-        >>> ).save().run_sync()
+        >>> ).save()
 
         # Query
-        >>> Concert.select(Concert.starts).run_sync()
+        >>> await Concert.select(Concert.starts)
         {'starts': datetime.datetime(2050, 1, 1, 0, 0)}
 
     """
@@ -820,14 +820,14 @@ class Timestamptz(Column):
             starts = Timestamptz()
 
         # Create
-        >>> Concert(
+        >>> await Concert(
         >>>    starts=datetime.datetime(
         >>>        year=2050, month=1, day=1, tzinfo=datetime.timezone.tz
         >>>    )
-        >>> ).save().run_sync()
+        >>> ).save()
 
         # Query
-        >>> Concert.select(Concert.starts).run_sync()
+        >>> await Concert.select(Concert.starts)
         {
             'starts': datetime.datetime(
                 2050, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
@@ -887,12 +887,12 @@ class Date(Column):
             starts = Date()
 
         # Create
-        >>> Concert(
+        >>> await Concert(
         >>>     starts=datetime.date(year=2020, month=1, day=1)
-        >>> ).save().run_sync()
+        >>> ).save()
 
         # Query
-        >>> Concert.select(Concert.starts).run_sync()
+        >>> await Concert.select(Concert.starts)
         {'starts': datetime.date(2020, 1, 1)}
 
     """
@@ -944,12 +944,12 @@ class Time(Column):
             starts = Time()
 
         # Create
-        >>> Concert(
+        >>> await Concert(
         >>>    starts=datetime.time(hour=20, minute=0, second=0)
-        >>> ).save().run_sync()
+        >>> ).save()
 
         # Query
-        >>> Concert.select(Concert.starts).run_sync()
+        >>> await Concert.select(Concert.starts)
         {'starts': datetime.time(20, 0, 0)}
 
     """
@@ -998,12 +998,12 @@ class Interval(Column):  # lgtm [py/missing-equals]
             duration = Interval()
 
         # Create
-        >>> Concert(
+        >>> await Concert(
         >>>    duration=timedelta(hours=2)
-        >>> ).save().run_sync()
+        >>> ).save()
 
         # Query
-        >>> Concert.select(Concert.duration).run_sync()
+        >>> await Concert.select(Concert.duration)
         {'duration': datetime.timedelta(seconds=7200)}
 
     """
@@ -1067,10 +1067,10 @@ class Boolean(Column):
             has_drummer = Boolean()
 
         # Create
-        >>> Band(has_drummer=True).save().run_sync()
+        >>> await Band(has_drummer=True).save()
 
         # Query
-        >>> Band.select(Band.has_drummer).run_sync()
+        >>> await Band.select(Band.has_drummer)
         {'has_drummer': True}
 
     """
@@ -1096,7 +1096,7 @@ class Boolean(Column):
 
             await MyTable.select().where(
                 MyTable.some_boolean_column == True
-            ).run()
+            )
 
         It's more Pythonic to use ``is True`` rather than ``== True``, which is
         why linters complain. The work around is to do the following instead:
@@ -1105,7 +1105,7 @@ class Boolean(Column):
 
             await MyTable.select().where(
                 MyTable.some_boolean_column.__eq__(True)
-            ).run()
+            )
 
         Using the ``__eq__`` magic method is a bit untidy, which is why this
         ``eq`` method exists.
@@ -1114,7 +1114,7 @@ class Boolean(Column):
 
             await MyTable.select().where(
                 MyTable.some_boolean_column.eq(True)
-            ).run()
+            )
 
         The ``ne`` method exists for the same reason, for ``!=``.
 
@@ -1163,10 +1163,10 @@ class Numeric(Column):
             price = Numeric(digits=(5,2))
 
         # Create
-        >>> Ticket(price=Decimal('50.0')).save().run_sync()
+        >>> await Ticket(price=Decimal('50.0')).save()
 
         # Query
-        >>> Ticket.select(Ticket.price).run_sync()
+        >>> await Ticket.select(Ticket.price)
         {'price': Decimal('50.0')}
 
     :param digits:
@@ -1282,10 +1282,10 @@ class Real(Column):
             rating = Real()
 
         # Create
-        >>> Concert(rating=7.8).save().run_sync()
+        >>> await Concert(rating=7.8).save()
 
         # Query
-        >>> Concert.select(Concert.rating).run_sync()
+        >>> await Concert.select(Concert.rating)
         {'rating': 7.8}
 
     """
@@ -1391,14 +1391,14 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
             manager = ForeignKey(references=Manager)
 
         # Create
-        >>> Band(manager=1).save().run_sync()
+        >>> await Band(manager=1).save()
 
         # Query
-        >>> Band.select(Band.manager).run_sync()
+        >>> await Band.select(Band.manager)
         {'manager': 1}
 
         # Query object
-        >>> band = await Band.objects().first().run()
+        >>> band = await Band.objects().first()
         >>> band.manager
         1
 
@@ -1408,14 +1408,14 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
 
     .. code-block:: python
 
-        >>> await Band.select(Band.name, Band.manager.name).first().run()
+        >>> await Band.select(Band.name, Band.manager.name).first()
         {'name': 'Pythonistas', 'manager.name': 'Guido'}
 
     To retrieve all of the columns in the related table:
 
     .. code-block:: python
 
-        >>> await Band.select(Band.name, *Band.manager.all_columns()).first().run()
+        >>> await Band.select(Band.name, *Band.manager.all_columns()).first()
         {'name': 'Pythonistas', 'manager.id': 1, 'manager.name': 'Guido'}
 
     To get a referenced row as an object:
@@ -1424,21 +1424,21 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
 
         manager = await Manager.objects().where(
             Manager.id == some_band.manager
-        ).run()
+        )
 
     Or use either of the following, which are just a proxy to the above:
 
     .. code-block:: python
 
-        manager = await band.get_related('manager').run()
-        manager = await band.get_related(Band.manager).run()
+        manager = await band.get_related('manager')
+        manager = await band.get_related(Band.manager)
 
     To change the manager:
 
     .. code-block:: python
 
         band.manager = some_manager_id
-        await band.save().run()
+        await band.save()
 
     :param references:
         The ``Table`` being referenced.
@@ -1710,25 +1710,25 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
 
         .. code-block:: python
 
-            Band.select(Band.name, Band.manager.all_columns()).run_sync()
+            await Band.select(Band.name, Band.manager.all_columns())
 
             # Equivalent to:
-            Band.select(
+            await Band.select(
                 Band.name,
                 Band.manager.id,
                 Band.manager.name
-            ).run_sync()
+            )
 
         To exclude certain columns:
 
         .. code-block:: python
 
-            Band.select(
+            await Band.select(
                 Band.name,
                 Band.manager.all_columns(
                     exclude=[Band.manager.id]
                 )
-            ).run_sync()
+            )
 
         :param exclude:
             Columns to exclude - can be the name of a column, or a column
@@ -1771,14 +1771,14 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
                 name = Varchar()
                 concert = ForeignKey(Concert)
 
-            Tour.objects(Tour.concert, Tour.concert.all_related()).run_sync()
+            await Tour.objects(Tour.concert, Tour.concert.all_related())
 
             # Equivalent to
-            Tour.objects(
+            await Tour.objects(
                 Tour.concert,
                 Tour.concert.band_1,
                 Tour.concert.band_2
-            ).run_sync()
+            )
 
         :param exclude:
             Columns to exclude - can be the name of a column, or a
@@ -2036,10 +2036,10 @@ class Bytea(Column):
             token = Bytea(default=b'token123')
 
         # Create
-        >>> Token(token=b'my-token').save().run_sync()
+        >>> await Token(token=b'my-token').save()
 
         # Query
-        >>> Token.select(Token.token).run_sync()
+        >>> await Token.select(Token.token)
         {'token': b'my-token'}
 
     """
@@ -2132,10 +2132,10 @@ class Array(Column):
             seat_numbers = Array(base_column=Integer())
 
         # Create
-        >>> Ticket(seat_numbers=[34, 35, 36]).save().run_sync()
+        >>> await Ticket(seat_numbers=[34, 35, 36]).save()
 
         # Query
-        >>> Ticket.select(Ticket.seat_numbers).run_sync()
+        >>> await Ticket.select(Ticket.seat_numbers)
         {'seat_numbers': [34, 35, 36]}
 
     """
@@ -2186,7 +2186,7 @@ class Array(Column):
 
         .. code-block:: python
 
-            >>> Ticket.select(Ticket.seat_numbers[0]).first().run_sync
+            >>> await Ticket.select(Ticket.seat_numbers[0]).first()
             {'seat_numbers': 325}
 
 
@@ -2226,7 +2226,7 @@ class Array(Column):
 
         .. code-block:: python
 
-            >>> Ticket.select().where(Ticket.seat_numbers.any(510)).run_sync()
+            >>> await Ticket.select().where(Ticket.seat_numbers.any(510))
 
         """
         engine_type = self._meta.table._meta.db.engine_type
@@ -2244,7 +2244,7 @@ class Array(Column):
 
         .. code-block:: python
 
-            >>> Ticket.select().where(Ticket.seat_numbers.all(510)).run_sync()
+            >>> await Ticket.select().where(Ticket.seat_numbers.all(510))
 
         """
         engine_type = self._meta.table._meta.db.engine_type

--- a/piccolo/columns/combination.py
+++ b/piccolo/columns/combination.py
@@ -138,18 +138,18 @@ class Where(CombinableMixin):
 
         .. code-block:: python
 
-            manager = Manager.objects.where(
+            manager = await Manager.objects.where(
                 Manager.name == 'Guido'
-            ).first().run_sync()
+            ).first()
 
             # The where clause should be:
-            Band.select().where(Band.manager.id == guido.id).run_sync()
+            await Band.select().where(Band.manager.id == guido.id)
             # Or
-            Band.select().where(Band.manager == guido.id).run_sync()
+            await Band.select().where(Band.manager == guido.id)
 
             # If the object is passed in, i.e. `guido` instead of `guido.id`,
             # it should still work.
-            Band.select().where(Band.manager == guido).run_sync()
+            await Band.select().where(Band.manager == guido)
 
         Also, convert Enums to their underlying values, and serialise any JSON.
 

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -187,10 +187,11 @@ class AppConfig:
 @dataclass
 class AppRegistry:
     """
-    Records all of the Piccolo apps in your project. Kept in piccolo_conf.py.
+    Records all of the Piccolo apps in your project. Kept in
+    ``piccolo_conf.py``.
 
     :param apps:
-        A list of paths to Piccolo apps, e.g. ['blog.piccolo_app']
+        A list of paths to Piccolo apps, e.g. ``['blog.piccolo_app']``.
 
     """
 

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -264,7 +264,7 @@ class Query:
             # In the corresponding view/endpoint of whichever web framework
             # you're using:
             async def top_bands(self, request):
-                return await TOP_BANDS.run()
+                return await TOP_BANDS
 
         It means that Piccolo doesn't have to work as hard each time the query
         is run to generate the corresponding SQL - some of it is cached. If the

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -79,18 +79,18 @@ class Count(Selectable):
 
     .. code-block:: python
 
-        Band.select(Band.name, Count()).group_by(Band.name).run()
+        await Band.select(Band.name, Count()).group_by(Band.name)
 
         # We can use an alias. These two are equivalent:
 
-        Band.select(
+        await Band.select(
             Band.name, Count(alias="total")
-        ).group_by(Band.name).run()
+        ).group_by(Band.name)
 
-        Band.select(
+        await Band.select(
             Band.name,
             Count().as_alias("total")
-        ).group_by(Band.name).run()
+        ).group_by(Band.name)
 
     """
 

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -333,9 +333,9 @@ class Table(metaclass=TableMetaclass):
 
             .. code-block:: python
 
-                band = Band.objects().first().run_sync()
+                band = await Band.objects().first()
                 band.popularity = 2000
-                band.save(columns=[Band.popularity]).run_sync()
+                await band.save(columns=[Band.popularity])
 
             If ``columns=None`` (the default) then all columns will be synced
             back to the database.

--- a/piccolo/utils/dictionary.py
+++ b/piccolo/utils/dictionary.py
@@ -12,7 +12,7 @@ def make_nested(dictionary: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
 
     .. code-block:: python
 
-        response = Band.select(Band.name, Band.manager.name).run_sync()
+        response = await Band.select(Band.name, Band.manager.name)
         >>> print(response)
         [{'name': 'Pythonistas', 'band.name': 'Guido'}]
 


### PR DESCRIPTION
Most of the examples in the docs use the sync version:

```python
Band.select().run_sync()
```

The reason for this was so people could copy and paste any query from the docs into the playground, and it would work.

However, the playground has supported top level await for a while. You can paste this in and it will work:

```python
await Band.select()
```

Also, Piccolo was designed to be async first, and is generally used within async web frameworks.

Long story short ... this PR changes the docs so examples use `async` by default instead of `run_sync`.
