### PR TITLE
comprehensions and literals

### DIFF
--- a/piccolo/apps/fixtures/commands/load.py
+++ b/piccolo/apps/fixtures/commands/load.py
@@ -24,9 +24,7 @@ async def load_json_string(json_string: str):
     fixture_configs = [
         FixtureConfig(
             app_name=app_name,
-            table_class_names=[
-                i for i in deserialised_contents[app_name].keys()
-            ],
+            table_class_names=list(deserialised_contents[app_name].keys()),
         )
         for app_name in app_names
     ]

--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -53,7 +53,7 @@ class AddColumnCollection:
 
     @property
     def table_class_names(self) -> t.List[str]:
-        return list(set([i.table_class_name for i in self.add_columns]))
+        return list({i.table_class_name for i in self.add_columns})
 
 
 @dataclass
@@ -74,7 +74,7 @@ class DropColumnCollection:
 
     @property
     def table_class_names(self) -> t.List[str]:
-        return list(set([i.table_class_name for i in self.drop_columns]))
+        return list({i.table_class_name for i in self.drop_columns})
 
 
 @dataclass
@@ -95,7 +95,7 @@ class RenameColumnCollection:
 
     @property
     def table_class_names(self) -> t.List[str]:
-        return list(set([i.table_class_name for i in self.rename_columns]))
+        return list({i.table_class_name for i in self.rename_columns})
 
 
 @dataclass
@@ -116,7 +116,7 @@ class AlterColumnCollection:
 
     @property
     def table_class_names(self) -> t.List[str]:
-        return list(set([i.table_class_name for i in self.alter_columns]))
+        return list({i.table_class_name for i in self.alter_columns})
 
 
 @dataclass

--- a/piccolo/apps/migrations/auto/schema_differ.py
+++ b/piccolo/apps/migrations/auto/schema_differ.py
@@ -519,4 +519,4 @@ class SchemaDiffer:
             count = len(statements.statements)
             print(f"{_message} {count}")
 
-        return [i for i in alter_statements.values()]
+        return list(alter_statements.values())

--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -17,8 +17,8 @@ from piccolo.columns.defaults.base import Default
 from piccolo.columns.reference import LazyTableReference
 from piccolo.table import Table
 from piccolo.utils.repr import repr_class_instance
-
 from .serialisation_legacy import deserialise_legacy_params
+
 
 ###############################################################################
 
@@ -52,11 +52,11 @@ class UniqueGlobalNamesMeta(type):
             bases,
             mcs.merge_class_attributes(
                 class_attributes_with_columns,
-                dict(
-                    unique_names=mcs.get_unique_class_attribute_values(
+                {
+                    "unique_names": mcs.get_unique_class_attribute_values(
                         class_attributes_with_columns
                     )
-                ),
+                },
             ),
         )
 
@@ -706,10 +706,10 @@ def serialise_params(params: t.Dict[str, t.Any]) -> SerialisedParams:
 
         # All other types can remain as is.
 
-    unique_extra_imports = [i for i in set(extra_imports)]
+    unique_extra_imports = list(set(extra_imports))
     UniqueGlobalNames.warn_if_are_conflicting_objects(unique_extra_imports)
 
