### PR TITLE
`Array` default improvements

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -2132,7 +2132,7 @@ class Blob(Bytea):
 ###############################################################################
 
 
-class List:
+class ListProxy:
     """
     Sphinx's autodoc fails if we have this function signature::
 
@@ -2179,7 +2179,9 @@ class Array(Column):
     def __init__(
         self,
         base_column: Column,
-        default: t.Union[t.List, Enum, t.Callable[[], t.List], None] = List(),
+        default: t.Union[
+            t.List, Enum, t.Callable[[], t.List], None
+        ] = ListProxy(),
         **kwargs,
     ) -> None:
         if isinstance(base_column, ForeignKey):
@@ -2187,7 +2189,7 @@ class Array(Column):
 
         # This is a workaround because having `list` as a default breaks
         # Sphinx's autodoc.
-        if isinstance(default, List):
+        if isinstance(default, ListProxy):
             default = list
 
         self._validate_default(default, (list, None))

--- a/tests/columns/test_array.py
+++ b/tests/columns/test_array.py
@@ -9,6 +9,17 @@ class MyTable(Table):
     value = Array(base_column=Integer())
 
 
+class TestArrayDefault(TestCase):
+    def test_array_default(self):
+        """
+        We use ``ListProxy`` instead of ``list`` as a default, because of
+        issues with Sphinx's autodoc. Make sure it's correctly converted to a
+        plain ``list`` in ``Array.__init__``.
+        """
+        column = Array(base_column=Integer())
+        self.assertTrue(column.default is list)
+
+
 class TestArrayPostgres(TestCase):
     """
     Make sure an Array column can be created.


### PR DESCRIPTION
 * Renamed `List` to `ListProxy` to avoid confusion with `typing.List`
 * Swap out `ListProxy` for `list` in `Array.__init__`.
