### PR TITLE
Changed occurances "of" contraint in the repository to "constraint"

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -457,7 +457,7 @@ class MigrationManager:
 
                 unique = params.get("unique")
                 if unique is not None:
-                    # When modifying unique contraints, we need to pass in
+                    # When modifying unique constraints, we need to pass in
                     # a column type, and not just the column name.
                     column = Column()
                     column._meta._table = _Table

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -356,7 +356,7 @@ class Column(Selectable):
         The column value to use if not specified by the user.
 
     :param unique:
-        If set, a unique contraint will be added to the column.
+        If set, a unique constraint will be added to the column.
 
     :param index:
         Whether an index is created for the column, which can improve

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -264,7 +264,7 @@ class Alter(DDL):
     __slots__ = (
         "_add_foreign_key_constraint",
         "_add",
-        "_drop_contraint",
+        "_drop_constraint",
         "_drop_default",
         "_drop_table",
         "_drop",
@@ -282,7 +282,7 @@ class Alter(DDL):
         super().__init__(table, **kwargs)
         self._add_foreign_key_constraint: t.List[AddForeignKeyConstraint] = []
         self._add: t.List[AddColumn] = []
-        self._drop_contraint: t.List[DropConstraint] = []
+        self._drop_constraint: t.List[DropConstraint] = []
         self._drop_default: t.List[DropDefault] = []
         self._drop_table: t.Optional[DropTable] = None
         self._drop: t.List[DropColumn] = []
@@ -434,7 +434,7 @@ class Alter(DDL):
         return f"{tablename}_{column_name}_fk"
 
     def drop_constraint(self, constraint_name: str) -> Alter:
-        self._drop_contraint.append(
+        self._drop_constraint.append(
             DropConstraint(constraint_name=constraint_name)
         )
         return self


### PR DESCRIPTION
I saw the typo contraint > constraint in the column documentation, and grepped on the project for other occurrences. There were a few in piccolo/query/methods/alter.py, plus one other occurrence in the docs. I ran the test suite, and it ran without errors after changing the _drop_contraint method and the code that uses it.
