### PR TITLE
Refactor test assertions using `teyit`

### DIFF
--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -32,7 +32,7 @@ class TestHelpText(TestCase):
         """
         help_text = "This is some important help text for users."
         column = Varchar(help_text=help_text)
-        self.assertTrue(column._meta.help_text == help_text)
+        self.assertEqual(column._meta.help_text, help_text)
 
 
 class TestSecretParameter(TestCase):
@@ -42,7 +42,7 @@ class TestSecretParameter(TestCase):
         """
         secret = False
         column = Varchar(secret=secret)
-        self.assertTrue(column._meta.secret == secret)
+        self.assertEqual(column._meta.secret, secret)
 
 
 class TestChoices(TestCase):

--- a/tests/columns/test_db_column_name.py
+++ b/tests/columns/test_db_column_name.py
@@ -48,7 +48,7 @@ class TestDBColumnName(DBTestCase):
         band.save().run_sync()
 
         band_from_db = Band.objects().first().run_sync()
-        self.assertTrue(band_from_db.name == "Pythonistas")
+        self.assertEqual(band_from_db.name, "Pythonistas")
 
     def test_create(self):
         """
@@ -59,10 +59,10 @@ class TestDBColumnName(DBTestCase):
             .create(name="Pythonistas", popularity=1000)
             .run_sync()
         )
-        self.assertTrue(band.name == "Pythonistas")
+        self.assertEqual(band.name, "Pythonistas")
 
         band_from_db = Band.objects().first().run_sync()
-        self.assertTrue(band_from_db.name == "Pythonistas")
+        self.assertEqual(band_from_db.name, "Pythonistas")
 
     def test_select(self):
         """

--- a/tests/columns/test_double_precision.py
+++ b/tests/columns/test_double_precision.py
@@ -20,5 +20,5 @@ class TestDoublePrecision(TestCase):
         row.save().run_sync()
 
         _row = MyTable.objects().first().run_sync()
-        self.assertTrue(type(_row.column_a) == float)
+        self.assertEqual(type(_row.column_a), float)
         self.assertAlmostEqual(_row.column_a, 1.23)

--- a/tests/columns/test_interval.py
+++ b/tests/columns/test_interval.py
@@ -64,7 +64,7 @@ class TestInterval(TestCase):
             .first()
             .run_sync()
         )
-        self.assertTrue(result is not None)
+        self.assertIsNotNone(result)
 
         result = (
             MyTable.objects()
@@ -72,7 +72,7 @@ class TestInterval(TestCase):
             .first()
             .run_sync()
         )
-        self.assertTrue(result is not None)
+        self.assertIsNotNone(result)
 
         result = (
             MyTable.objects()
@@ -80,7 +80,7 @@ class TestInterval(TestCase):
             .first()
             .run_sync()
         )
