### PR TITLE
change `TableMeta` placeholder

### DIFF
--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -140,9 +140,8 @@ class TableMetaclass(type):
 
 
 class Table(metaclass=TableMetaclass):
-    # These are just placeholder values, so type inference isn't confused - the
-    # actual values are set in __init_subclass__.
-    _meta = TableMeta()
+    # The value is set in __init_subclass__:
+    _meta: TableMeta
 
     def __init_subclass__(
         cls,


### PR DESCRIPTION
The `_meta` placeholder is just for MyPy - the value gets assigned in `__init_subclass__`.

Just declaring the variable is sufficient. Assigning it a value is redundant.