### PR TITLE
fix `JSONB` column where null

### DIFF
--- a/docs/src/piccolo/engines/index.rst
+++ b/docs/src/piccolo/engines/index.rst
@@ -75,7 +75,7 @@ In your terminal:
 
     export PICCOLO_CONF=piccolo_conf_test
 
-Or at the entypoint of your app, before any other imports:
+Or at the entrypoint of your app, before any other imports:
 
 .. code-block:: python
 

--- a/docs/src/piccolo/getting_started/example_schema.rst
+++ b/docs/src/piccolo/getting_started/example_schema.rst
@@ -3,7 +3,10 @@
 Example Schema
 ==============
 
-This is the schema used by the example queries throughout the docs.
+This is the schema used by the example queries throughout the docs, and also
+in the :ref:`playground<Playground>`.
+
+``Manager`` and ``Band`` are most commonly used:
 
 .. code-block:: python
 
@@ -19,5 +22,31 @@ This is the schema used by the example queries throughout the docs.
         name = Varchar(length=100)
         manager = ForeignKey(references=Manager)
         popularity = Integer()
+
+We sometimes use these other tables in the examples too:
+
+.. code-block:: python
+
+    class Venue(Table):
+        name = Varchar()
+        capacity = Integer()
+
+
+    class Concert(Table):
+        band_1 = ForeignKey(references=Band)
+        band_2 = ForeignKey(references=Band)
+        venue = ForeignKey(references=Venue)
+        starts = Timestamp()
+        duration = Interval()
+
+
+    class Ticket(Table):
+        concert = ForeignKey(references=Concert)
+        price = Numeric()
+
+
+    class RecordingStudio(Table):
+        name = Varchar()
+        facilities = JSONB()
 
 To understand more about defining your own schemas, see :ref:`DefiningSchema`.

--- a/docs/src/piccolo/query_clauses/output.rst
+++ b/docs/src/piccolo/query_clauses/output.rst
@@ -54,6 +54,8 @@ Output any data from related tables in nested dictionaries.
 Select and Objects queries
 --------------------------
 
+.. _load_json:
+
 load_json
 ~~~~~~~~~
 

--- a/docs/src/piccolo/query_types/django_comparison.rst
+++ b/docs/src/piccolo/query_types/django_comparison.rst
@@ -173,7 +173,7 @@ Piccolo has something similar:
 .. code-block:: python
 
     # Piccolo
-    band = Band.objects(Band.manager).get(name='Pythonistas')
+    band = Band.objects(Band.manager).get(Band.name == 'Pythonistas').run_sync()
     >>> band.manager
     <Manager: 1>
 

--- a/docs/src/piccolo/schema/column_types.rst
+++ b/docs/src/piccolo/schema/column_types.rst
@@ -192,36 +192,116 @@ JSONB
 
 .. autoclass:: JSONB
 
+Serialising
+===========
+
+Piccolo automatically converts Python values into JSON strings:
+
+.. code-block:: python
+
+    studio = RecordingStudio(
+        name="Abbey Road",
+        facilities={"restaurant": True, "mixing_desk": True}  # Automatically serialised
+    )
+    await studio.save()
+
+You can also pass in a JSON string if you prefer:
+
+.. code-block:: python
+
+    studio = RecordingStudio(
+        name="Abbey Road",
+        facilities='{"restaurant": true, "mixing_desk": true}'
+    )
+    await studio.save()
+
+Deserialising
+=============
+
+The contents of a ``JSON`` / ``JSONB`` column are returned as a string by
+default:
+
+.. code-block:: python
+
+    >>> await RecordingStudio.select(RecordingStudio.facilities)
+    [{facilities: '{"restaurant": true, "mixing_desk": true}'}]
+
+However, we can ask Piccolo to deserialise the JSON automatically (see :ref:`load_json`):
+
+.. code-block:: python
+
+    >>> await RecordingStudio.select(
+    >>>     RecordingStudio.facilities
+    >>> ).output(
+    >>>     load_json=True
+    >>> )
+    [facilities: {"restaurant": True, "mixing_desk": True}}]
+
+With ``objects`` queries, we can modify the returned JSON, and then save it:
+
+.. code-block:: python
+
+    studio = await RecordingStudio.objects().get(
+        RecordingStudio.name == 'Abbey Road'
+    ).output(load_json=True)
+
+    studio['facilities']['restaurant'] = False
+    await studio.save()
+
 arrow
 =====
 
 ``JSONB`` columns have an ``arrow`` function, which is useful for retrieving