-        self.assertTrue(result is not None)
+        self.assertIsNotNone(result)
 
         result = (
             MyTable.exists()
@@ -102,4 +102,4 @@ class TestIntervalDefault(TestCase):
         row.save().run_sync()
 
         result = MyTableDefault.objects().first().run_sync()
-        self.assertTrue(result.interval.days == 1)
+        self.assertEqual(result.interval.days, 1)

--- a/tests/columns/test_m2m.py
+++ b/tests/columns/test_m2m.py
@@ -631,10 +631,7 @@ class TestM2MComplexSchema(TestCase):
             returned_value = data[column_name]
 
             if type(column) == UUID:
-                self.assertIn(
-                    type(returned_value),
-                    (uuid.UUID, asyncpgUUID)
-                )
+                self.assertIn(type(returned_value), (uuid.UUID, asyncpgUUID))
             else:
                 self.assertEqual(
                     type(original_value),
@@ -658,10 +655,7 @@ class TestM2MComplexSchema(TestCase):
             returned_value = response[0]["mega_rows"][0]
 
             if type(column) == UUID:
-                self.assertIn(
-                    type(returned_value),
-                    (uuid.UUID, asyncpgUUID)
-                )
+                self.assertIn(type(returned_value), (uuid.UUID, asyncpgUUID))
                 self.assertEqual(str(original_value), str(returned_value))
             else:
                 self.assertEqual(

--- a/tests/columns/test_m2m.py
+++ b/tests/columns/test_m2m.py
@@ -600,10 +600,10 @@ class TestM2MComplexSchema(TestCase):
             SmallTable.varchar_col, SmallTable.mega_rows(load_json=True)
         ).run_sync()
 
-        self.assertTrue(len(response) == 1)
+        self.assertEqual(len(response), 1)
         mega_rows = response[0]["mega_rows"]
 
-        self.assertTrue(len(mega_rows) == 1)
+        self.assertEqual(len(mega_rows), 1)
         mega_row = mega_rows[0]
 
         for key, value in mega_row.items():
@@ -631,8 +631,9 @@ class TestM2MComplexSchema(TestCase):
             returned_value = data[column_name]
 
             if type(column) == UUID:
-                self.assertTrue(
-                    type(returned_value) in (uuid.UUID, asyncpgUUID)
+                self.assertIn(
+                    type(returned_value),
+                    (uuid.UUID, asyncpgUUID)
                 )
             else:
                 self.assertEqual(
@@ -657,8 +658,9 @@ class TestM2MComplexSchema(TestCase):
             returned_value = response[0]["mega_rows"][0]
 
             if type(column) == UUID:
-                self.assertTrue(
-                    type(returned_value) in (uuid.UUID, asyncpgUUID)
+                self.assertIn(
+                    type(returned_value),
+                    (uuid.UUID, asyncpgUUID)
                 )
                 self.assertEqual(str(original_value), str(returned_value))
             else:

--- a/tests/columns/test_numeric.py
+++ b/tests/columns/test_numeric.py
@@ -23,8 +23,8 @@ class TestNumeric(TestCase):
 
         _row = MyTable.objects().first().run_sync()
 
-        self.assertTrue(type(_row.column_a) == Decimal)
-        self.assertTrue(type(_row.column_b) == Decimal)
+        self.assertEqual(type(_row.column_a), Decimal)
+        self.assertEqual(type(_row.column_b), Decimal)
 
         self.assertAlmostEqual(_row.column_a, Decimal(1.23))
         self.assertEqual(_row.column_b, Decimal("1.23"))

--- a/tests/columns/test_primary_key.py
+++ b/tests/columns/test_primary_key.py
@@ -139,7 +139,7 @@ class TestPrimaryKeyQueries(TestCase):
             ["pk", "name"],
         )
 
-        self.assertTrue(isinstance(manager_dict["pk"], uuid.UUID))
+        self.assertIsInstance(manager_dict["pk"], uuid.UUID)
 
         #######################################################################
         # Make sure we can create rows with foreign keys to tables with a
@@ -155,8 +155,8 @@ class TestPrimaryKeyQueries(TestCase):
         self.assertEqual(
             [i for i in band_dict.keys()], ["pk", "name", "manager"]
         )
-        self.assertTrue(isinstance(band_dict["pk"], uuid.UUID))
-        self.assertTrue(isinstance(band_dict["manager"], uuid.UUID))
+        self.assertIsInstance(band_dict["pk"], uuid.UUID)
+        self.assertIsInstance(band_dict["manager"], uuid.UUID)
 
         #######################################################################
         # Make sure foreign key values can be specified as the primary key's

--- a/tests/columns/test_readable.py
+++ b/tests/columns/test_readable.py
@@ -23,7 +23,7 @@ class TestReadable(unittest.TestCase):
 
     def test_readable(self):
         response = MyTable.select(MyTable.get_readable()).run_sync()
-        self.assertTrue(response[0]["readable"] == "Guido van Rossum")
+        self.assertEqual(response[0]["readable"], "Guido van Rossum")
 
     def tearDown(self):
         MyTable.alter().drop_table().run_sync()

--- a/tests/columns/test_real.py
+++ b/tests/columns/test_real.py
@@ -20,5 +20,5 @@ class TestReal(TestCase):
         row.save().run_sync()
 
         _row = MyTable.objects().first().run_sync()
-        self.assertTrue(type(_row.column_a) == float)
+        self.assertEqual(type(_row.column_a), float)
         self.assertAlmostEqual(_row.column_a, 1.23)

--- a/tests/columns/test_time.py
+++ b/tests/columns/test_time.py
@@ -57,5 +57,5 @@ class TestTimeDefault(TestCase):
                 minute=created_on.minute,
                 second=created_on.second,
             ),
-            datetime.timedelta(seconds=1)
+            datetime.timedelta(seconds=1),
         )

--- a/tests/columns/test_time.py
+++ b/tests/columns/test_time.py
@@ -46,7 +46,7 @@ class TestTimeDefault(TestCase):
         _datetime = partial(datetime.datetime, year=2020, month=1, day=1)
 
         result = MyTableDefault.objects().first().run_sync()
-        self.assertTrue(
+        self.assertLess(
             _datetime(
                 hour=result.created_on.hour,
                 minute=result.created_on.minute,
@@ -56,6 +56,6 @@ class TestTimeDefault(TestCase):
                 hour=created_on.hour,
                 minute=created_on.minute,
                 second=created_on.second,
-            )
-            < datetime.timedelta(seconds=1)
+            ),
+            datetime.timedelta(seconds=1)
         )

--- a/tests/columns/test_timestamp.py
+++ b/tests/columns/test_timestamp.py
@@ -62,7 +62,6 @@ class TestTimestampDefault(TestCase):
 
         result = MyTableDefault.objects().first().run_sync()
         self.assertLess(
-            result.created_on - created_on,
-            datetime.timedelta(seconds=1)
+            result.created_on - created_on, datetime.timedelta(seconds=1)
         )
         self.assertIsNone(result.created_on.tzinfo)

--- a/tests/columns/test_timestamp.py
+++ b/tests/columns/test_timestamp.py
@@ -61,7 +61,8 @@ class TestTimestampDefault(TestCase):
         row.save().run_sync()
 
         result = MyTableDefault.objects().first().run_sync()
-        self.assertTrue(
-            result.created_on - created_on < datetime.timedelta(seconds=1)
+        self.assertLess(
+            result.created_on - created_on,
+            datetime.timedelta(seconds=1)
         )
-        self.assertTrue(result.created_on.tzinfo is None)
+        self.assertIsNone(result.created_on.tzinfo)

--- a/tests/columns/test_timestamptz.py
+++ b/tests/columns/test_timestamptz.py
@@ -94,5 +94,5 @@ class TestTimestamptzDefault(TestCase):
 
         result = MyTableDefault.objects().first().run_sync()
         delta = result.created_on - created_on
-        self.assertTrue(delta < datetime.timedelta(seconds=1))
+        self.assertLess(delta, datetime.timedelta(seconds=1))
         self.assertEqual(result.created_on.tzinfo, datetime.timezone.utc)

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -19,12 +19,12 @@ class TestAppRegistry(TestCase):
     def test_get_app_config(self):
         app_registry = AppRegistry(apps=["piccolo.apps.user.piccolo_app"])
         app_config = app_registry.get_app_config(app_name="user")
-        self.assertTrue(isinstance(app_config, AppConfig))
+        self.assertIsInstance(app_config, AppConfig)
 
     def test_get_table_classes(self):
         app_registry = AppRegistry(apps=["piccolo.apps.user.piccolo_app"])
         table_classes = app_registry.get_table_classes(app_name="user")
-        self.assertTrue(BaseUser in table_classes)
+        self.assertIn(BaseUser, table_classes)
 
         with self.assertRaises(ValueError):
             app_registry.get_table_classes(app_name="Foo")

--- a/tests/engine/test_nested_transaction.py
+++ b/tests/engine/test_nested_transaction.py
@@ -45,11 +45,11 @@ class TestDifferentDB(TestCase):
 
         self.assertTrue(await Musician.table_exists().run())
         musician = await Musician.select("name").first().run()
-        self.assertTrue(musician["name"] == "Bob")
+        self.assertEqual(musician["name"], "Bob")
 
         self.assertTrue(await Roadie.table_exists().run())
         roadie = await Roadie.select("name").first().run()
-        self.assertTrue(roadie["name"] == "Dave")
+        self.assertEqual(roadie["name"], "Dave")
 
     def test_nested(self):
         asyncio.run(self.run_nested())

--- a/tests/engine/test_pool.py
+++ b/tests/engine/test_pool.py
@@ -26,7 +26,7 @@ class TestPool(DBTestCase):
 
         await Manager(name="Bob").save().run()
         response = await Manager.select().run()
-        self.assertTrue("Bob" in [i["name"] for i in response])
+        self.assertIn("Bob", [i["name"] for i in response])
 
         await Manager._meta.db.close_connection_pool()
 

--- a/tests/query/test_freeze.py
+++ b/tests/query/test_freeze.py
@@ -95,9 +95,9 @@ class TestFreeze(DBTestCase):
         )
 
         # Remove the outliers before comparing
-        self.assertTrue(
-            sum(sorted(query_duration)[5:-5])
-            > sum(sorted(frozen_query_duration)[5:-5])
+        self.assertGreater(
+            sum(sorted(query_duration)[5:-5]),
+            sum(sorted(frozen_query_duration)[5:-5])
         )
 
     def test_attribute_access(self):

--- a/tests/query/test_freeze.py
+++ b/tests/query/test_freeze.py
@@ -97,7 +97,7 @@ class TestFreeze(DBTestCase):
         # Remove the outliers before comparing
         self.assertGreater(
             sum(sorted(query_duration)[5:-5]),
-            sum(sorted(frozen_query_duration)[5:-5])
+            sum(sorted(frozen_query_duration)[5:-5]),
         )
 
     def test_attribute_access(self):

--- a/tests/table/test_alter.py
+++ b/tests/table/test_alter.py
@@ -86,7 +86,7 @@ class TestDropColumn(DBTestCase):
         response = Band.raw("SELECT * FROM band").run_sync()
 
         column_names = response[0].keys()
-        self.assertTrue("popularity" not in column_names)
+        self.assertNotIn("popularity", column_names)
 
     def test_drop_string(self):
         self._test_drop(Band.popularity)
@@ -105,7 +105,7 @@ class TestAddColumn(DBTestCase):
         response = Band.raw("SELECT * FROM band").run_sync()
 
         column_names = response[0].keys()
-        self.assertTrue(column_name in column_names)
+        self.assertIn(column_name, column_names)
 
         self.assertEqual(response[0][column_name], expected_value)
 
@@ -158,7 +158,7 @@ class TestUnique(DBTestCase):
             Manager(name="Bob").save().run_sync()
 
         response = Manager.select().run_sync()
-        self.assertTrue(len(response) == 2)
+        self.assertEqual(len(response), 2)
 
         # Now remove the constraint, and add a row.
         not_unique_query = Manager.alter().set_unique(Manager.name, False)
@@ -188,8 +188,8 @@ class TestMultiple(DBTestCase):
         response = Band.raw("SELECT * FROM manager").run_sync()
 
         column_names = response[0].keys()
-        self.assertTrue("column_a" in column_names)
-        self.assertTrue("column_b" in column_names)
+        self.assertIn("column_a", column_names)
+        self.assertIn("column_b", column_names)
 
 
 # TODO - test more conversions.
@@ -271,11 +271,11 @@ class TestSetNull(DBTestCase):
 
         Band.alter().set_null(Band.popularity, boolean=True).run_sync()
         response = Band.raw(query).run_sync()
-        self.assertTrue(response[0]["is_nullable"] == "YES")
+        self.assertEqual(response[0]["is_nullable"], "YES")
 
         Band.alter().set_null(Band.popularity, boolean=False).run_sync()
         response = Band.raw(query).run_sync()
-        self.assertTrue(response[0]["is_nullable"] == "NO")
+        self.assertEqual(response[0]["is_nullable"], "NO")
 
 
 @postgres_only
@@ -291,7 +291,7 @@ class TestSetLength(DBTestCase):
         for length in (5, 20, 50):
             Band.alter().set_length(Band.name, length=length).run_sync()
             response = Band.raw(query).run_sync()
-            self.assertTrue(response[0]["character_maximum_length"] == length)
+            self.assertEqual(response[0]["character_maximum_length"], length)
 
 
 @postgres_only
@@ -305,7 +305,7 @@ class TestSetDefault(DBTestCase):
         ).run_sync()
 
         manager = Manager.objects().first().run_sync()
-        self.assertTrue(manager.name == "Pending")
+        self.assertEqual(manager.name, "Pending")
 
 
 ###############################################################################
@@ -336,10 +336,10 @@ class TestSetDigits(TestCase):
             column=Ticket.price, digits=(6, 2)
         ).run_sync()
         response = Ticket.raw(query).run_sync()
-        self.assertTrue(response[0]["numeric_precision"] == 6)
-        self.assertTrue(response[0]["numeric_scale"] == 2)
+        self.assertEqual(response[0]["numeric_precision"], 6)
+        self.assertEqual(response[0]["numeric_scale"], 2)
 
         Ticket.alter().set_digits(column=Ticket.price, digits=None).run_sync()
         response = Ticket.raw(query).run_sync()
-        self.assertTrue(response[0]["numeric_precision"] is None)
-        self.assertTrue(response[0]["numeric_scale"] is None)
+        self.assertIsNone(response[0]["numeric_precision"])
+        self.assertIsNone(response[0]["numeric_scale"])

--- a/tests/table/test_batch.py
+++ b/tests/table/test_batch.py
@@ -10,12 +10,12 @@ class TestBatchSelect(DBTestCase):
         """
         Make sure the data is returned in the correct format.
         """
-        self.assertTrue(type(batch) == list)
+        self.assertEqual(type(batch), list)
         if len(batch) > 0:
             row = batch[0]
-            self.assertTrue(type(row) == dict)
-            self.assertTrue("name" in row.keys())
-            self.assertTrue("id" in row.keys())
+            self.assertEqual(type(row), dict)
+            self.assertIn("name", row.keys())
+            self.assertIn("id", row.keys())
 
     async def run_batch(self, batch_size):
         row_count = 0
@@ -44,8 +44,8 @@ class TestBatchSelect(DBTestCase):
 
         _iterations = math.ceil(row_count / batch_size)
 
-        self.assertTrue(_row_count == row_count)
-        self.assertTrue(iterations == _iterations)
+        self.assertEqual(_row_count, row_count)
+        self.assertEqual(iterations, _iterations)
 
 
 class TestBatchObjects(DBTestCase):
@@ -53,10 +53,10 @@ class TestBatchObjects(DBTestCase):
         """
         Make sure the data is returned in the correct format.
         """
-        self.assertTrue(type(batch) == list)
+        self.assertEqual(type(batch), list)
         if len(batch) > 0:
             row = batch[0]
-            self.assertTrue(isinstance(row, Manager))
+            self.assertIsInstance(row, Manager)
 
     async def run_batch(self, batch_size):
         row_count = 0
@@ -85,5 +85,5 @@ class TestBatchObjects(DBTestCase):
 
         _iterations = math.ceil(row_count / batch_size)
 
-        self.assertTrue(_row_count == row_count)
-        self.assertTrue(iterations == _iterations)
+        self.assertEqual(_row_count, row_count)
+        self.assertEqual(iterations, _iterations)

--- a/tests/table/test_count.py
+++ b/tests/table/test_count.py
@@ -8,4 +8,4 @@ class TestCount(DBTestCase):
 
         response = Band.count().where(Band.name == "Pythonistas").run_sync()
 
-        self.assertTrue(response == 1)
+        self.assertEqual(response, 1)

--- a/tests/table/test_create.py
+++ b/tests/table/test_create.py
@@ -27,7 +27,7 @@ class TestCreateWithIndexes(TestCase):
     def test_create_table_with_indexes(self):
         index_names = BandMember.indexes().run_sync()
         index_name = BandMember._get_index_name(["name"])
-        self.assertTrue(index_name in index_names)
+        self.assertIn(index_name, index_names)
 
     def test_create_if_not_exists_with_indexes(self):
         """

--- a/tests/table/test_create_table_class.py
+++ b/tests/table/test_create_table_class.py
@@ -21,7 +21,7 @@ class TestCreateTableClass(TestCase):
         _Table = create_table_class(
             class_name="MyTable", class_members={"name": column}
         )
-        self.assertTrue(column in _Table._meta.columns)
+        self.assertIn(column, _Table._meta.columns)
 
     def test_protected_tablenames(self):
         """

--- a/tests/table/test_exists.py
+++ b/tests/table/test_exists.py
@@ -8,4 +8,4 @@ class TestExists(DBTestCase):
 
         response = Band.exists().where(Band.name == "Pythonistas").run_sync()
 
-        self.assertTrue(response is True)
+        self.assertTrue(response)

--- a/tests/table/test_indexes.py
+++ b/tests/table/test_indexes.py
@@ -27,11 +27,11 @@ class TestIndexes(TestCase):
             )
 
             index_names = Manager.indexes().run_sync()
