### PR TITLE
mypy ignore override

### DIFF
--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -661,13 +661,13 @@ class Column(Selectable):
 
         return False
 
-    def __eq__(self, value) -> Where:  # type: ignore
+    def __eq__(self, value) -> Where:  # type: ignore[override]
         if value is None:
             return Where(column=self, operator=IsNull)
         else:
             return Where(column=self, value=value, operator=Equal)
 
-    def __ne__(self, value) -> Where:  # type: ignore
+    def __ne__(self, value) -> Where:  # type: ignore[override]
         if value is None:
             return Where(column=self, operator=IsNotNull)
         else:


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/444

We can use `type: ignore[override]` instead of `type: ignore`.

See the [mypy docs](https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides).

