### PR TITLE
Doc improvements

### DIFF
--- a/docs/src/piccolo/authentication/baseuser.rst
+++ b/docs/src/piccolo/authentication/baseuser.rst
@@ -65,7 +65,7 @@ For example:
 
     piccolo user change_permissions some_user --active=true
 
-The Piccolo Admin (see :ref:`Ecosystem`) uses these attributes to control who
+The :ref:`Piccolo Admin<PiccoloAdmin>` uses these attributes to control who
 can login and what they can do.
 
 * **active** and **admin** - must be true for a user to be able to login.

--- a/docs/src/piccolo/authentication/baseuser.rst
+++ b/docs/src/piccolo/authentication/baseuser.rst
@@ -70,7 +70,7 @@ can login and what they can do.
 
 * **active** and **admin** - must be true for a user to be able to login.
 * **superuser** - must be true for a user to be able to change other user's
-   passwords.
+  passwords.
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/authentication/baseuser.rst
+++ b/docs/src/piccolo/authentication/baseuser.rst
@@ -172,3 +172,4 @@ Source
 
 .. autoclass:: BaseUser
     :members: create_user, create_user_sync, login, login_sync, update_password, update_password_sync
+    :class-doc-from: class

--- a/docs/src/piccolo/projects_and_apps/piccolo_projects.rst
+++ b/docs/src/piccolo/projects_and_apps/piccolo_projects.rst
@@ -87,8 +87,7 @@ Here's an example:
 DB
 --
 
-The DB setting is an ``Engine`` instance. To learn more Engines, see
-:ref:`Engines`.
+The DB setting is an ``Engine`` instance (see the :ref:`Engine docs <Engines>`).
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/query_clauses/output.rst
+++ b/docs/src/piccolo/query_clauses/output.rst
@@ -59,8 +59,8 @@ Select and Objects queries
 load_json
 ~~~~~~~~~
 
-If querying JSON or JSONB columns, you can tell Piccolo to deserialise the JSON
-values automatically.
+If querying :class:`JSON <piccolo.columns.column_types.JSON>` or :class:`JSONB <piccolo.columns.column_types.JSONB>`
+columns, you can tell Piccolo to deserialise the JSON values automatically.
 
 .. code-block:: python
 

--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -30,11 +30,12 @@ Equal / Not Equal
         Band.name != 'Rustaceans'
     )
 
-.. hint:: With ``Boolean`` columns, some linters will complain if you write
-    ``SomeTable.some_column == True`` (because it's more Pythonic to do
-    ``is True``). To work around this, you can do
-    ``SomeTable.some_column.eq(True)``. Likewise, with ``!=`` you can use
-    ``SomeTable.some_column.ne(True)``
+.. hint:: With :class:`Boolean <piccolo.columns.column_types.Boolean>` columns,
+   some linters will complain if you write
+   ``SomeTable.some_column == True`` (because it's more Pythonic to do
+   ``is True``). To work around this, you can do
+   ``SomeTable.some_column.eq(True)``. Likewise, with ``!=`` you can use
+   ``SomeTable.some_column.ne(True)``
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -116,7 +116,7 @@ is_null / is_not_null
 ---------------------
 
 These queries work, but some linters will complain about doing a comparison
-with None:
+with ``None``:
 
 .. code-block:: python
 

--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -107,8 +107,9 @@ Fetching related objects
 get_related
 ~~~~~~~~~~~
 
-If you have an object from a table with a ``ForeignKey`` column, and you want
-to fetch the related row as an object, you can do so using ``get_related``.
+If you have an object from a table with a :class:`ForeignKey <piccolo.columns.column_types.ForeignKey>`
+column, and you want to fetch the related row as an object, you can do so
+using ``get_related``.
 
 .. code-block:: python
 
@@ -126,8 +127,8 @@ Prefetching related objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also prefetch the rows from related tables, and store them as child
-objects. To do this, pass ``ForeignKey`` columns into ``objects``, which
-refer to the related rows you want to load.
+objects. To do this, pass :class:`ForeignKey <piccolo.columns.column_types.ForeignKey>`
+columns into ``objects``, which refer to the related rows you want to load.
 
 .. code-block:: python
 
@@ -166,8 +167,9 @@ database, just as you would expect:
     ticket.concert.band_1.name = 'Pythonistas 2'
     await ticket.concert.band_1.save()
 
-Instead of passing the ``ForeignKey`` columns into the ``objects`` method, you
-can use the ``prefetch`` clause if you prefer.
+Instead of passing the :class:`ForeignKey <piccolo.columns.column_types.ForeignKey>`
+columns into the ``objects`` method, you can use the ``prefetch`` clause if you
+prefer.
 
 .. code-block:: python
 

--- a/docs/src/piccolo/query_types/select.rst
+++ b/docs/src/piccolo/query_types/select.rst
@@ -235,7 +235,10 @@ You also can have multiple different aggregate functions in one query:
 .. code-block:: python
 
     >>> from piccolo.query import Avg, Sum
-    >>> response = await Band.select(Avg(Band.popularity), Sum(Band.popularity)).first()
+    >>> response = await Band.select(
+    ...     Avg(Band.popularity),
+    ...     Sum(Band.popularity)
+    ... ).first()
     >>> response
     {"avg": 750.0, "sum": 1500}
 
