### PR TITLE
Add operator support to `Timestamp` updates

### DIFF
--- a/docs/src/piccolo/query_types/update.rst
+++ b/docs/src/piccolo/query_types/update.rst
@@ -1,3 +1,4 @@
+
 .. _Update:
 
 Update
@@ -149,6 +150,45 @@ Likewise, we can decrease the values by 1 day:
             Concert.starts: Concert.starts - datetime.timedelta(days=1)
         },
         force=True
+    )
+
+What about null values?
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If we have a table with a nullable column:
+
+.. code-block:: python
+
+    class Band(Table):
+        name = Varchar(null=True)
+
+Any rows with a value of null aren't modified by an update:
+
+.. code-block:: python
+
+    >>> await Band.insert(Band(name="Pythonistas"), Band(name=None))
+    >>> await Band.update(
+    ...     {
+    ...         Band.name: Band.name + '!!!'
+    ...     },
+    ...     force=True
+    ... )
+    >>> await Band.select()
+    # Note how the second row's name value is still `None`:
+    [{'id': 1, 'name': 'Pythonistas!!!'}, {'id': 2, 'name': None}]
+
+It's more efficient to exclude any rows with a value of null using a
+:ref:`where clause <where>`:
+
+.. code-block:: python
+
+    await Band.update(
+        {
+            Band.name + '!!!'
+        },
+        force=True
+    ).where(
+        Band.name.is_not_null()
     )
 
 -------------------------------------------------------------------------------

--- a/docs/src/piccolo/query_types/update.rst
+++ b/docs/src/piccolo/query_types/update.rst
@@ -19,9 +19,9 @@ This is used to update any rows in the table which match the criteria.
 force
 -----
 
-Piccolo won't let you run an update query without a where clause, unless you
-explicitly tell it to do so. This is to prevent accidentally overwriting
-the data in a table.
+Piccolo won't let you run an update query without a :ref:`where clause <where>`,
+unless you explicitly tell it to do so. This is to prevent accidentally
+overwriting the data in a table.
 
 .. code-block:: python
 
@@ -31,13 +31,18 @@ the data in a table.
     # Works fine:
     >>> await Band.update({Band.popularity: 0}, force=True)
 
+    # Or just add a where clause:
+    >>> await Band.update({Band.popularity: 0}).where(Band.popularity < 50)
+
 -------------------------------------------------------------------------------
 
 Modifying values
 ----------------
 
-As well as replacing values with new ones, you can also modify existing values, for
-instance by adding to an integer.
+As well as replacing values with new ones, you can also modify existing values,
+for instance by adding an integer.
+
+You can currently only combine two values together at a time.
 
 Integer columns
 ~~~~~~~~~~~~~~~
@@ -47,29 +52,44 @@ You can add / subtract / multiply / divide values:
 .. code-block:: python
 
     # Add 100 to the popularity of each band:
-    await Band.update({
-        Band.popularity: Band.popularity + 100
-    })
+    await Band.update(
+        {
+            Band.popularity: Band.popularity + 100
+        },
+        force=True
+    )
 
     # Decrease the popularity of each band by 100.
-    await Band.update({
-        Band.popularity: Band.popularity - 100
-    })
+    await Band.update(
+        {
+            Band.popularity: Band.popularity - 100
+        },
+        force=True
+    )
 
     # Multiply the popularity of each band by 10.
-    await Band.update({
-        Band.popularity: Band.popularity * 10
-    })
+    await Band.update(
+        {
+            Band.popularity: Band.popularity * 10
+        },
+        force=True
+    )
 
     # Divide the popularity of each band by 10.
-    await Band.update({
-        Band.popularity: Band.popularity / 10
-    })
+    await Band.update(
+        {
+            Band.popularity: Band.popularity / 10
+        },
+        force=True
+    )
 
     # You can also use the operators in reverse:
-    await Band.update({
-        Band.popularity: 2000 - Band.popularity
-    })
+    await Band.update(
+        {
+            Band.popularity: 2000 - Band.popularity
+        },
+        force=True
+    )
 
 Varchar / Text columns
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -79,22 +99,57 @@ You can concatenate values:
 .. code-block:: python
 
     # Append "!!!" to each band name.
