### PR TITLE
prototype for multiple engines

### DIFF
--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -231,12 +231,12 @@ class PostgresEngine(Engine):
         to a ``PostgresEngine`` instance. For example::
 
             DB = PostgresEngine(
-                config={'database': 'main_db}:
+                config={'database': 'main_db},
                 extra_nodes={
                     'read_replica_1': PostgresEngine(
                         config={
                             'database': 'main_db',
-                            host="read_replicate.my_db.com"
+                            host: 'read_replicate.my_db.com'
                         }
                     )
                 }

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -231,7 +231,7 @@ class PostgresEngine(Engine):
         to a ``PostgresEngine`` instance. For example::
 
             DB = PostgresEngine(
-                config={'database': 'main_db},
+                config={'database': 'main_db'},
                 extra_nodes={
                     'read_replica_1': PostgresEngine(
                         config={

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -222,8 +222,30 @@ class PostgresEngine(Engine):
         in Postgres.
 
     :param log_queries:
-        If True, all SQL and DDL statements are printed out before being run.
-        Useful for debugging.
+        If ``True``, all SQL and DDL statements are printed out before being
+        run. Useful for debugging.
+
+    :param extra_nodes:
+        If you have additional database nodes (e.g. read replicas) for the
+        server, you can specify them here. It's a mapping of a memorable name
+        to a ``PostgresEngine`` instance. For example::
+
+            DB = PostgresEngine(
+                config={'database': 'main_db}:
+                extra_nodes={
+                    'read_replica_1': PostgresEngine(
+                        config={
+                            'database': 'main_db',
+                            host="read_replicate.my_db.com"
+                        }
+                    )
+                }
+            )
+
+        When executing a query, you can specify one of these nodes instead
+        of the main database. For example::
+
+            >>> await MyTable.select().run(node="read_replica_1")
 
     """  # noqa: E501
 
@@ -231,6 +253,7 @@ class PostgresEngine(Engine):
         "config",
         "extensions",
         "log_queries",
+        "extra_nodes",
         "pool",
         "transaction_connection",
     )
@@ -243,12 +266,17 @@ class PostgresEngine(Engine):
         config: t.Dict[str, t.Any],
         extensions: t.Sequence[str] = None,
         log_queries: bool = False,
+        extra_nodes: t.Dict[str, PostgresEngine] = None,
     ) -> None:
         if extensions is None:
             extensions = ["uuid-ossp"]
+        if extra_nodes is None:
+            extra_nodes = {}
+
         self.config = config
         self.extensions = extensions
         self.log_queries = log_queries
+        self.extra_nodes = extra_nodes
         self.pool: t.Optional[Pool] = None
         database_name = config.get("database", "Unknown")
         self.transaction_connection = contextvars.ContextVar(

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -193,7 +193,7 @@ class Query:
             from piccolo.engine.postgres import PostgresEngine
 
             if isinstance(engine, PostgresEngine):
-                engine = engine.extra_nodes["node"]
+                engine = engine.extra_nodes[node]
 
         querystrings = self.querystrings
 

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -167,15 +167,33 @@ class Query:
         """
         return self.run().__await__()
 
-    async def run(self, in_pool=True):
+    async def run(self, node: t.Optional[str] = None, in_pool: bool = True):
+        """
+        Run the query on the database.
+
+        :param node:
+            If specified, run this query against another database node. Only
+            available in Postgres. See :class:`PostgresEngine <piccolo.engine.postgres.PostgresEngine>`.
+        :param in_pool:
+            Whether to run this in a connection pool if one is running. This is
+            mostly just for debugging - use a connection pool where possible.
+
+        """  # noqa: E501
         self._validate()
 
         engine = self.table._meta.db
+
         if not engine:
             raise ValueError(
                 f"Table {self.table._meta.tablename} has no db defined in "
                 "_meta"
             )
+
+        if node is not None:
+            from piccolo.engine.postgres import PostgresEngine
+
+            if isinstance(engine, PostgresEngine):
+                engine = engine.extra_nodes["node"]
 
         querystrings = self.querystrings
 
@@ -186,7 +204,6 @@ class Query:
             return await self._process_results(results)
         else:
             responses = []
-            # TODO - run in a transaction
             for querystring in querystrings:
                 results = await engine.run_querystring(
                     querystring, in_pool=in_pool
@@ -197,8 +214,13 @@ class Query:
     def run_sync(self, timed=False, *args, **kwargs):
         """
         A convenience method for running the coroutine synchronously.
+
+        :param timed:
+            If ``True``, the time taken to run the query is printed out. Useful
+            for debugging.
+
         """
-        coroutine = self.run(*args, **kwargs, in_pool=False)
+        coroutine = self.run(*args, **kwargs)
 
         if not timed:
             return run_sync(coroutine)

--- a/tests/engine/test_extra_nodes.py
+++ b/tests/engine/test_extra_nodes.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from piccolo.columns.column_types import Varchar
+from piccolo.engine.postgres import PostgresEngine
+from piccolo.table import Table
+from tests.base import AsyncMock, postgres_only
+
+
+@postgres_only
+class TestExtraNodes(TestCase):
+    def test_extra_nodes(self):
+        """
+        Make sure that other nodes can be queried.
+        """
+        EXTRA_NODE = MagicMock(spec=PostgresEngine(config={}))
+        EXTRA_NODE.run_querystring = AsyncMock(return_value=[])
+
+        DB = PostgresEngine(config={}, extra_nodes={"read_1": EXTRA_NODE})
+
+        class Manager(Table, db=DB):
+            name = Varchar()
+
+        # Make sure the node is queried
+        Manager.select().run_sync(node="read_1")
+        self.assertTrue(EXTRA_NODE.run_querystring.called)
+
+        # Make sure that a non existent node raises an error
+        with self.assertRaises(KeyError):
+            Manager.select().run_sync(node="read_2")

--- a/tests/engine/test_extra_nodes.py
+++ b/tests/engine/test_extra_nodes.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 
 from piccolo.columns.column_types import Varchar
+from piccolo.engine import engine_finder
 from piccolo.engine.postgres import PostgresEngine
 from piccolo.table import Table
 from tests.base import AsyncMock, postgres_only
@@ -13,10 +14,15 @@ class TestExtraNodes(TestCase):
         """
         Make sure that other nodes can be queried.
         """
-        EXTRA_NODE = MagicMock(spec=PostgresEngine(config={}))
+        # Get the test database credentials:
+        test_engine = engine_finder()
+
+        EXTRA_NODE = MagicMock(spec=PostgresEngine(config=test_engine.config))
         EXTRA_NODE.run_querystring = AsyncMock(return_value=[])
 
-        DB = PostgresEngine(config={}, extra_nodes={"read_1": EXTRA_NODE})
+        DB = PostgresEngine(
+            config=test_engine.config, extra_nodes={"read_1": EXTRA_NODE}
+        )
 
         class Manager(Table, db=DB):
             name = Varchar()


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/142

You can now specify extra nodes for a database. For example, if you have a read replica.

```python
DB = PostgresEngine(
    config={'database': 'main_db'},
    extra_nodes={
        'read_replica_1': PostgresEngine(
            config={
                'database': 'main_db',
                'host': 'read_replica_1.my_db.com'
            }
        )
    }
)
```

And can then run queries on these other nodes using:

```python
await MyTable.select().run(node="read_replica_1")
```