### PR TITLE
add array column support to modelbuilder

### DIFF
--- a/piccolo/testing/model_builder.py
+++ b/piccolo/testing/model_builder.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from uuid import UUID
 
-from piccolo.columns.base import Column
+from piccolo.columns import Array, Column
 from piccolo.table import Table
 from piccolo.testing.random_builder import RandomBuilder
 from piccolo.utils.sync import run_sync
@@ -139,11 +139,18 @@ class ModelBuilder:
             Column class to randomize.
 
         """
+        random_value: t.Any
         if column.value_type == Decimal:
             precision, scale = column._meta.params["digits"]
             random_value = RandomBuilder.next_float(
                 maximum=10 ** (precision - scale), scale=scale
             )
+        elif column.value_type == list:
+            length = RandomBuilder.next_int(maximum=10)
+            base_type = t.cast(Array, column).base_column.value_type
+            random_value = [
+                cls.__DEFAULT_MAPPER[base_type]() for _ in range(length)
+            ]
         elif column._meta.choices:
             random_value = RandomBuilder.next_enum(column._meta.choices)
         else:

--- a/tests/testing/test_model_builder.py
+++ b/tests/testing/test_model_builder.py
@@ -1,6 +1,8 @@
 import asyncio
 import unittest
 
+from piccolo.columns import Array, Boolean, Integer, Varchar
+from piccolo.table import Table
 from piccolo.testing.model_builder import ModelBuilder
 from tests.example_apps.music.tables import (
     Band,
@@ -12,6 +14,12 @@ from tests.example_apps.music.tables import (
     Ticket,
     Venue,
 )
+
+
+class TableWithArrayField(Table):
+    strings = Array(Varchar(30))
+    numbers = Array(Integer())
+    booleans = Array(Boolean())
 
 
 class TestModelBuilder(unittest.TestCase):
@@ -27,12 +35,14 @@ class TestModelBuilder(unittest.TestCase):
             Venue,
             Concert,
             Ticket,
+            TableWithArrayField,
         ):
             table_class.create_table().run_sync()
 
     @classmethod
     def tearDownClass(cls) -> None:
         for table_class in (
+            TableWithArrayField,
             Ticket,
             Concert,
             Venue,
@@ -52,12 +62,14 @@ class TestModelBuilder(unittest.TestCase):
         asyncio.run(build_model(Ticket))
         asyncio.run(build_model(Poster))
         asyncio.run(build_model(RecordingStudio))
+        asyncio.run(build_model(TableWithArrayField))
 
     def test_model_builder_sync(self):
         ModelBuilder.build_sync(Manager)
         ModelBuilder.build_sync(Ticket)
         ModelBuilder.build_sync(Poster)
         ModelBuilder.build_sync(RecordingStudio)
+        ModelBuilder.build_sync(TableWithArrayField)
 
     def test_model_builder_with_choices(self):
         shirt = ModelBuilder.build_sync(Shirt)


### PR DESCRIPTION
i have a model with an array field on it, and the model builder is crashing with the following error:
```python
>           random_value = cls.__DEFAULT_MAPPER[column.value_type]()
E           KeyError: <class 'list'>
```

this change adds basic support for array fields by generating a list of values of the appropriate types.