-    await Band.update({
-        Band.name: Band.name + "!!!"
-    })
+    await Band.update(
+        {
+            Band.name: Band.name + "!!!"
+        },
+        force=True
+    )
 
     # Concatenate the values in each column:
-    await Band.update({
-        Band.name: Band.name + Band.name
-    })
+    await Band.update(
+        {
+            Band.name: Band.name + Band.name
+        },
+        force=True
+    )
 
     # Prepend "!!!" to each band name.
-    await Band.update({
-        Band.popularity: "!!!" + Band.popularity
-    })
+    await Band.update(
+        {
+            Band.popularity: "!!!" + Band.popularity
+        },
+        force=True
+    )
 
+Date / Timestamp / Timestamptz / Interval columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can currently only combine two values together at a time.
+You can add or substract a :class:`timedelta <datetime.timedelta>` to any of
+these columns.
+
+For example, if we have a ``Concert`` table, and we want each concert to start
+one day later, we can simply do this:
+
+.. code-block:: python
+
+    await Concert.update(
+        {
+            Concert.starts: Concert.starts + datetime.timedelta(days=1)
+        },
+        force=True
+    )
+
+Likewise, we can decrease the values by 1 day:
+
+.. code-block:: python
+
+    await Concert.update(
+        {
+            Concert.starts: Concert.starts - datetime.timedelta(days=1)
+        },
+        force=True
+    )
 
 -------------------------------------------------------------------------------
 
@@ -106,11 +161,11 @@ you prefer:
 
 .. code-block:: python
 
-    >>> await Band.update(
-    ...     name='Pythonistas 2'
-    ... ).where(
-    ...     Band.name == 'Pythonistas'
-    ... )
+    await Band.update(
+        name='Pythonistas 2'
+    ).where(
+        Band.name == 'Pythonistas'
+    )
 
 -------------------------------------------------------------------------------
 

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -35,6 +35,8 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 
+from typing_extensions import Literal
+
 from piccolo.columns.base import Column, ForeignKeyMeta, OnDelete, OnUpdate
 from piccolo.columns.combination import Where
 from piccolo.columns.defaults.date import DateArg, DateCustom, DateNow
@@ -132,7 +134,7 @@ class MathDelegate:
     def get_querystring(
         self,
         column_name: str,
-        operator: t.Literal["+", "-", "/", "*"],
+        operator: Literal["+", "-", "/", "*"],
         value: t.Union[int, float, Integer],
         reverse: bool = False,
     ) -> QueryString:

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -197,7 +197,7 @@ class TimedeltaDelegate:
         if isinstance(value, timedelta):
             value_string = self.get_interval_string(interval=value)
             return QueryString(
-                f'"{column_name}" {operator} INTERVAL \'{value_string}\'',
+                f"\"{column_name}\" {operator} INTERVAL '{value_string}'",
             )
         else:
             raise ValueError("Only timedelta values can be added.")

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -169,10 +169,13 @@ class TimedeltaDelegate:
 
     Example::
 
+        class Concert(Table):
+            starts = Timestamp()
+
         # Lets us increase all of the matching values by 1 day:
-        await Concert.update({
-            Concert.starts: Concert.starts + datetime.timedelta(days=1)
-        })
+        >>> await Concert.update({
+        ...     Concert.starts: Concert.starts + datetime.timedelta(days=1)
+        ... })
 
     """
 
@@ -251,6 +254,9 @@ class Varchar(Column):
     @property
     def column_type(self):
         return f"VARCHAR({self.length})" if self.length else "VARCHAR"
+
+    ###########################################################################
+    # For update queries
 
     def __add__(self, value: t.Union[str, Varchar, Text]) -> QueryString:
         engine_type = self._meta.table._meta.db.engine_type
@@ -348,6 +354,9 @@ class Text(Column):
         self.default = default
         kwargs.update({"default": default})
         super().__init__(**kwargs)
+
+    ###########################################################################
+    # For update queries
 
     def __add__(self, value: t.Union[str, Varchar, Text]) -> QueryString:
         engine_type = self._meta.table._meta.db.engine_type
@@ -480,6 +489,9 @@ class Integer(Column):
         self.default = default
         kwargs.update({"default": default})
         super().__init__(**kwargs)
+
+    ###########################################################################
+    # For update queries
 
     def __add__(self, value: t.Union[int, float, Integer]) -> QueryString:
         return self.math_delegate.get_querystring(
@@ -810,7 +822,7 @@ class Timestamp(Column):
     """
 
     value_type = datetime