-            self.assertTrue(index_name in index_names)
+            self.assertIn(index_name, index_names)
 
             Manager.drop_index(columns).run_sync()
             index_names = Manager.indexes().run_sync()
-            self.assertTrue(index_name not in index_names)
+            self.assertNotIn(index_name, index_names)
 
 
 class Concert(Table):
@@ -55,11 +55,11 @@ class TestProblematicColumnName(TestCase):
         index_name = Concert._get_index_name([i._meta.name for i in columns])
 
         index_names = Concert.indexes().run_sync()
-        self.assertTrue(index_name in index_names)
+        self.assertIn(index_name, index_names)
 
         Concert.drop_index(columns).run_sync()
         index_names = Concert.indexes().run_sync()
-        self.assertTrue(index_name not in index_names)
+        self.assertNotIn(index_name, index_names)
 
 
 class TestIndexName(TestCase):

--- a/tests/table/test_insert.py
+++ b/tests/table/test_insert.py
@@ -11,7 +11,7 @@ class TestInsert(DBTestCase):
         response = Band.select(Band.name).run_sync()
         names = [i["name"] for i in response]
 
-        self.assertTrue("Rustaceans" in names)
+        self.assertIn("Rustaceans", names)
 
     def test_add(self):
         self.insert_rows()
@@ -21,7 +21,7 @@ class TestInsert(DBTestCase):
         response = Band.select(Band.name).run_sync()
         names = [i["name"] for i in response]
 
