### PR TITLE
Docs for renaming migration files, and `is_in` / `not_in`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,13 @@ Changes
 0.69.2
 ------
 
- * Lots of documentation improvements, including how to customise ``BaseUser``
-   (courtesy @sinisaos).
- * Fixed a bug with creating indexes when the column name clashes with a SQL
-   keyword (e.g. ``'order'``). See `Pr 433 <https://github.com/piccolo-orm/piccolo/pull/433>`_.
-   Thanks to @wmshort for reporting this issue.
- * Fixed an issue where some slots were incorrectly configured (courtesy
-   @ariebovenberg). See `PR 426 <https://github.com/piccolo-orm/piccolo/pull/426>`_.
+* Lots of documentation improvements, including how to customise ``BaseUser``
+  (courtesy @sinisaos).
+* Fixed a bug with creating indexes when the column name clashes with a SQL
+  keyword (e.g. ``'order'``). See `Pr 433 <https://github.com/piccolo-orm/piccolo/pull/433>`_.
+  Thanks to @wmshort for reporting this issue.
+* Fixed an issue where some slots were incorrectly configured (courtesy
+  @ariebovenberg). See `PR 426 <https://github.com/piccolo-orm/piccolo/pull/426>`_.
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/migrations/create.rst
+++ b/docs/src/piccolo/migrations/create.rst
@@ -12,12 +12,14 @@ automatically. To create an empty migration:
     piccolo migrations new my_app
 
 This creates a new migration file in the migrations folder of the app. The
-migration filename is a timestamp, which also serves as the migration ID.
+migration filename is a timestamp:
 
 .. code-block:: bash
 
     piccolo_migrations/
         2021-08-06T16-22-51-415781.py
+
+.. hint:: You can rename this file if you like to make it more memorable.
 
 The contents of an empty migration file looks like this:
 
@@ -39,6 +41,9 @@ The contents of an empty migration file looks like this:
 
         manager.add_raw(run)
         return manager
+
+The ``ID`` is very important - it uniquely identifies the migration, and
+shouldn't be changed.
 
 Replace the ``run`` function with whatever you want the migration to do -
 typically running some SQL. It can be a function or a coroutine.

--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -94,16 +94,20 @@ Usage is the same as ``like`` excepts it excludes matching rows.
 is_in / not_in
 --------------
 
+You can get all rows with a value contained in the list:
+
 .. code-block:: python
 
     await Band.select().where(
-        Band.name.is_in(['Pythonistas'])
+        Band.name.is_in(['Pythonistas', 'Rustaceans'])
     )
 
+And all rows with a value not contained in the list:
+
 .. code-block:: python
 
     await Band.select().where(
-        Band.name.not_in(['Rustaceans'])
+        Band.name.not_in(['Terrible Band', 'Awful Band'])
     )
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Changes to the docs:

 * Mentioning that migration files can be renamed (related to https://github.com/piccolo-orm/piccolo/discussions/427)
 * The docs for `is_in` / `not_in` were pretty basic - they now include better examples, and a description.