-    timedelta_delta = TimedeltaDelegate()
+    timedelta_delegate = TimedeltaDelegate()
 
     def __init__(
         self, default: TimestampArg = TimestampNow(), **kwargs
@@ -832,8 +844,11 @@ class Timestamp(Column):
         kwargs.update({"default": default})
         super().__init__(**kwargs)
 
+    ###########################################################################
+    # For update queries
+
     def __add__(self, value: timedelta) -> QueryString:
-        return self.timedelta_delta.get_querystring(
+        return self.timedelta_delegate.get_querystring(
             column_name=self._meta.db_column_name, operator="+", value=value
         )
 
@@ -841,7 +856,7 @@ class Timestamp(Column):
         return self.__add__(value)
 
     def __sub__(self, value: timedelta) -> QueryString:
-        return self.timedelta_delta.get_querystring(
+        return self.timedelta_delegate.get_querystring(
             column_name=self._meta.db_column_name, operator="-", value=value
         )
 
@@ -896,6 +911,7 @@ class Timestamptz(Column):
     """
 
     value_type = datetime
+    timedelta_delegate = TimedeltaDelegate()
 
     def __init__(
         self, default: TimestamptzArg = TimestamptzNow(), **kwargs
@@ -913,6 +929,22 @@ class Timestamptz(Column):
         self.default = default
         kwargs.update({"default": default})
         super().__init__(**kwargs)
+
+    ###########################################################################
+    # For update queries
+
+    def __add__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="+", value=value
+        )
+
+    def __radd__(self, value: timedelta) -> QueryString:
+        return self.__add__(value)
+
+    def __sub__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="-", value=value
+        )
 
     ###########################################################################
     # Descriptors
@@ -957,6 +989,7 @@ class Date(Column):
     """
 
     value_type = date
+    timedelta_delegate = TimedeltaDelegate()
 
     def __init__(self, default: DateArg = DateNow(), **kwargs) -> None:
         self._validate_default(default, DateArg.__args__)  # type: ignore
@@ -970,6 +1003,22 @@ class Date(Column):
         self.default = default
         kwargs.update({"default": default})
         super().__init__(**kwargs)
+
+    ###########################################################################
+    # For update queries
+
+    def __add__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="+", value=value
+        )
+
+    def __radd__(self, value: timedelta) -> QueryString:
+        return self.__add__(value)
+
+    def __sub__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="-", value=value
+        )
 
     ###########################################################################
     # Descriptors
@@ -1014,6 +1063,7 @@ class Time(Column):
     """
 
     value_type = time
+    timedelta_delegate = TimedeltaDelegate()
 
     def __init__(self, default: TimeArg = TimeNow(), **kwargs) -> None:
         self._validate_default(default, TimeArg.__args__)  # type: ignore
@@ -1024,6 +1074,22 @@ class Time(Column):
         self.default = default
         kwargs.update({"default": default})
         super().__init__(**kwargs)
+
+    ###########################################################################
+    # For update queries
+
+    def __add__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="+", value=value
+        )
+
+    def __radd__(self, value: timedelta) -> QueryString:
+        return self.__add__(value)
+
+    def __sub__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="-", value=value
+        )
 
     ###########################################################################
     # Descriptors
@@ -1068,6 +1134,7 @@ class Interval(Column):  # lgtm [py/missing-equals]
     """
 
     value_type = timedelta
+    timedelta_delegate = TimedeltaDelegate()
 
     def __init__(
         self, default: IntervalArg = IntervalCustom(), **kwargs
@@ -1092,6 +1159,22 @@ class Interval(Column):  # lgtm [py/missing-equals]
             # https://sqlite.org/datatype3.html#determination_of_column_affinity
             return "SECONDS"
         raise Exception("Unrecognized engine type")
+
+    ###########################################################################
+    # For update queries
+
+    def __add__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="+", value=value
+        )
+
+    def __radd__(self, value: timedelta) -> QueryString:
+        return self.__add__(value)
+
+    def __sub__(self, value: timedelta) -> QueryString:
+        return self.timedelta_delegate.get_querystring(
+            column_name=self._meta.db_column_name, operator="-", value=value
+        )
 
     ###########################################################################
     # Descriptors

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -837,6 +837,9 @@ class Timestamp(Column):
             column_name=self._meta.db_column_name, operator="+", value=value
         )
 
