### PR TITLE
fix migrations for tables with arrays of `BigInt`

### DIFF
--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -10,6 +10,7 @@ from piccolo.columns import Column
 from piccolo.columns.column_types import (
     JSON,
     JSONB,
+    Array,
     ForeignKey,
     Secret,
     Serial,
@@ -216,6 +217,9 @@ class Table(metaclass=TableMetaclass):
 
                 column._meta._name = attribute_name
                 column._meta._table = cls
+
+                if isinstance(column, Array):
+                    column.base_column._meta._table = cls
 
                 if isinstance(column, Secret):
                     secret_columns.append(column)

--- a/tests/apps/migrations/auto/integration/test_migrations.py
+++ b/tests/apps/migrations/auto/integration/test_migrations.py
@@ -598,6 +598,21 @@ class TestMigrations(MigrationTestCase):
             ),
         )
 
+    def test_array_column_bigint(self):
+        """
+        There was a bug with using an array of ``BigInt`` - see issue 500 on
+        GitHub. It's because ``BigInt`` requires access to the parent table to
+        determine what the column type is.
+        """
+        self._test_migrations(
+            table_snapshots=[
+                [self.table(column)]
+                for column in [
+                    Array(base_column=BigInt()),
+                ]
+            ]
+        )
+
     ###########################################################################
 
     # We deliberately don't test setting JSON or JSONB columns as indexes, as


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/500

If you had a table containing an array of `BigInt`, then migrations could fail:

```python
from piccolo.table import Table
from piccolo.columns.column_types import Array, BigInt

class MyTable(Table):
    my_column = Array(base_column=BigInt())
```

It's because the ``BigInt`` base column needs access to the parent table to know if it's targeting Postgres or SQLite.