### PR TITLE
add `html_short_title` to Sphinx `conf.py`

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -61,6 +61,7 @@ autoclass_content = "both"
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = "piccolo_theme"
+html_short_title = "Piccolo"
 html_show_sphinx = False
 globaltoc_maxdepth = 3
 


### PR DESCRIPTION
In the docs, the title shown in the nav bar was the full project name and version - it just needs to be `Piccolo`.

<img width="355" alt="Screenshot 2022-03-24 at 11 14 17" src="https://user-images.githubusercontent.com/350976/159904738-1b5d4b06-bc7f-4e91-8cb1-52d12b355ebb.png">
 