### PR TITLE
bump targ version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 black
 colorama>=0.4.0
 Jinja2>=2.11.0
-targ>=0.3.3
+targ>=0.3.7
 inflection>=0.5.1
 typing-extensions>=3.10.0.0
 pydantic>=1.6


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/479

This new version of targ makes it more obvious that `--trace` can be passed in on the command line for a full stack trace when a command raises an exception.