-a subset of the JSON data, and for filtering in a where clause.
+a subset of the JSON data:
 
 .. code-block:: python
 
-    # Example schema:
-    class Booking(Table):
-        data = JSONB()
+    >>> await RecordingStudio.select(
+    >>>     RecordingStudio.name,
+    >>>     RecordingStudio.facilities.arrow('mixing_desk').as_alias('mixing_desk')
+    >>> ).output(load_json=True)
+    [{'name': 'Abbey Road', 'mixing_desk': True}]
 
-    await Booking.create_table()
+It can also be used for filtering in a where clause:
 
-    # Example data:
-    await Booking.insert(
-        Booking(data='{"name": "Alison"}'),
-        Booking(data='{"name": "Bob"}')
-    )
+.. code-block:: python
 
-    # Example queries
-    >>> await Booking.select(
-    >>>     Booking.id, Booking.data.arrow('name').as_alias('name')
+    >>> await RecordingStudio.select(RecordingStudio.name).where(
+    >>>     RecordingStudio.facilities.arrow('mixing_desk') == True
     >>> )
-    [{'id': 1, 'name': '"Alison"'}, {'id': 2, 'name': '"Bob"'}]
+    [{'name': 'Abbey Road'}]
 
-    >>> await Booking.select(Booking.id).where(
-    >>>     Booking.data.arrow('name') == '"Alison"'
+Handling null
+=============
+
+When assigning a value of ``None`` to a ``JSON`` or ``JSONB`` column, this is
+treated as null in the database.
+
+.. code-block:: python
+
+    await RecordingStudio(name="ABC Studios", facilities=None).save()
+
+    >>> await RecordingStudio.select(
+    >>>     RecordingStudio.facilities
+    >>> ).where(
+    >>>     RecordingStudio.name == "ABC Studios"
     >>> )
-    [{'id': 1}]
+    [{'facilities': None}]
+
+
+If instead you want to store JSON null in the database, assign a value of ``'null'``
+instead.
+
+.. code-block:: python
+
+    await RecordingStudio(name="ABC Studios", facilities='null').save()
+
+    >>> await RecordingStudio.select(
+    >>>     RecordingStudio.facilities
+    >>> ).where(
+    >>>     RecordingStudio.name == "ABC Studios"
+    >>> )
+    [{'facilities': 'null'}]
 
 -------------------------------------------------------------------------------
 

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -58,7 +58,7 @@ class DiscountCode(Table):
 
 class RecordingStudio(Table):
     name = Varchar(length=100)
-    facilities = JSON()
+    facilities = JSON(null=True)
 
 
 TABLES = (Manager, Band, Venue, Concert, Ticket, DiscountCode, RecordingStudio)

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -668,14 +668,14 @@ class Column(Selectable):
     def is_null(self) -> Where:
         """
         Can be used instead of ``MyTable.column != None``, because some linters
-        don't like a comparison to None.
+        don't like a comparison to ``None``.
         """
         return Where(column=self, operator=IsNull)
 
     def is_not_null(self) -> Where:
         """
         Can be used instead of ``MyTable.column == None``, because some linters
-        don't like a comparison to None.
+        don't like a comparison to ``None``.
         """
         return Where(column=self, operator=IsNotNull)
 

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -1996,12 +1996,27 @@ class JSONB(JSON):
             just_alias=just_alias, include_quotes=True
         )
         if self.json_operator is None:
-            return select_string
+            if self.alias is None:
+                return select_string
+            else:
+                return f"{select_string} AS {self.alias}"
         else:
             if self.alias is None:
                 return f"{select_string} {self.json_operator}"
             else:
                 return f"{select_string} {self.json_operator} AS {self.alias}"
+
+    def eq(self, value) -> Where:
+        """
+        See ``Boolean.eq`` for more details.
+        """
+        return self.__eq__(value)
+
+    def ne(self, value) -> Where:
+        """
+        See ``Boolean.ne`` for more details.
+        """
+        return self.__ne__(value)
 
     ###########################################################################
     # Descriptors

--- a/piccolo/columns/combination.py
+++ b/piccolo/columns/combination.py
@@ -122,7 +122,11 @@ class Where(CombinableMixin):
         omitted, vs None, which is a valid value for a where clause.
         """
         self.column = column
-        self.value = self.clean_value(value)
+
+        if value == UNDEFINED:
+            self.value = value
+        else:
+            self.value = self.clean_value(value)
 
         if values == UNDEFINED:
             self.values = values
@@ -133,7 +137,7 @@ class Where(CombinableMixin):
 
     def clean_value(self, value: t.Any) -> t.Any:
         """
-        If a where clause contains a Table instance, we should convert that
+        If a where clause contains a ``Table`` instance, we should convert that
         to a column reference. For example:
 
         .. code-block:: python

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -80,6 +80,11 @@ class Query:
             for column in json_columns:
                 if column.alias is not None:
                     json_column_names.append(column.alias)
+                elif column.json_operator is not None:
+                    # If no alias is specified, then the default column name
+                    # that Postgres gives when using the `->` operator is
+                    # `?column?`.
+                    json_column_names.append("?column?")
                 elif len(column._meta.call_chain) > 0:
                     json_column_names.append(
                         column.get_select_string(

--- a/piccolo/utils/sql_values.py
+++ b/piccolo/utils/sql_values.py
@@ -34,6 +34,9 @@ def convert_to_sql_value(value: t.Any, column: Column) -> t.Any:
     elif isinstance(value, Enum):
         return value.value
     elif isinstance(column, (JSON, JSONB)) and not isinstance(value, str):
-        return dump_json(value)
+        if value is None and column._meta.null:
+            return None
+        else:
+            return dump_json(value)
     else:
         return value

--- a/piccolo/utils/sql_values.py
+++ b/piccolo/utils/sql_values.py
@@ -34,7 +34,7 @@ def convert_to_sql_value(value: t.Any, column: Column) -> t.Any:
     elif isinstance(value, Enum):
         return value.value
     elif isinstance(column, (JSON, JSONB)) and not isinstance(value, str):
-        if value is None and column._meta.null:
+        if value is None:
             return None
         else:
             return dump_json(value)

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,9 +1,9 @@
-black>=21.7b0
+black==22.1.0
 ipdb==0.13.9
-ipython==7.31.1
+ipython==8.0.1
 flake8==4.0.1
 isort==5.10.1
 twine==3.7.1
-mypy==0.930
+mypy==0.931
 pip-upgrader==1.4.15
 wheel==0.37.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,6 +1,6 @@
 black==22.1.0
 ipdb==0.13.9
-ipython==8.0.1
+ipython>=7.31.1
 flake8==4.0.1
 isort==5.10.1
 twine==3.7.1

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==4.3.1
+Sphinx==4.4.0
 sphinx-rtd-theme==1.0.0
 livereload==2.6.3

--- a/tests/columns/test_bigint.py
+++ b/tests/columns/test_bigint.py
@@ -25,7 +25,7 @@ class TestBigIntPostgres(TestCase):
 
     def _test_length(self):
         # Can store 8 bytes, but split between positive and negative values.
-        max_value = int(2 ** 64 / 2) - 1
+        max_value = int(2**64 / 2) - 1
         min_value = max_value * -1
 
         print("Testing max value")

--- a/tests/columns/test_jsonb.py
+++ b/tests/columns/test_jsonb.py
@@ -2,45 +2,87 @@ from unittest import TestCase
 
 from piccolo.columns.column_types import JSONB
 from piccolo.table import Table
+from tests.base import postgres_only
 
-from ..base import postgres_only
 
-
-class MyTable(Table):
-    json = JSONB()
+class RecordingStudio(Table):
+    facilities = JSONB(null=True)
 
 
 @postgres_only
 class TestJSONB(TestCase):
     def setUp(self):
-        MyTable.create_table().run_sync()
+        RecordingStudio.create_table().run_sync()
 
     def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+        RecordingStudio.alter().drop_table().run_sync()
 
     def test_json(self):
         """
         Test storing a valid JSON string.
         """
-        row = MyTable(json='{"a": 1}')
+        row = RecordingStudio(facilities='{"a": 1}')
         row.save().run_sync()
-        self.assertEqual(row.json, '{"a": 1}')
+        self.assertEqual(row.facilities, '{"a": 1}')
+
+    def test_where(self):
+        """
+        Test using the where clause to match a subset of rows.
+        """
+        RecordingStudio.insert(
+            RecordingStudio(facilities={"mixing_desk": True}),
+            RecordingStudio(facilities=None),
+        ).run_sync()
+
+        self.assertEqual(
+            RecordingStudio.count()
+            .where(RecordingStudio.facilities == {"mixing_desk": True})
+            .run_sync(),
+            1,
+        )
+
+        self.assertEqual(
+            RecordingStudio.count()
+            .where(RecordingStudio.facilities == '{"mixing_desk": true}')
+            .run_sync(),
+            1,
+        )
+
+        self.assertEqual(
+            RecordingStudio.count()
+            .where(RecordingStudio.facilities.is_null())
+            .run_sync(),
+            1,
+        )
+
+        self.assertEqual(
+            RecordingStudio.count()
+            .where(RecordingStudio.facilities.is_not_null())
+            .run_sync(),
+            1,
+        )
 
     def test_arrow(self):
         """
         Test using the arrow function to retrieve a subset of the JSON.
         """
-        MyTable(json='{"a": 1}').save().run_sync()
-        row = MyTable.select(MyTable.json.arrow("a")).first().run_sync()
+        RecordingStudio(facilities='{"a": 1}').save().run_sync()
+        row = (
+            RecordingStudio.select(RecordingStudio.facilities.arrow("a"))
+            .first()
+            .run_sync()
+        )
         self.assertEqual(row["?column?"], "1")
 
     def test_arrow_as_alias(self):
         """
         Test using the arrow function to retrieve a subset of the JSON.
         """
-        MyTable(json='{"a": 1}').save().run_sync()
+        RecordingStudio(facilities='{"a": 1}').save().run_sync()
         row = (
-            MyTable.select(MyTable.json.arrow("a").as_alias("a"))
+            RecordingStudio.select(
+                RecordingStudio.facilities.arrow("a").as_alias("a")
+            )
             .first()
             .run_sync()
         )
@@ -50,27 +92,35 @@ class TestJSONB(TestCase):
         """
         Make sure the arrow function can be used within a WHERE clause.
         """
-        MyTable(json='{"a": 1}').save().run_sync()
+        RecordingStudio(facilities='{"a": 1}').save().run_sync()
         self.assertEqual(
-            MyTable.count().where(MyTable.json.arrow("a") == "1").run_sync(), 1
+            RecordingStudio.count()
+            .where(RecordingStudio.facilities.arrow("a") == "1")
+            .run_sync(),
+            1,
         )
 
         self.assertEqual(
-            MyTable.count().where(MyTable.json.arrow("a") == "2").run_sync(), 0
+            RecordingStudio.count()
+            .where(RecordingStudio.facilities.arrow("a") == "2")
+            .run_sync(),
+            0,
         )
 
     def test_arrow_first(self):
         """
         Make sure the arrow function can be used with the first clause.
         """
-        MyTable.insert(
-            MyTable(json='{"a": 1}'),
-            MyTable(json='{"b": 2}'),
+        RecordingStudio.insert(
+            RecordingStudio(facilities='{"a": 1}'),
+            RecordingStudio(facilities='{"b": 2}'),
         ).run_sync()
 
         self.assertEqual(
-            MyTable.select(MyTable.json.arrow("a").as_alias("json"))
+            RecordingStudio.select(
+                RecordingStudio.facilities.arrow("a").as_alias("facilities")
+            )
             .first()
             .run_sync(),
-            {"json": "1"},
+            {"facilities": "1"},
         )

--- a/tests/columns/test_jsonb.py
+++ b/tests/columns/test_jsonb.py
@@ -28,6 +28,27 @@ class TestJSONB(TestCase):
         row.save().run_sync()
         self.assertEqual(row.facilities, '{"mixing_desk": true}')
 
+    def test_raw(self):
+        """
+        Make sure raw queries convert the Python value into a JSON string.
+        """
+        RecordingStudio.raw(
+            "INSERT INTO recording_studio (name, facilities) VALUES ({}, {})",
+            "Abbey Road",
+            '{"mixing_desk": true}',
+        ).run_sync()
+
+        self.assertEqual(
+            RecordingStudio.select().run_sync(),
+            [
+                {
+                    "id": 1,
+                    "name": "Abbey Road",
+                    "facilities": '{"mixing_desk": true}',
+                }
+            ],
+        )
+
     def test_where(self):
         """
         Test using the where clause to match a subset of rows.

--- a/tests/columns/test_smallint.py
+++ b/tests/columns/test_smallint.py
@@ -25,7 +25,7 @@ class TestSmallIntPostgres(TestCase):
 
     def _test_length(self):
         # Can store 2 bytes, but split between positive and negative values.
-        max_value = int(2 ** 16 / 2) - 1
+        max_value = int(2**16 / 2) - 1
         min_value = max_value * -1
 
         print("Testing max value")


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/410

For example:

```python
class RecordingStudio(Table):
    facilities = JSONB(null=True)

# This was causing an error:
await RecordingStudio.select().where(
    RecordingStudio.facilities.is_null()
)
```

The problem was due to a bug with how Piccolo serialises JSON values.
