### PR TITLE
improve docstring for `piccolo migrations new` command

### DIFF
--- a/piccolo/apps/migrations/commands/new.py
+++ b/piccolo/apps/migrations/commands/new.py
@@ -199,8 +199,8 @@ async def new(
     :param auto:
         Auto create the migration contents.
     :param desc:
-        A description of what the migration does, for example 'adding name
-        column'.
+        A description of what the migration does, for example --desc='adding
+        name column'.
     :param auto_input:
         If provided, all prompts for user input will automatically have this
         entered. For example, --auto_input='y'.


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/418

The Piccolo CLI requires arguments like `--arg=foo` not `--arg foo` (note the `=` sign).

We will fix the underlying `targ` library to support this, but in the meantime I've updated the docstring with a better example.