### PR TITLE
fix `ModelBuilder` bug with nullable columns

### DIFF
--- a/piccolo/testing/model_builder.py
+++ b/piccolo/testing/model_builder.py
@@ -94,7 +94,7 @@ class ModelBuilder:
         minimal: bool = False,
         persist: bool = True,
     ) -> Table:
-        model = table_class()
+        model = table_class(ignore_missing=True)
         defaults = {} if not defaults else defaults
 
         for column, value in defaults.items():


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/461

There was a bug with `ModelBuilder` if using columns with `null=False`.