-    unique_extra_definitions = [i for i in set(extra_definitions)]
+    unique_extra_definitions = list(set(extra_definitions))
     UniqueGlobalNames.warn_if_are_conflicting_objects(unique_extra_definitions)
 
     return SerialisedParams(

--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -17,8 +17,8 @@ from piccolo.columns.defaults.base import Default
 from piccolo.columns.reference import LazyTableReference
 from piccolo.table import Table
 from piccolo.utils.repr import repr_class_instance
-from .serialisation_legacy import deserialise_legacy_params
 
+from .serialisation_legacy import deserialise_legacy_params
 
 ###############################################################################
 

--- a/piccolo/apps/migrations/commands/base.py
+++ b/piccolo/apps/migrations/commands/base.py
@@ -67,7 +67,7 @@ class BaseMigrationManager(Finder):
         """
         Returns a list of migration IDs, from the Python migration files.
         """
-        return sorted(list(migration_module_dict.keys()))
+        return sorted(migration_module_dict.keys())
 
     async def get_migration_managers(
         self,

--- a/piccolo/apps/migrations/commands/new.py
+++ b/piccolo/apps/migrations/commands/new.py
@@ -107,11 +107,11 @@ async def _create_new_migration(
             chain(*[i.statements for i in alter_statements])
         )
         extra_imports = sorted(
-            list(set(chain(*[i.extra_imports for i in alter_statements]))),
+            set(chain(*[i.extra_imports for i in alter_statements])),
             key=lambda x: x.__repr__(),
         )
         extra_definitions = sorted(
-            list(set(chain(*[i.extra_definitions for i in alter_statements]))),
+            set(chain(*[i.extra_definitions for i in alter_statements])),
         )
 
         if sum(len(i.statements) for i in alter_statements) == 0:

--- a/piccolo/apps/schema/commands/generate.py
+++ b/piccolo/apps/schema/commands/generate.py
@@ -869,7 +869,7 @@ async def get_output_schema(
     output_schema.tables = sort_table_classes(
         sorted(output_schema.tables, key=lambda x: x._meta.tablename)
     )
-    output_schema.imports = sorted(list(set(output_schema.imports)))
+    output_schema.imports = sorted(set(output_schema.imports))
 
     return output_schema
 

--- a/piccolo/apps/schema/commands/generate.py
+++ b/piccolo/apps/schema/commands/generate.py
@@ -231,12 +231,9 @@ class TableIndexes:
         return None
 
     def get_warnings(self) -> t.List[str]:
-        return [
-            i
-            for i in itertools.chain(
-                *[index.warnings for index in self.indexes]
-            )
-        ]
+        return list(
+            itertools.chain(*[index.warnings for index in self.indexes])
+        )
 
 
 @dataclasses.dataclass

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -1873,9 +1873,7 @@ class ForeignKey(Column):  # lgtm [py/missing-equals]
                 column
             ) in value._foreign_key_meta.resolved_references._meta.columns:
                 _column: Column = column.copy()
-                _column._meta.call_chain = [
-                    i for i in new_column._meta.call_chain
-                ]
+                _column._meta.call_chain = list(new_column._meta.call_chain)
                 setattr(new_column, _column._meta.name, _column)
                 foreign_key_meta.proxy_columns.append(_column)
 

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -229,7 +229,7 @@ class AppRegistry:
         app_names.sort()
         grouped = itertools.groupby(app_names)
         for key, value in grouped:
-            count = len([i for i in value])
+            count = len(list(value))
             if count > 1:
                 raise ValueError(
                     f"There are {count} apps with the name `{key}`. This can "
@@ -303,7 +303,7 @@ class Finder:
         Remove all duplicates - just leaving the first instance.
         """
         # Deduplicate, but preserve order - which is why set() isn't used.
-        return list(dict([(c, None) for c in config_modules]).keys())
+        return list({c: None for c in config_modules}.keys())
 
     def _import_app_modules(
         self, config_module_paths: t.List[str]

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -15,7 +15,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 class AlterStatement:
-    __slots__ = tuple()  # type: ignore
+    __slots__ = ()  # type: ignore
 
     @property
     def ddl(self) -> str:
@@ -168,7 +168,6 @@ class SetNull(AlterColumnStatement):
 
 @dataclass
 class SetLength(AlterColumnStatement):
-
     __slots__ = ("length",)
 
     length: int
@@ -222,7 +221,6 @@ class AddForeignKeyConstraint(AlterStatement):
 
 @dataclass
 class SetDigits(AlterColumnStatement):
-
     __slots__ = ("digits", "column_type")
 
     digits: t.Optional[t.Tuple[int, int]]
@@ -263,7 +261,6 @@ class DropTable:
 
 
 class Alter(DDL):
-
     __slots__ = (
         "_add_foreign_key_constraint",
         "_add",

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -211,7 +211,6 @@ class Sum(Selectable):
 
 
 class Select(Query):
-
     __slots__ = (
         "columns_list",
         "exclude_secrets",
@@ -286,7 +285,7 @@ class Select(Query):
         as_list: bool = False,
     ):
         row_ids = list(
-            {i for i in itertools.chain(*[row[m2m_name] for row in response])}
+            set(itertools.chain(*[row[m2m_name] for row in response]))
         )
         extra_rows = (
             (

--- a/piccolo/query/methods/table_exists.py
+++ b/piccolo/query/methods/table_exists.py
@@ -8,7 +8,7 @@ from piccolo.querystring import QueryString
 
 class TableExists(Query):
 
-    __slots__: t.Tuple = tuple()
+    __slots__: t.Tuple = ()
 
     async def response_handler(self, response):
         return bool(response[0]["exists"])

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -310,7 +310,7 @@ class Table(metaclass=TableMetaclass):
 
         unrecognized = kwargs.keys()
         if unrecognized:
-            unrecognised_list = [i for i in unrecognized]
+            unrecognised_list = list(unrecognized)
             raise ValueError(f"Unrecognized columns - {unrecognised_list}")
 
     @classmethod

--- a/piccolo/utils/dictionary.py
+++ b/piccolo/utils/dictionary.py
@@ -22,7 +22,7 @@ def make_nested(dictionary: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
     """
     output: t.Dict[str, t.Any] = {}
 
-    items = [i for i in dictionary.items()]
+    items = list(dictionary.items())
     items.sort(key=lambda x: x[0])
 
     for key, value in items:

--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -174,12 +174,11 @@ def create_pydantic_model(
     )
 
     if include_columns:
-        include_columns_plus_ancestors = [
-            i
-            for i in itertools.chain(
+        include_columns_plus_ancestors = list(
+            itertools.chain(
                 include_columns, *[i._meta.call_chain for i in include_columns]
             )
-        ]
+        )
         piccolo_columns = tuple(
             i
             for i in piccolo_columns


### PR DESCRIPTION
I found out that these cases can be optimized easily:

- `list(dictionary.items())` is much faster than `[i for i in dictionary.items()]`
- `{"key": value}` is much much faster than `dict(key=value)`
- using literals is a faster way of setting up empty data structures. for e.g: `dict() -> {}`, `tuple() -> ()` and so  on.

then I found out this awesome [flake8 plugin](https://github.com/adamchainz/flake8-comprehensions)  and changed them in piccolo's codebase. I'm not sure how much this would benefit the performance but it can't hurt.

sorry about the messed-up commits.