### PR TITLE
limit GitHub Action workflow duration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
     linters:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         strategy:
             matrix:
                 python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -30,6 +31,7 @@ jobs:
 
     integration:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         strategy:
             matrix:
                 # These tests are slow, so we only run on the latest Python
@@ -76,6 +78,7 @@ jobs:
 
     postgres:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         strategy:
             matrix:
                 python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -131,6 +134,7 @@ jobs:
 
     sqlite:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         strategy:
             matrix:
                 python-version: ["3.7", "3.8", "3.9", "3.10"]


### PR DESCRIPTION
By default a GitHub action workflow will run for 6 hours (!) before getting cancelled.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

Yesterday we had a problem where pip couldn't resolve some dependencies, and got stuck in a loop for over 2 hours.

The problem is, this eats through our allowance of build minutes for the month, so I've set a limit of 30 minutes on each workflow, which should be more than enough for normal operation.