### PR TITLE
add `force` argument to `Update` queries

### DIFF
--- a/docs/src/piccolo/query_types/update.rst
+++ b/docs/src/piccolo/query_types/update.rst
@@ -14,13 +14,30 @@ This is used to update any rows in the table which match the criteria.
     >>> )
     []
 
-As well as replacing values with new ones, you can also modify existing values, for
-instance by adding to an integer.
+-------------------------------------------------------------------------------
+
+force
+-----
+
+Piccolo won't let you run an update query without a where clause, unless you
+explicitly tell it to do so. This is to prevent accidentally overwriting
+the data in a table.
+
+.. code-block:: python
+
+    >>> await Band.update()
+    Raises: UpdateError
+
+    # Works fine:
+    >>> await Band.update({Band.popularity: 0}, force=True)
 
 -------------------------------------------------------------------------------
 
 Modifying values
 ----------------
+
+As well as replacing values with new ones, you can also modify existing values, for
+instance by adding to an integer.
 
 Integer columns
 ~~~~~~~~~~~~~~~
@@ -78,6 +95,22 @@ You can concatenate values:
 
 
 You can currently only combine two values together at a time.
+
+-------------------------------------------------------------------------------
+
+Kwarg values
+------------
+
+Rather than passing in a dictionary of values, you can use kwargs instead if
+you prefer:
+
+.. code-block:: python
+
+    >>> await Band.update(
+    >>>     name='Pythonistas 2'
+    >>> ).where(
+    >>>     Band.name == 'Pythonistas'
+    >>> )
 
 -------------------------------------------------------------------------------
 

--- a/piccolo/query/methods/delete.py
+++ b/piccolo/query/methods/delete.py
@@ -37,7 +37,8 @@ class Delete(Query):
             classname = self.table.__name__
             raise DeletionError(
                 "Do you really want to delete all the data from "
-                f"{classname}? If so, use {classname}.delete(force=True)."
+                f"{classname}? If so, use {classname}.delete(force=True). "
+                "Otherwise, add a where clause."
             )
 
     @property

--- a/piccolo/query/methods/update.py
+++ b/piccolo/query/methods/update.py
@@ -12,12 +12,17 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from piccolo.table import Table
 
 
+class UpdateError(Exception):
+    pass
+
+
 class Update(Query):
 
-    __slots__ = ("values_delegate", "where_delegate")
+    __slots__ = ("force", "values_delegate", "where_delegate")
 
-    def __init__(self, table: t.Type[Table], **kwargs):
+    def __init__(self, table: t.Type[Table], force: bool = False, **kwargs):
         super().__init__(table, **kwargs)
+        self.force = force
         self.values_delegate = ValuesDelegate(table=table)
         self.where_delegate = WhereDelegate()
 
@@ -32,22 +37,26 @@ class Update(Query):
         self.where_delegate.where(*where)
         return self
 
-    def validate(self):
+    def _validate(self):
         if len(self.values_delegate._values) == 0:
-            raise ValueError(
-                "No values were specified to update - please use .values"
-            )
+            raise ValueError("No values were specified to update.")
 
         for column, _ in self.values_delegate._values.items():
             if len(column._meta.call_chain) > 0:
                 raise ValueError(
-                    "Related values can't be updated via an update"
+                    "Related values can't be updated via an update."
                 )
+
+        if (not self.where_delegate._where) and (not self.force):
+            classname = self.table.__name__
+            raise UpdateError(
+                "Do you really want to update all rows in "
+                f"{classname}? If so, use pass `force=True` into "
+                f"`{classname}.update`. Otherwise, add a where clause."
+            )
 
     @property
     def default_querystrings(self) -> t.Sequence[QueryString]:
