### PR TITLE
`AppConfig` now accepts `pathlib.Path` arguments

### DIFF
--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import itertools
 import os
+import pathlib
 import traceback
 import typing as t
 from dataclasses import dataclass, field
@@ -154,6 +155,9 @@ class AppConfig:
         self.commands = [
             i if isinstance(i, Command) else Command(i) for i in self.commands
         ]
+
+        if isinstance(self.migrations_folder_path, pathlib.Path):
+            self.migrations_folder_path = str(self.migrations_folder_path)
 
     def register_table(self, table_class: t.Type[Table]):
         self.table_classes.append(table_class)

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,10 +1,10 @@
-black==22.1.0
+black==22.3.0
 ipdb==0.13.9
 ipython>=7.31.1
 flake8==4.0.1
 isort==5.10.1
-slotscheck==0.12.0
-twine==3.7.1
-mypy==0.931
+slotscheck==0.14.0
+twine==3.8.0
+mypy==0.942
 pip-upgrader==1.4.15
 wheel==0.37.1

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest import TestCase
 
 from piccolo.apps.user.tables import BaseUser
@@ -73,11 +74,21 @@ class TestAppRegistry(TestCase):
 
 
 class TestAppConfig(TestCase):
+    def test_pathlib(self):
+        """
+        Make sure a ``pathlib.Path`` instance can be passed in as a
+        ``migrations_folder_path`` argument.
+        """
+        config = AppConfig(
+            app_name="music", migrations_folder_path=pathlib.Path(__file__)
+        )
+        self.assertEqual(config.migrations_folder_path, __file__)
+
     def test_get_table_with_name(self):
         """
         Register a table, then test retrieving it.
         """
-        config = AppConfig(app_name="Music", migrations_folder_path="")
+        config = AppConfig(app_name="music", migrations_folder_path="")
         config.register_table(table_class=Manager)
         self.assertEqual(config.get_table_with_name("Manager"), Manager)
 


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/discussions/471

You can now pass in a `pathlib.Path` argument instead of a string if you prefer:

```python
import pathlib

APP_CONFIG = AppConfig(
    app_name="blog",
    migrations_folder_path=pathlib.Path(__file__) /  "piccolo_migrations"
)
```