+    def __radd__(self, value: timedelta) -> QueryString:
+        return self.__add__(value)
+
     def __sub__(self, value: timedelta) -> QueryString:
         return self.timedelta_delta.get_querystring(
             column_name=self._meta.db_column_name, operator="-", value=value

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -194,7 +194,7 @@ class TimedeltaDelegate:
         return " ".join(output)
 
     def get_querystring(
-        self, column_name: str, operator: t.Literal["+", "-"], value: timedelta
+        self, column_name: str, operator: Literal["+", "-"], value: timedelta
     ) -> QueryString:
         if isinstance(value, timedelta):
             value_string = self.get_interval_string(interval=value)

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -188,6 +188,13 @@ class TimedeltaDelegate:
     }
 
     def get_postgres_interval_string(self, interval: timedelta) -> str:
+        """
+        :returns:
+            A string like::
+
+                "'1 DAYS 5 SECONDS 1000 MICROSECONDS'"
+
+        """
         output = []
         for timedelta_key, postgres_name in self.postgres_attr_map.items():
             timestamp_value = getattr(interval, timedelta_key)
@@ -198,6 +205,13 @@ class TimedeltaDelegate:
         return f"'{output_string}'"
 
     def get_sqlite_interval_string(self, interval: timedelta) -> str:
