### PR TITLE
Warn if a `bool` is passed into a `where` clause

### DIFF
--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -116,6 +116,14 @@ class WhereDelegate:
 
     def where(self, *where: Combinable):
         for arg in where:
+            if isinstance(arg, bool):
+                raise ValueError(
+                    "A boolean value has been passed in to a where clause. "
+                    "This is probably a mistake. For example "
+                    "`.where(MyTable.some_column is None)` instead of "
+                    "`.where(MyTable.some_column.is_null())`."
+                )
+
             self._where = And(self._where, arg) if self._where else arg
 
 

--- a/tests/apps/fixtures/commands/test_dump_load.py
+++ b/tests/apps/fixtures/commands/test_dump_load.py
@@ -18,6 +18,8 @@ class TestDumpLoad(TestCase):
     together.
     """
 
+    maxDiff = None
+
     def setUp(self):
         for table_class in (SmallTable, MegaTable):
             table_class.create_table().run_sync()
@@ -46,7 +48,9 @@ class TestDumpLoad(TestCase):
             smallint_col=1,
             text_col="hello",
             timestamp_col=datetime.datetime(year=2021, month=1, day=1),
-            timestamptz_col=datetime.datetime(year=2021, month=1, day=1),
+            timestamptz_col=datetime.datetime(
+                year=2021, month=1, day=1, tzinfo=datetime.timezone.utc
+            ),
             uuid_col=uuid.UUID("12783854-c012-4c15-8183-8eecb46f2c4e"),
             varchar_col="hello",
             unique_col="hello",

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -239,6 +239,15 @@ class TestSelect(DBTestCase):
             response = query.run_sync()
             self.assertEqual(response, [{"name": "Managerless"}])
 
+    def test_where_bool(self):
+        """
+        If passing a boolean into a where clause, an exception should be
+        raised. It's possible for a user to do this by accident, for example
+        ``where(Band.has_drummer is None)``, which evaluates to a boolean.
+        """
+        with self.assertRaises(ValueError):
+            Band.select().where(False)
+
     def test_where_is_not_null(self):
         self.insert_rows()
 


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/444