-        self.assertTrue("Rustaceans" in names)
+        self.assertIn("Rustaceans", names)
 
     def test_incompatible_type(self):
         """
@@ -41,4 +41,4 @@ class TestInsert(DBTestCase):
         response = Band.select(Band.name).run_sync()
         names = [i["name"] for i in response]
 
-        self.assertTrue("{}" in names)
+        self.assertIn("{}", names)

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -22,7 +22,7 @@ class TestObjects(DBTestCase):
 
         self.assertEqual(
             Band.select(Band.name).output(as_list=True).run_sync()[0],
-            "Rustaceans"
+            "Rustaceans",
         )
 
     @postgres_only

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -8,21 +8,21 @@ class TestObjects(DBTestCase):
 
         response = Band.objects().run_sync()
 
-        self.assertTrue(len(response) == 1)
+        self.assertEqual(len(response), 1)
 
         instance = response[0]
 
-        self.assertTrue(isinstance(instance, Band))
-        self.assertTrue(instance.name == "Pythonistas")
+        self.assertIsInstance(instance, Band)
+        self.assertEqual(instance.name, "Pythonistas")
 
         # Now try changing the value and saving it.
         instance.name = "Rustaceans"
         save_query = instance.save()
         save_query.run_sync()
 
-        self.assertTrue(
-            Band.select(Band.name).output(as_list=True).run_sync()[0]
-            == "Rustaceans"
+        self.assertEqual(
+            Band.select(Band.name).output(as_list=True).run_sync()[0],
+            "Rustaceans"
         )
 
     @postgres_only
@@ -60,7 +60,7 @@ class TestObjects(DBTestCase):
 
         band = Band.objects().get(Band.name == "Pythonistas").run_sync()
 
-        self.assertTrue(band.name == "Pythonistas")
+        self.assertEqual(band.name, "Pythonistas")
 
     def test_get__prefetch(self):
         self.insert_rows()
@@ -96,8 +96,8 @@ class TestObjects(DBTestCase):
         )
 
         self.assertIsInstance(instance, Band)
-        self.assertTrue(instance.name == "Pink Floyd")
-        self.assertTrue(instance.popularity == 100)
+        self.assertEqual(instance.name, "Pink Floyd")
+        self.assertEqual(instance.popularity, 100)
 
         # When the row already exists in the db:
         Band.objects().get_or_create(
@@ -109,8 +109,8 @@ class TestObjects(DBTestCase):
         )
 
         self.assertIsInstance(instance, Band)
-        self.assertTrue(instance.name == "Pink Floyd")
-        self.assertTrue(instance.popularity == 100)
+        self.assertEqual(instance.name, "Pink Floyd")
+        self.assertEqual(instance.popularity, 100)
 
     def test_get_or_create_complex(self):
         """