+        """
+        :returns:
+            A string like::
+
+                "'+1 DAYS', '+5.001 SECONDS'"
+
+        """
         output = []
 
         data = {

--- a/piccolo/columns/operators/__init__.py
+++ b/piccolo/columns/operators/__init__.py
@@ -16,4 +16,4 @@ from .comparison import (
     NotLike,
 )
 from .math import Add, Divide, Multiply, Subtract
-from .string import ConcatPostgres, ConcatSQLite
+from .string import Concat

--- a/piccolo/columns/operators/string.py
+++ b/piccolo/columns/operators/string.py
@@ -5,9 +5,5 @@ class StringOperator(Operator):
     pass
 
 
-class ConcatPostgres(StringOperator):
-    template = "CONCAT({value_1}, {value_2})"
-
-
-class ConcatSQLite(StringOperator):
+class Concat(StringOperator):
     template = "{value_1} || {value_2}"

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,12 +15,21 @@ from piccolo.table import Table, create_table_class
 
 ENGINE = engine_finder()
 
+
+def is_running_postgres():
+    return isinstance(ENGINE, PostgresEngine)
+
+
+def is_running_sqlite():
+    return isinstance(ENGINE, SQLiteEngine)
+
+
 postgres_only = pytest.mark.skipif(
-    not isinstance(ENGINE, PostgresEngine), reason="Only running for Postgres"
+    not is_running_postgres(), reason="Only running for Postgres"
 )
 
 sqlite_only = pytest.mark.skipif(
-    not isinstance(ENGINE, SQLiteEngine), reason="Only running for SQLite"
+    not is_running_sqlite(), reason="Only running for SQLite"
 )
 
 unix_only = pytest.mark.skipif(

--- a/tests/columns/test_varchar.py
+++ b/tests/columns/test_varchar.py
@@ -17,7 +17,7 @@ class TestVarchar(TestCase):
 
     https://www.sqlite.org/faq.html#q9
 
-    Might consider enforncing this at the ORM level instead in the future.
+    Might consider enforcing this at the ORM level instead in the future.
     """
 
     def setUp(self):

--- a/tests/table/test_update.py
+++ b/tests/table/test_update.py
@@ -276,6 +276,11 @@ class Concert(Table):
 # TODO - add SQLite support
 @postgres_only
 class TestTimestampUpdateOperators(TestCase):
+
+    delta = datetime.timedelta(
+        days=1, hours=1, minutes=1, seconds=30, microseconds=500
+    )
+
     def setUp(self):
         Concert.create_table().run_sync()
         Concert.insert(
@@ -290,10 +295,9 @@ class TestTimestampUpdateOperators(TestCase):
     def tearDown(self):
         Concert.alter().drop_table().run_sync()
 
-    # TODO - test all timedelta attributes (i.e. days / seconds / microseconds)
     def test_add(self):
         query = Concert.update(
-            {Concert.starts: Concert.starts + datetime.timedelta(hours=1)},
+            {Concert.starts: Concert.starts + self.delta},
             force=True,
         )
         query.run_sync()
@@ -303,12 +307,20 @@ class TestTimestampUpdateOperators(TestCase):
         )
         self.assertEqual(
             new_start_value,
-            datetime.datetime(year=2022, month=1, day=1, hour=22, minute=0),
+            datetime.datetime(
+                year=2022,
+                month=1,
+                day=2,
+                hour=22,
+                minute=1,
+                second=30,
+                microsecond=500,
+            ),
         )
 
     def test_radd(self):
         query = Concert.update(
-            {Concert.starts: datetime.timedelta(hours=1) + Concert.starts},
+            {Concert.starts: self.delta + Concert.starts},
             force=True,
         )
         query.run_sync()
@@ -318,12 +330,20 @@ class TestTimestampUpdateOperators(TestCase):
         )
         self.assertEqual(
             new_start_value,
-            datetime.datetime(year=2022, month=1, day=1, hour=22, minute=0),
+            datetime.datetime(
+                year=2022,
+                month=1,
+                day=2,
+                hour=22,
+                minute=1,
+                second=30,
+                microsecond=500,
+            ),
         )
 
     def test_substract(self):
         query = Concert.update(
-            {Concert.starts: Concert.starts - datetime.timedelta(hours=1)},
+            {Concert.starts: Concert.starts - self.delta},
             force=True,
         )
         query.run_sync()
@@ -333,5 +353,13 @@ class TestTimestampUpdateOperators(TestCase):
         )
         self.assertEqual(
             new_start_value,
-            datetime.datetime(year=2022, month=1, day=1, hour=20, minute=0),
+            datetime.datetime(
+                year=2021,
+                month=12,
+                day=31,
+                hour=19,
+                minute=58,
+                second=29,
+                microsecond=999500,
+            ),
         )

--- a/tests/table/test_update.py
+++ b/tests/table/test_update.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from piccolo.columns.column_types import Timestamp, Varchar
 from piccolo.table import Table
-from tests.base import DBTestCase
+from tests.base import DBTestCase, postgres_only
 from tests.example_apps.music.tables import Band, Poster
 
 
@@ -273,6 +273,8 @@ class Concert(Table):
     starts = Timestamp()
 
 
+# TODO - add SQLite support
+@postgres_only
 class TestTimestampUpdateOperators(TestCase):
     def setUp(self):
         Concert.create_table().run_sync()

--- a/tests/table/test_update.py
+++ b/tests/table/test_update.py
@@ -306,6 +306,21 @@ class TestTimestampUpdateOperators(TestCase):
             datetime.datetime(year=2022, month=1, day=1, hour=22, minute=0),
         )
 
+    def test_radd(self):
+        query = Concert.update(
+            {Concert.starts: datetime.timedelta(hours=1) + Concert.starts},
+            force=True,
+        )
+        query.run_sync()
+
+        new_start_value = (
+            Concert.select(Concert.starts).first().run_sync()["starts"]
+        )
+        self.assertEqual(
+            new_start_value,
+            datetime.datetime(year=2022, month=1, day=1, hour=22, minute=0),
+        )
+
     def test_substract(self):
         query = Concert.update(
             {Concert.starts: Concert.starts - datetime.timedelta(hours=1)},

--- a/tests/table/test_update.py
+++ b/tests/table/test_update.py
@@ -111,13 +111,13 @@ class TestUpdate(DBTestCase):
 
 
 class MyTable(Table):
-    integer = Integer()
-    timestamp = Timestamp()
-    timestamptz = Timestamptz()
-    date = Date()
-    interval = Interval()
-    varchar = Varchar()
-    text = Text()
+    integer = Integer(null=True)
+    timestamp = Timestamp(null=True)
+    timestamptz = Timestamptz(null=True)
+    date = Date(null=True)
+    interval = Interval(null=True)
+    varchar = Varchar(null=True)
+    text = Text(null=True)
 
 
 INITIAL_DATETIME = datetime.datetime(
@@ -163,6 +163,20 @@ TEST_CASES = [
         querystring="!!!" + MyTable.text,
         expected="!!!Pythonistas",
     ),
+    OperatorTestCase(
+        description="Text is null",
+        column=MyTable.text,
+        initial=None,
+        querystring=MyTable.text + "!!!",
+        expected=None,
+    ),
+    OperatorTestCase(
+        description="Reverse Text is null",
+        column=MyTable.text,
+        initial=None,
+        querystring="!!!" + MyTable.text,
+        expected=None,
+    ),
     # Varchar
     OperatorTestCase(
         description="Add Varchar",
@@ -184,6 +198,20 @@ TEST_CASES = [
         initial="Pythonistas",
         querystring="!!!" + MyTable.varchar,
         expected="!!!Pythonistas",
+    ),
+    OperatorTestCase(
+        description="Varchar is null",
+        column=MyTable.varchar,
+        initial=None,
+        querystring=MyTable.varchar + "!!!",
+        expected=None,
+    ),
+    OperatorTestCase(
+        description="Reverse Varchar is null",
+        column=MyTable.varchar,
+        initial=None,
+        querystring="!!!" + MyTable.varchar,
+        expected=None,
     ),
     # Integer
     OperatorTestCase(
@@ -249,6 +277,20 @@ TEST_CASES = [
         querystring=2000 / MyTable.integer,
         expected=2,
     ),
+    OperatorTestCase(
+        description="Integer is null",
+        column=MyTable.integer,
+        initial=None,
+        querystring=MyTable.integer + 1,
+        expected=None,
+    ),
+    OperatorTestCase(
+        description="Reverse Integer is null",
+        column=MyTable.integer,
+        initial=None,
+        querystring=1 + MyTable.integer,
+        expected=None,
+    ),
     # Timestamp
     OperatorTestCase(
         description="Add Timestamp",
@@ -294,6 +336,13 @@ TEST_CASES = [
             second=29,
             microsecond=999000,
         ),
+    ),
+    OperatorTestCase(
+        description="Timestamp is null",
+        column=MyTable.timestamp,
+        initial=None,
+        querystring=MyTable.timestamp + DATETIME_DELTA,
+        expected=None,
     ),
     # Timestamptz
     OperatorTestCase(
@@ -344,6 +393,13 @@ TEST_CASES = [
             tzinfo=datetime.timezone.utc,
         ),
     ),
+    OperatorTestCase(
+        description="Timestamptz is null",
+        column=MyTable.timestamptz,
+        initial=None,
+        querystring=MyTable.timestamptz + DATETIME_DELTA,
+        expected=None,
+    ),
     # Date
     OperatorTestCase(
         description="Add Date",
@@ -365,6 +421,13 @@ TEST_CASES = [
         initial=INITIAL_DATETIME,
         querystring=MyTable.date - DATE_DELTA,
         expected=datetime.date(year=2021, month=12, day=31),
+    ),
+    OperatorTestCase(
+        description="Date is null",
+        column=MyTable.date,
+        initial=None,
+        querystring=MyTable.date + DATE_DELTA,
+        expected=None,
     ),
     # Interval
     OperatorTestCase(
@@ -389,6 +452,13 @@ TEST_CASES = [
         expected=datetime.timedelta(
             days=-1, seconds=86369, microseconds=999000
         ),
+    ),
+    OperatorTestCase(
+        description="Interval is null",
+        column=MyTable.interval,
+        initial=None,
+        querystring=MyTable.interval + DATETIME_DELTA,
+        expected=None,
     ),
 ]
 

--- a/tests/table/test_update.py
+++ b/tests/table/test_update.py
@@ -15,7 +15,7 @@ from piccolo.columns.column_types import (
 )
 from piccolo.querystring import QueryString
 from piccolo.table import Table
-from tests.base import DBTestCase, is_running_postgres, sqlite_only
+from tests.base import DBTestCase, sqlite_only
 from tests.example_apps.music.tables import Band
 
 
@@ -366,42 +366,31 @@ TEST_CASES = [
         querystring=MyTable.date - DATE_DELTA,
         expected=datetime.date(year=2021, month=12, day=31),
     ),
+    # Interval
+    OperatorTestCase(
+        description="Add Interval",
+        column=MyTable.interval,
+        initial=INITIAL_INTERVAL,
+        querystring=MyTable.interval + DATETIME_DELTA,
+        expected=datetime.timedelta(days=2, seconds=7350, microseconds=1000),
+    ),
+    OperatorTestCase(
+        description="Reverse add Interval",
+        column=MyTable.interval,
+        initial=INITIAL_INTERVAL,
+        querystring=DATETIME_DELTA + MyTable.interval,
+        expected=datetime.timedelta(days=2, seconds=7350, microseconds=1000),
+    ),
+    OperatorTestCase(
+        description="Subtract Interval",
+        column=MyTable.interval,
+        initial=INITIAL_INTERVAL,
+        querystring=MyTable.interval - DATETIME_DELTA,
+        expected=datetime.timedelta(
+            days=-1, seconds=86369, microseconds=999000
+        ),
+    ),
 ]
-
-
-if is_running_postgres():
-    TEST_CASES.extend(
-        [
-            # Interval
-            OperatorTestCase(
-                description="Add Interval",
-                column=MyTable.interval,
-                initial=INITIAL_INTERVAL,
-                querystring=MyTable.interval + DATETIME_DELTA,
-                expected=datetime.timedelta(
-                    days=2, seconds=7350, microseconds=1000
-                ),
-            ),
-            OperatorTestCase(
-                description="Reverse add Interval",
-                column=MyTable.interval,
-                initial=INITIAL_INTERVAL,
-                querystring=DATETIME_DELTA + MyTable.interval,
-                expected=datetime.timedelta(
-                    days=2, seconds=7350, microseconds=1000
-                ),
-            ),
-            OperatorTestCase(
-                description="Subtract Interval",
-                column=MyTable.interval,
-                initial=INITIAL_INTERVAL,
-                querystring=MyTable.interval - DATETIME_DELTA,
-                expected=datetime.timedelta(
-                    days=-1, seconds=86369, microseconds=999000
-                ),
-            ),
-        ]
-    )
 
 
 class TestOperators(TestCase):
@@ -444,11 +433,6 @@ class TestOperators(TestCase):
         Some usecases aren't supported by SQLite, and should raise a
         ``ValueError``.
         """
-        with self.assertRaises(ValueError):
-            # We don't currently support this, because there isn't really an
-            # interval type in SQLite. We're
-            MyTable.interval + datetime.timedelta(hours=1)
-
         with self.assertRaises(ValueError):
             # An error should be raised because we can't save at this level
             # of resolution - 1 millisecond is the minimum.


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/485

We can now update `Date`, `Timestamp`, `Timestamptz`, and `Interval` columns using a `timedelta`.

For example:

```python
# To increase the start time of each concert by 1 day:
await Concert.update({Concert.starts: Concert.starts + datetime.timedelta(days=1)})
```