-        self.validate()
-
         columns_str = ", ".join(
             f'"{col._meta.db_column_name}" = {{}}'
             for col, _ in self.values_delegate._values.items()

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -955,7 +955,10 @@ class Table(metaclass=TableMetaclass):
 
     @classmethod
     def update(
-        cls, values: t.Dict[t.Union[Column, str], t.Any] = {}, **kwargs
+        cls,
+        values: t.Dict[t.Union[Column, str], t.Any] = {},
+        force: bool = False,
+        **kwargs,
     ) -> Update:
         """
         Update rows.
@@ -982,9 +985,13 @@ class Table(metaclass=TableMetaclass):
                 Band.name=="Pythonistas"
             ).run()
 
+        :param force:
+            Unless set to ``True``, updates aren't allowed without a
+            ``where`` clause, to prevent accidental mass overriding of data.
+
         """
         values = dict(values, **kwargs)
-        return Update(table=cls).values(values)
+        return Update(table=cls, force=force).values(values)
 
     @classmethod
     def indexes(cls) -> Indexes:

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -4,6 +4,6 @@ ipython==7.31.1
 flake8==4.0.1
 isort==5.10.1
 twine==3.7.1
-mypy==0.930
+mypy==0.931
 pip-upgrader==1.4.15
 wheel==0.37.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,4 +1,4 @@
-black>=21.7b0
+black==22.1.0
 ipdb==0.13.9
 ipython==7.31.1
 flake8==4.0.1

--- a/tests/columns/test_bigint.py
+++ b/tests/columns/test_bigint.py
@@ -25,7 +25,7 @@ class TestBigIntPostgres(TestCase):
 
     def _test_length(self):
         # Can store 8 bytes, but split between positive and negative values.
-        max_value = int(2 ** 64 / 2) - 1
+        max_value = int(2**64 / 2) - 1
         min_value = max_value * -1
 
         print("Testing max value")

--- a/tests/columns/test_db_column_name.py
+++ b/tests/columns/test_db_column_name.py
@@ -114,7 +114,7 @@ class TestDBColumnName(DBTestCase):
         """
         Band.objects().create(name="Pythonistas", popularity=1000).run_sync()
 
-        Band.update({Band.name: "Pythonistas 2"}).run_sync()
+        Band.update({Band.name: "Pythonistas 2"}, force=True).run_sync()
 
         bands = Band.select().run_sync()
         self.assertEqual(
@@ -128,7 +128,7 @@ class TestDBColumnName(DBTestCase):
             ],
         )
 
-        Band.update({"name": "Pythonistas 3"}).run_sync()
+        Band.update({"name": "Pythonistas 3"}, force=True).run_sync()
 
         bands = Band.select().run_sync()
         self.assertEqual(

--- a/tests/columns/test_json.py
+++ b/tests/columns/test_json.py
@@ -138,7 +138,9 @@ class TestJSONUpdate(TestCase):
         Test updating a JSON field using a string.
         """
         self.add_row()
-        MyTable.update({MyTable.json: '{"message": "updated"}'}).run_sync()
+        MyTable.update(
+            {MyTable.json: '{"message": "updated"}'}, force=True
+        ).run_sync()
         self.check_response()
 
     def test_json_update_object(self):
@@ -146,5 +148,7 @@ class TestJSONUpdate(TestCase):
         Test updating a JSON field using an object.
         """
         self.add_row()
-        MyTable.update({MyTable.json: {"message": "updated"}}).run_sync()
+        MyTable.update(
+            {MyTable.json: {"message": "updated"}}, force=True
+        ).run_sync()
         self.check_response()

--- a/tests/columns/test_reserved_column_names.py
+++ b/tests/columns/test_reserved_column_names.py
@@ -46,7 +46,7 @@ class TestReservedColumnNames(TestCase):
         )
 
         # Update
-        Concert.update({Concert.order: 3}).run_sync()
+        Concert.update({Concert.order: 3}, force=True).run_sync()
         self.assertEqual(
             Concert.select(Concert.order).run_sync(),
             [{"order": 3}],

--- a/tests/columns/test_smallint.py
+++ b/tests/columns/test_smallint.py
@@ -25,7 +25,7 @@ class TestSmallIntPostgres(TestCase):
 
     def _test_length(self):
         # Can store 2 bytes, but split between positive and negative values.
-        max_value = int(2 ** 16 / 2) - 1
+        max_value = int(2**16 / 2) - 1
         min_value = max_value * -1
 
         print("Testing max value")

--- a/tests/table/test_update.py
+++ b/tests/table/test_update.py
@@ -93,7 +93,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_add(self):
         self.insert_row()
 
-        Band.update({Band.popularity: Band.popularity + 10}).run_sync()
+        Band.update(
+            {Band.popularity: Band.popularity + 10}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -103,7 +105,7 @@ class TestIntUpdateOperators(DBTestCase):
         self.insert_row()
 
         Band.update(
-            {Band.popularity: Band.popularity + Band.popularity}
+            {Band.popularity: Band.popularity + Band.popularity}, force=True
         ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
@@ -113,7 +115,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_radd(self):
         self.insert_row()
 
-        Band.update({Band.popularity: 10 + Band.popularity}).run_sync()
+        Band.update(
+            {Band.popularity: 10 + Band.popularity}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -122,7 +126,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_sub(self):
         self.insert_row()
 
-        Band.update({Band.popularity: Band.popularity - 10}).run_sync()
+        Band.update(
+            {Band.popularity: Band.popularity - 10}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -131,7 +137,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_rsub(self):
         self.insert_row()
 
-        Band.update({Band.popularity: 1100 - Band.popularity}).run_sync()
+        Band.update(
+            {Band.popularity: 1100 - Band.popularity}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -140,7 +148,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_mul(self):
         self.insert_row()
 
-        Band.update({Band.popularity: Band.popularity * 2}).run_sync()
+        Band.update(
+            {Band.popularity: Band.popularity * 2}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -149,7 +159,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_rmul(self):
         self.insert_row()
 
-        Band.update({Band.popularity: 2 * Band.popularity}).run_sync()
+        Band.update(
+            {Band.popularity: 2 * Band.popularity}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -158,7 +170,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_div(self):
         self.insert_row()
 
-        Band.update({Band.popularity: Band.popularity / 10}).run_sync()
+        Band.update(
+            {Band.popularity: Band.popularity / 10}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -167,7 +181,9 @@ class TestIntUpdateOperators(DBTestCase):
     def test_rdiv(self):
         self.insert_row()
 
-        Band.update({Band.popularity: 1000 / Band.popularity}).run_sync()
+        Band.update(
+            {Band.popularity: 1000 / Band.popularity}, force=True
+        ).run_sync()
 
         response = Band.select(Band.popularity).first().run_sync()
 
@@ -178,7 +194,7 @@ class TestVarcharUpdateOperators(DBTestCase):
     def test_add(self):
         self.insert_row()
 
-        Band.update({Band.name: Band.name + "!!!"}).run_sync()
+        Band.update({Band.name: Band.name + "!!!"}, force=True).run_sync()
 
         response = Band.select(Band.name).first().run_sync()
 
@@ -187,7 +203,7 @@ class TestVarcharUpdateOperators(DBTestCase):
     def test_add_column(self):
         self.insert_row()
 
-        Band.update({Band.name: Band.name + Band.name}).run_sync()
+        Band.update({Band.name: Band.name + Band.name}, force=True).run_sync()
 
         response = Band.select(Band.name).first().run_sync()
 
@@ -196,7 +212,7 @@ class TestVarcharUpdateOperators(DBTestCase):
     def test_radd(self):
         self.insert_row()
 
-        Band.update({Band.name: "!!!" + Band.name}).run_sync()
+        Band.update({Band.name: "!!!" + Band.name}, force=True).run_sync()
 
         response = Band.select(Band.name).first().run_sync()
 
@@ -209,7 +225,9 @@ class TestTextUpdateOperators(DBTestCase):
         Poster(content="Join us for this amazing show").save().run_sync()
 
     def test_add(self):
-        Poster.update({Poster.content: Poster.content + "!!!"}).run_sync()
+        Poster.update(
+            {Poster.content: Poster.content + "!!!"}, force=True
+        ).run_sync()
 
         response = Poster.select(Poster.content).first().run_sync()
 
@@ -221,7 +239,7 @@ class TestTextUpdateOperators(DBTestCase):
         self.insert_row()
 
         Poster.update(
-            {Poster.content: Poster.content + Poster.content}
+            {Poster.content: Poster.content + Poster.content}, force=True
         ).run_sync()
 
         response = Poster.select(Poster.content).first().run_sync()
@@ -234,7 +252,9 @@ class TestTextUpdateOperators(DBTestCase):
     def test_radd(self):
         self.insert_row()
 
-        Poster.update({Poster.content: "!!!" + Poster.content}).run_sync()
+        Poster.update(
+            {Poster.content: "!!!" + Poster.content}, force=True
+        ).run_sync()
 
         response = Poster.select(Poster.content).first().run_sync()
 


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/411

As observed in this discussion https://github.com/piccolo-orm/piccolo/discussions/409, an accidental mass update can be almost as disruptive as a mass deletion.

```python
# This would be bad if done by accident, as every band would have its name updated to 'Mega Band':
await Band.update({Band.name: 'Mega Band'})
```

This PR makes it so an update query requires a where clause, or specifying `force=True`.

```python
>>> await Band.update({Band.name: 'Mega Band'})
UpdateError!

# Works OK, because it has a where clause:
>>> await Band.update({Band.name: 'Mega Band'}).where(Band.name == 'Good Band')

 # You can still update every row, but you must specify `force=True`
>>> await Band.update({Band.name: 'Mega Band'}, force=True)
```

This is a somewhat breaking change, which we try to avoid. However, the impact is likely to be small, as I imagine most users only use update with a where clause. On balance I think it's definitely worthwhile.