--- a/tests/table/test_output.py
+++ b/tests/table/test_output.py
@@ -10,7 +10,7 @@ class TestOutputList(DBTestCase):
         self.insert_row()
 
         response = Band.select(Band.name).output(as_list=True).run_sync()
-        self.assertTrue(response == ["Pythonistas"])
+        self.assertEqual(response, ["Pythonistas"])
 
         # Make sure that if no rows are found, an empty list is returned.
         empty_response = (
@@ -19,7 +19,7 @@ class TestOutputList(DBTestCase):
             .output(as_list=True)
             .run_sync()
         )
-        self.assertTrue(empty_response == [])
+        self.assertEqual(empty_response, [])
 
 
 class TestOutputJSON(DBTestCase):
@@ -28,7 +28,7 @@ class TestOutputJSON(DBTestCase):
 
         response = Band.select(Band.name).output(as_json=True).run_sync()
 
-        self.assertTrue(json.loads(response) == [{"name": "Pythonistas"}])
+        self.assertEqual(json.loads(response), [{"name": "Pythonistas"}])
 
 
 class TestOutputLoadJSON(TestCase):

--- a/tests/table/test_raw.py
+++ b/tests/table/test_raw.py
@@ -20,7 +20,7 @@ class TestRaw(DBTestCase):
             "select * from band where name = {}", "Pythonistas"
         ).run_sync()
 