@@ -244,7 +247,9 @@ And can use aliases for aggregate functions like this:
 .. code-block:: python
 
     # Alternatively, you can use the `as_alias` method.
-    >>> response = await Band.select(Avg(Band.popularity).as_alias("popularity_avg")).first()
+    >>> response = await Band.select(
+    ...     Avg(Band.popularity).as_alias("popularity_avg")
+    ... ).first()
     >>> response["popularity_avg"]
     750.0
 

--- a/docs/src/piccolo/schema/advanced.rst
+++ b/docs/src/piccolo/schema/advanced.rst
@@ -89,7 +89,7 @@ use mixins to reduce the amount of repetition.
 Choices
 -------
 
-You can specify choices for a column, using Python's ``Enum`` support.
+You can specify choices for a column, using Python's :class:`Enum <enum.Enum>` support.
 
 .. code-block:: python
 

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -2132,6 +2132,28 @@ class Blob(Bytea):
 ###############################################################################
 
 
+class List:
+    """
+    This is a hack. Sphinx's autodoc fails if we have this function signature::
+
+        class Array(Column):
+
+            def __init__(default=list):
+                ...
+
+    We can't use ``list`` as a default value without breaking autodoc, so
+    instead we assign an instance of this class, which effectively acts like
+    the builtin ``list`` function, without breaking autodoc.
+
+    """
+
+    def __call__(self):
+        return []
+
+    def __repr__(self):
+        return "list"
+
+
 class Array(Column):
     """
     Used for storing lists of data.
@@ -2157,7 +2179,7 @@ class Array(Column):
     def __init__(
         self,
         base_column: Column,
-        default: t.Union[t.List, Enum, t.Callable[[], t.List], None] = list,
+        default: t.Union[t.List, Enum, t.Callable[[], t.List], None] = List(),
         **kwargs,
     ) -> None:
         if isinstance(base_column, ForeignKey):

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -2188,9 +2188,7 @@ class Array(Column):
         """
         Allows queries which retrieve an item from the array. The index starts
         with 0 for the first value. If you were to write the SQL by hand, the
-        first index would be 1 instead:
-
-        https://www.postgresql.org/docs/current/arrays.html
+        first index would be 1 instead (see `Postgres docs <https://www.postgresql.org/docs/current/arrays.html>`_).
 
         However, we keep the first index as 0 to fit better with Python.
 
@@ -2202,7 +2200,7 @@ class Array(Column):
             {'seat_numbers': 325}
 
 
-        """
+        """  # noqa: E501
         engine_type = self._meta.table._meta.db.engine_type
         if engine_type != "postgres":
             raise ValueError(

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -188,7 +188,6 @@ class AppConfig:
         return filtered[0]
 
 
-@dataclass
 class AppRegistry:
     """
     Records all of the Piccolo apps in your project. Kept in
@@ -199,9 +198,8 @@ class AppRegistry:
 
     """
 
-    apps: t.List[str] = field(default_factory=list)
-
-    def __post_init__(self):
+    def __init__(self, apps: t.List[str] = None):
+        self.apps = apps or []
         self.app_configs: t.Dict[str, AppConfig] = {}
         app_names = []
 
@@ -214,7 +212,7 @@ class AppRegistry:
                     raise e from e
                 app += ".piccolo_app"
                 app_conf_module = import_module(app)
-                app_config: AppConfig = getattr(app_conf_module, "APP_CONFIG")
+                app_config = getattr(app_conf_module, "APP_CONFIG")
                 colored_warning(
                     f"App {app[:-12]} should end with `.piccolo_app`",
                     level=Level.medium,

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -214,9 +214,8 @@ class PostgresEngine(Engine):
 
         For example, ``{'host': 'localhost', 'port': 5432}``.
 
-        To see all available options:
-
-        * https://magicstack.github.io/asyncpg/current/api/index.html#connection
+        See the `asyncpg docs <https://magicstack.github.io/asyncpg/current/api/index.html#connection>`_
+        for all available options.
 
     :param extensions:
         When the engine starts, it will try and create these extensions

--- a/piccolo/engine/sqlite.py
+++ b/piccolo/engine/sqlite.py
@@ -344,10 +344,10 @@ class SQLiteEngine(Engine):
     """
     Any connection kwargs are passed into the database adapter.
 
-    See here for more info:
-    https://docs.python.org/3/library/sqlite3.html#sqlite3.connect
+    See the `SQLite docs <https://docs.python.org/3/library/sqlite3.html#sqlite3.connect>`_
+    for more info.
 
-    """
+    """  # noqa: E501
 
     __slots__ = ("connection_kwargs", "transaction_connection")
 


### PR DESCRIPTION
Fixing this broken autodoc snippet:

<img width="702" alt="Screenshot 2022-03-25 at 20 19 39" src="https://user-images.githubusercontent.com/350976/160195284-c50ff4c5-017c-4ee5-b353-05c8b9b806aa.png">

Prettifying raw links like this:

<img width="698" alt="Screenshot 2022-03-25 at 20 20 15" src="https://user-images.githubusercontent.com/350976/160195349-2aa02458-7b5d-442e-a1d6-5388958a3831.png">

Using `:class` more extensively, to link to autodoc.

And lots of other little documentation improvements.