### PR TITLE
Update uvloop.txt

### DIFF
--- a/requirements/extras/uvloop.txt
+++ b/requirements/extras/uvloop.txt
@@ -1,1 +1,1 @@
-uvloop>=0.12.0
+uvloop>=0.12.0; sys_platform != "win32"


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/491

Uvloop isn't supported on Windows, so running `pip install piccolo[all]` would fail.