-        self.assertTrue(len(response) == 1)
+        self.assertEqual(len(response), 1)
         self.assertDictEqual(
             response[0],
             {"id": 1, "name": "Pythonistas", "manager": 1, "popularity": 1000},

--- a/tests/table/test_ref.py
+++ b/tests/table/test_ref.py
@@ -7,4 +7,4 @@ from tests.example_apps.music.tables import Band
 class TestRef(TestCase):
     def test_ref(self):
         column = Band.ref("manager.name")
-        self.assertTrue(isinstance(column, Varchar))
+        self.assertIsInstance(column, Varchar)

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -493,8 +493,7 @@ class TestSelect(DBTestCase):
 
         response = query.run_sync()
         self.assertEqual(
-            response,
-            [{"name": "Pythonistas"}, {"name": "Pythonistas"}]
+            response, [{"name": "Pythonistas"}, {"name": "Pythonistas"}]
         )
 
         query = query.distinct()
@@ -523,7 +522,7 @@ class TestSelect(DBTestCase):
                 {"name": "CSharps", "count": 2},
                 {"name": "Pythonistas", "count": 2},
                 {"name": "Rustaceans", "count": 2},
-            ]
+            ],
         )
 
     def test_count_with_alias_group_by(self):
@@ -546,7 +545,7 @@ class TestSelect(DBTestCase):
                 {"name": "CSharps", "total": 2},
                 {"name": "Pythonistas", "total": 2},
                 {"name": "Rustaceans", "total": 2},
-            ]
+            ],
         )
 
     def test_count_with_as_alias_group_by(self):
@@ -569,7 +568,7 @@ class TestSelect(DBTestCase):
                 {"name": "CSharps", "total": 2},
                 {"name": "Pythonistas", "total": 2},
                 {"name": "Rustaceans", "total": 2},
-            ]
+            ],
         )
 
     def test_count_column_group_by(self):
@@ -610,7 +609,7 @@ class TestSelect(DBTestCase):
                 {"manager.name": "Graydon", "count": 2},
                 {"manager.name": "Guido", "count": 2},
                 {"manager.name": "Mads", "count": 2},
-            ]
+            ],
         )
 
         # This time the nulls should be counted, as we omit the column argument
@@ -631,7 +630,7 @@ class TestSelect(DBTestCase):
                 {"manager.name": "Graydon", "count": 2},
                 {"manager.name": "Guido", "count": 2},
                 {"manager.name": "Mads", "count": 2},
-            ]
+            ],
         )
 
     def test_avg(self):
@@ -650,10 +649,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertEqual(
-            float(response["popularity_avg"]),
-            1003.3333333333334
-        )
+        self.assertEqual(float(response["popularity_avg"]), 1003.3333333333334)
 
     def test_avg_as_alias_method(self):
         self.insert_rows()
@@ -664,10 +660,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertEqual(
-            float(response["popularity_avg"]),
-            1003.3333333333334
-        )
+        self.assertEqual(float(response["popularity_avg"]), 1003.3333333333334)
 
     def test_avg_with_where_clause(self):
         self.insert_rows()
@@ -868,10 +861,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertEqual(
-            float(response["popularity_avg"]),
-            1003.3333333333334
-        )
+        self.assertEqual(float(response["popularity_avg"]), 1003.3333333333334)
         self.assertEqual(response["popularity_sum"], 3010)
 
     def test_avg_validation(self):

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -381,7 +381,7 @@ class TestSelect(DBTestCase):
         response = query.run_sync()
 
         self.assertEqual(response, [{"name": "Rustaceans"}])
-        self.assertTrue("AND" in query.__str__())
+        self.assertIn("AND", query.__str__())
 
     def test_complex_where(self):
         """
@@ -489,18 +489,19 @@ class TestSelect(DBTestCase):
         self.insert_rows()
 
         query = Band.select(Band.name).where(Band.name == "Pythonistas")
-        self.assertTrue("DISTINCT" not in query.__str__())
+        self.assertNotIn("DISTINCT", query.__str__())
 
         response = query.run_sync()
-        self.assertTrue(
-            response == [{"name": "Pythonistas"}, {"name": "Pythonistas"}]
+        self.assertEqual(
+            response,
+            [{"name": "Pythonistas"}, {"name": "Pythonistas"}]
         )
 
         query = query.distinct()
-        self.assertTrue("DISTINCT" in query.__str__())
+        self.assertIn("DISTINCT", query.__str__())
 
         response = query.run_sync()
-        self.assertTrue(response == [{"name": "Pythonistas"}])
+        self.assertEqual(response, [{"name": "Pythonistas"}])
 
     def test_count_group_by(self):
         """
