### PR TITLE
replace `get_event_loop` with `get_running_loop`

### DIFF
--- a/piccolo/utils/sync.py
+++ b/piccolo/utils/sync.py
@@ -9,21 +9,19 @@ def run_sync(coroutine: t.Coroutine):
     """
     Run the coroutine synchronously - trying to accommodate as many edge cases
     as possible.
-
      1. When called within a coroutine.
      2. When called from ``python -m asyncio``, or iPython with %autoawait
         enabled, which means an event loop may already be running in the
         current thread.
-
     """
     try:
-        loop = asyncio.get_event_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
+        # No current event loop, so it's safe to use:
         return asyncio.run(coroutine)
     else:
-        if not loop.is_running():
-            return loop.run_until_complete(coroutine)
-
+        # We're already inside a running event loop, so run the coroutine in a
+        # new thread:
         new_loop = asyncio.new_event_loop()
 
         with ThreadPoolExecutor(max_workers=1) as executor:


### PR DESCRIPTION
`get_event_loop` is deprecated in Python 3.10, and emits a warning.

Fixes https://github.com/piccolo-orm/piccolo/issues/522