### PR TITLE
Fix migrations with custom columns

### DIFF
--- a/piccolo/apps/migrations/auto/schema_differ.py
+++ b/piccolo/apps/migrations/auto/schema_differ.py
@@ -345,6 +345,7 @@ class SchemaDiffer:
                             expect_conflict_with_global_name=getattr(
                                 UniqueGlobalNames,
                                 f"COLUMN_{alter_column.column_class.__name__.upper()}",  # noqa: E501
+                                None,
                             ),
                         )
                     )
@@ -425,6 +426,7 @@ class SchemaDiffer:
                         expect_conflict_with_global_name=getattr(
                             UniqueGlobalNames,
                             f"COLUMN_{column_class.__name__.upper()}",
+                            None,
                         ),
                     )
                 )
@@ -480,6 +482,7 @@ class SchemaDiffer:
                         expect_conflict_with_global_name=getattr(
                             UniqueGlobalNames,
                             f"COLUMN_{column.__class__.__name__.upper()}",
+                            None,
                         ),
                     )
                 )

--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -525,6 +525,7 @@ def serialise_params(params: t.Dict[str, t.Any]) -> SerialisedParams:
                     expect_conflict_with_global_name=getattr(
                         UniqueGlobalNames,
                         f"COLUMN_{column_class_name.upper()}",
+                        None,
                     ),
                 )
             )
@@ -679,6 +680,7 @@ def serialise_params(params: t.Dict[str, t.Any]) -> SerialisedParams:
                     expect_conflict_with_global_name=getattr(
                         UniqueGlobalNames,
                         f"COLUMN_{primary_key_class.__name__.upper()}",
+                        None,
                     ),
                 )
             )


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/496

If a user defines a custom column, for example:

```python
class MyColumn(Varchar):
    def __init__(self, custom_arg='', *args, **kwargs):
        self.custom_arg = custom_arg
        super().__init__(*args, **kwargs)

class MyTable(Table):
    name = MyColumn(custom_arg='abc')
```

If a migration was run based off this table it would fail, because we have some code which checks for name clashes in global variables, and this couldn't gracefully handle custom defined columns.