@@ -516,9 +517,9 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(
-            response
-            == [
+        self.assertEqual(
+            response,
+            [
                 {"name": "CSharps", "count": 2},
                 {"name": "Pythonistas", "count": 2},
                 {"name": "Rustaceans", "count": 2},
@@ -539,9 +540,9 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(
-            response
-            == [
+        self.assertEqual(
+            response,
+            [
                 {"name": "CSharps", "total": 2},
                 {"name": "Pythonistas", "total": 2},
                 {"name": "Rustaceans", "total": 2},
@@ -562,9 +563,9 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(
-            response
-            == [
+        self.assertEqual(
+            response,
+            [
                 {"name": "CSharps", "total": 2},
                 {"name": "Pythonistas", "total": 2},
                 {"name": "Rustaceans", "total": 2},
@@ -602,9 +603,9 @@ class TestSelect(DBTestCase):
         # differently when sorting.
         response = sorted(response, key=lambda x: x["manager.name"] or "")
 
-        self.assertTrue(
-            response
-            == [
+        self.assertEqual(
+            response,
+            [
                 {"manager.name": None, "count": 0},
                 {"manager.name": "Graydon", "count": 2},
                 {"manager.name": "Guido", "count": 2},
@@ -623,9 +624,9 @@ class TestSelect(DBTestCase):
 
         response = sorted(response, key=lambda x: x["manager.name"] or "")
 
-        self.assertTrue(
-            response
-            == [
+        self.assertEqual(
+            response,
+            [
                 {"manager.name": None, "count": 1},
                 {"manager.name": "Graydon", "count": 2},
                 {"manager.name": "Guido", "count": 2},
@@ -638,7 +639,7 @@ class TestSelect(DBTestCase):
 
         response = Band.select(Avg(Band.popularity)).first().run_sync()
 
-        self.assertTrue(float(response["avg"]) == 1003.3333333333334)
+        self.assertEqual(float(response["avg"]), 1003.3333333333334)
 
     def test_avg_alias(self):
         self.insert_rows()
@@ -649,8 +650,9 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(
-            float(response["popularity_avg"]) == 1003.3333333333334
+        self.assertEqual(
+            float(response["popularity_avg"]),
+            1003.3333333333334
         )
 
     def test_avg_as_alias_method(self):
@@ -662,8 +664,9 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(
-            float(response["popularity_avg"]) == 1003.3333333333334
+        self.assertEqual(
+            float(response["popularity_avg"]),
+            1003.3333333333334
         )
 
     def test_avg_with_where_clause(self):
@@ -676,7 +679,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["avg"] == 1500)
+        self.assertEqual(response["avg"], 1500)
 
     def test_avg_alias_with_where_clause(self):
         """
@@ -692,7 +695,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_avg"] == 1500)
+        self.assertEqual(response["popularity_avg"], 1500)
 
     def test_avg_as_alias_method_with_where_clause(self):
         """
@@ -708,14 +711,14 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_avg"] == 1500)
+        self.assertEqual(response["popularity_avg"], 1500)
 
     def test_max(self):
         self.insert_rows()
 
         response = Band.select(Max(Band.popularity)).first().run_sync()
 
-        self.assertTrue(response["max"] == 2000)
+        self.assertEqual(response["max"], 2000)
 
     def test_max_alias(self):
         self.insert_rows()
@@ -726,7 +729,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_max"] == 2000)
+        self.assertEqual(response["popularity_max"], 2000)
 
     def test_max_as_alias_method(self):
         self.insert_rows()
@@ -737,14 +740,14 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_max"] == 2000)
+        self.assertEqual(response["popularity_max"], 2000)
 
     def test_min(self):
         self.insert_rows()
 
         response = Band.select(Min(Band.popularity)).first().run_sync()
 
-        self.assertTrue(response["min"] == 10)
+        self.assertEqual(response["min"], 10)
 
     def test_min_alias(self):
         self.insert_rows()
@@ -755,7 +758,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_min"] == 10)
+        self.assertEqual(response["popularity_min"], 10)
 
     def test_min_as_alias_method(self):
         self.insert_rows()
@@ -766,14 +769,14 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_min"] == 10)
+        self.assertEqual(response["popularity_min"], 10)
 
     def test_sum(self):
         self.insert_rows()
 
         response = Band.select(Sum(Band.popularity)).first().run_sync()
 
-        self.assertTrue(response["sum"] == 3010)
+        self.assertEqual(response["sum"], 3010)
 
     def test_sum_alias(self):
         self.insert_rows()
@@ -784,7 +787,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_sum"] == 3010)
+        self.assertEqual(response["popularity_sum"], 3010)
 
     def test_sum_as_alias_method(self):
         self.insert_rows()
@@ -795,7 +798,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_sum"] == 3010)
+        self.assertEqual(response["popularity_sum"], 3010)
 
     def test_sum_with_where_clause(self):
         self.insert_rows()
@@ -807,7 +810,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["sum"] == 3000)
+        self.assertEqual(response["sum"], 3000)
 
     def test_sum_alias_with_where_clause(self):
         """
@@ -823,7 +826,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_sum"] == 3000)
+        self.assertEqual(response["popularity_sum"], 3000)
 
     def test_sum_as_alias_method_with_where_clause(self):
         """
@@ -839,7 +842,7 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(response["popularity_sum"] == 3000)
+        self.assertEqual(response["popularity_sum"], 3000)
 
     def test_chain_different_functions(self):
         self.insert_rows()
@@ -850,8 +853,8 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(float(response["avg"]) == 1003.3333333333334)
-        self.assertTrue(response["sum"] == 3010)
+        self.assertEqual(float(response["avg"]), 1003.3333333333334)
+        self.assertEqual(response["sum"], 3010)
 
     def test_chain_different_functions_alias(self):
         self.insert_rows()
@@ -865,10 +868,11 @@ class TestSelect(DBTestCase):
             .run_sync()
         )
 
-        self.assertTrue(
-            float(response["popularity_avg"]) == 1003.3333333333334
+        self.assertEqual(
+            float(response["popularity_avg"]),
+            1003.3333333333334
         )
-        self.assertTrue(response["popularity_sum"] == 3010)
+        self.assertEqual(response["popularity_sum"], 3010)
 
     def test_avg_validation(self):
         with self.assertRaises(ValueError):
@@ -892,7 +896,7 @@ class TestSelect(DBTestCase):
             .first()
             .run_sync()
         )
-        self.assertTrue(response == {"name": "Pythonistas"})
+        self.assertEqual(response, {"name": "Pythonistas"})
 
         # Multiple calls to 'columns' should be additive.
         response = (
@@ -903,7 +907,7 @@ class TestSelect(DBTestCase):
             .first()
             .run_sync()
         )
-        self.assertTrue(response == {"id": 1, "name": "Pythonistas"})
+        self.assertEqual(response, {"id": 1, "name": "Pythonistas"})
 
     def test_call_chain(self):
         """
@@ -963,7 +967,7 @@ class TestSelectSecret(TestCase):
         user.save().run_sync()
 
         user_dict = BaseUser.select(exclude_secrets=True).first().run_sync()
-        self.assertTrue("password" not in user_dict.keys())
+        self.assertNotIn("password", user_dict.keys())
 
 
 class TestSelectSecretParameter(TestCase):
@@ -983,4 +987,4 @@ class TestSelectSecretParameter(TestCase):
 
         venue_dict = Venue.select(exclude_secrets=True).first().run_sync()
         self.assertTrue(venue_dict, {"id": 1, "name": "The Garage"})
-        self.assertTrue("capacity" not in venue_dict.keys())
+        self.assertNotIn("capacity", venue_dict.keys())

--- a/tests/table/test_table_exists.py
+++ b/tests/table/test_table_exists.py
@@ -9,7 +9,7 @@ class TestTableExists(TestCase):
 
     def test_table_exists(self):
         response = Manager.table_exists().run_sync()
-        self.assertTrue(response is True)
+        self.assertTrue(response)
 
     def tearDown(self):
         Manager.alter().drop_table().run_sync()

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -494,7 +494,7 @@ class TestNestedModel(TestCase):
         self.assertEqual(ManagerModel.__qualname__, "Band.manager")
 
         AssistantManagerType = BandModel.__fields__["assistant_manager"].type_
-        self.assertTrue(AssistantManagerType is int)
+        self.assertIs(AssistantManagerType, int)
 
         #######################################################################
         # Test two levels deep
@@ -511,7 +511,7 @@ class TestNestedModel(TestCase):
         self.assertEqual(ManagerModel.__qualname__, "Band.manager")
 
         AssistantManagerType = BandModel.__fields__["assistant_manager"].type_
-        self.assertTrue(AssistantManagerType is int)
+        self.assertIs(AssistantManagerType, int)
 
         CountryModel = ManagerModel.__fields__["country"].type_
         self.assertTrue(issubclass(CountryModel, pydantic.BaseModel))
@@ -526,7 +526,7 @@ class TestNestedModel(TestCase):
         )
 
         VenueModel = ConcertModel.__fields__["venue"].type_
-        self.assertTrue(VenueModel is int)
+        self.assertIs(VenueModel, int)
 
         BandModel = ConcertModel.__fields__["band_1"].type_
         self.assertTrue(issubclass(BandModel, pydantic.BaseModel))
@@ -545,10 +545,10 @@ class TestNestedModel(TestCase):
         self.assertEqual(ManagerModel.__qualname__, "Concert.band_1.manager")
 
         AssistantManagerType = BandModel.__fields__["assistant_manager"].type_
-        self.assertTrue(AssistantManagerType is int)
+        self.assertIs(AssistantManagerType, int)
 
         CountryModel = ManagerModel.__fields__["country"].type_
-        self.assertTrue(CountryModel is int)
+        self.assertIs(CountryModel, int)
 
         #######################################################################
         # Test with `model_name` arg
@@ -638,7 +638,7 @@ class TestRecursionDepth(TestCase):
 
         # We should have hit the recursion depth:
         CountryModel = ManagerModel.__fields__["country"].type_
-        self.assertTrue(CountryModel is int)
+        self.assertIs(CountryModel, int)
 
 
 class TestDBColumnName(TestCase):
@@ -655,7 +655,7 @@ class TestDBColumnName(TestCase):
 
         model = BandModel(regrettable_column_name="test")
 
-        self.assertTrue(model.name == "test")
+        self.assertEqual(model.name, "test")
 
 
 class TestSchemaExtraKwargs(TestCase):


### PR DESCRIPTION
I ran this tool on the Piccolo test suite:

https://github.com/isidentical/teyit

It replaces assertions like `self.assertTrue(some_var == 'foo')` with `self.assertEqual(some_var, 'foo')`.

By having more specific assertions, the tests output better error messages when they fail.

I may add `teyit` to our CI at some point.