### PR TITLE
prototype Pydantic choice support in `create_pydantic_model`

### DIFF
--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -207,8 +207,10 @@ def create_pydantic_model(
         #######################################################################
         # Work out the column type
 
-        if isinstance(column, (Decimal, Numeric)):
-            value_type: t.Type = pydantic.condecimal(
+        if column._meta.choices:
+            value_type: t.Type = column._meta.choices
+        elif isinstance(column, (Decimal, Numeric)):
+            value_type = pydantic.condecimal(
                 max_digits=column.precision, decimal_places=column.scale
             )
         elif isinstance(column, Varchar):


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/467

Just a prototype at the moment.

If a Piccolo column has choices, we can use the choices `Enum` as the Pydantic type. For example:

```python
class RelationshipType(str, enum.Enum):
    colleague = "colleague"
    friend = "friend"

class Person(Table):
    type = Varchar(choices=RelationshipType)    
```

It would become this Pydantic model:

```python
class PersonModel(BaseModel):
    type: RelationshipType
```

The problem is the JSON schema it generates is quite complex, and Piccolo Admin doesn't currently understand `$ref` values:

<img width="440" alt="Screenshot 2022-03-24 at 10 17 21" src="https://user-images.githubusercontent.com/350976/159901108-99542d31-5baa-4750-9198-12f18b9e524d.png">

So the options are:

 1. Modify Piccolo Admin so it understands `$ref`
 2. Start work on https://github.com/piccolo-orm/piccolo/issues/331, which would add a new API for creating Pydantic models. `create_pydantic_model` will still be supported, and used by Piccolo admin for now, but we can migrate to this new API at a later date.


