### PR TITLE
remove null check

### DIFF
--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -458,12 +458,6 @@ class Column(Selectable):
             }
         )
 
-        if kwargs.get("default", ...) is None and not null:
-            raise ValueError(
-                "A default value of None isn't allowed if the column is "
-                "not nullable."
-            )
-
         if choices is not None:
             self._validate_choices(choices, allowed_type=self.value_type)
 

--- a/tests/columns/test_defaults.py
+++ b/tests/columns/test_defaults.py
@@ -36,8 +36,6 @@ class TestDefaults(TestCase):
             _type(default=None, null=True)
             with self.assertRaises(ValueError):
                 _type(default="hello world")
-            with self.assertRaises(ValueError):
-                _type(default=None, null=False)
 
     def test_text(self):
         for _type in (Text, Varchar):
@@ -45,32 +43,24 @@ class TestDefaults(TestCase):
             _type(default=None, null=True)
             with self.assertRaises(ValueError):
                 _type(default=123)
-            with self.assertRaises(ValueError):
-                _type(default=None, null=False)
 
     def test_real(self):
         Real(default=0.0)
         Real(default=None, null=True)
         with self.assertRaises(ValueError):
             Real(default="hello world")
-        with self.assertRaises(ValueError):
-            Real(default=None, null=False)
 
     def test_double_precision(self):
         DoublePrecision(default=0.0)
         DoublePrecision(default=None, null=True)
         with self.assertRaises(ValueError):
             DoublePrecision(default="hello world")
-        with self.assertRaises(ValueError):
-            DoublePrecision(default=None, null=False)
 
     def test_numeric(self):
         Numeric(default=decimal.Decimal(1.0))
         Numeric(default=None, null=True)
         with self.assertRaises(ValueError):
             Numeric(default="hello world")
-        with self.assertRaises(ValueError):
-            Numeric(default=None, null=False)
 
     def test_uuid(self):
         UUID(default=None, null=True)
@@ -78,8 +68,6 @@ class TestDefaults(TestCase):
         UUID(default=uuid.uuid4())
         with self.assertRaises(ValueError):
             UUID(default="hello world")
-        with self.assertRaises(ValueError):
-            UUID(default=None, null=False)
 
     def test_time(self):
         Time(default=None, null=True)
@@ -87,8 +75,6 @@ class TestDefaults(TestCase):
         Time(default=datetime.datetime.now().time())
         with self.assertRaises(ValueError):
             Time(default="hello world")
-        with self.assertRaises(ValueError):
-            Time(default=None, null=False)
 
     def test_date(self):
         Date(default=None, null=True)
@@ -96,8 +82,6 @@ class TestDefaults(TestCase):
         Date(default=datetime.datetime.now().date())
         with self.assertRaises(ValueError):
             Date(default="hello world")
-        with self.assertRaises(ValueError):
-            Date(default=None, null=False)
 
     def test_timestamp(self):
         Timestamp(default=None, null=True)
@@ -105,8 +89,6 @@ class TestDefaults(TestCase):
         Timestamp(default=datetime.datetime.now())
         with self.assertRaises(ValueError):
             Timestamp(default="hello world")
-        with self.assertRaises(ValueError):
-            Timestamp(default=None, null=False)
 
     def test_foreignkey(self):
         class MyTable(Table):
@@ -116,5 +98,3 @@ class TestDefaults(TestCase):
         ForeignKey(references=MyTable, default=1)
         with self.assertRaises(ValueError):
             ForeignKey(references=MyTable, default="hello world")
-        with self.assertRaises(ValueError):
-            ForeignKey(references=MyTable, default=None, null=False)


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/446

Also related to https://github.com/piccolo-orm/piccolo/issues/207

We were raising an error if a column was defined as `null=False`, but had a default value of `None`.

It ended up causing problems, because Postgres does allow you to have a column without a 'not null' constraint, and no default value.