### PR TITLE
add callbacks to queries

### DIFF
--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -12,6 +12,7 @@ from piccolo.columns.readable import Readable
 from piccolo.engine.base import Batch
 from piccolo.query.base import Query
 from piccolo.query.mixins import (
+    CallbackDelegate,
     ColumnsDelegate,
     DistinctDelegate,
     GroupByDelegate,
@@ -28,6 +29,7 @@ from piccolo.utils.warnings import colored_warning
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from piccolo.custom_types import Combinable
+    from piccolo.query.mixins import Callback
     from piccolo.table import Table  # noqa
 
 
@@ -221,6 +223,7 @@ class Select(Query):
         "offset_delegate",
         "order_by_delegate",
         "output_delegate",
+        "callback_delegate",
         "where_delegate",
     )
 
@@ -243,6 +246,7 @@ class Select(Query):
         self.offset_delegate = OffsetDelegate()
         self.order_by_delegate = OrderByDelegate()
         self.output_delegate = OutputDelegate()
+        self.callback_delegate = CallbackDelegate()
         self.where_delegate = WhereDelegate()
 
         self.columns(*columns_list)
@@ -459,6 +463,10 @@ class Select(Query):
             load_json=load_json,
             nested=nested,
         )
+        return self
+
+    def callback(self, callback: Callback) -> Select:
+        self.callback_delegate.callback(callback)
         return self
 
     def where(self, *where: Combinable) -> Select:

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 import typing as t
 from unittest import TestCase
@@ -44,6 +45,12 @@ class AsyncMock(MagicMock):
     This is a workaround for the fact that MagicMock is not async compatible in
     Python 3.7.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # this makes asyncio.iscoroutinefunction(AsyncMock()) return True
+        self._is_coroutine = asyncio.coroutines._is_coroutine
 
     async def __call__(self, *args, **kwargs):
         return super(AsyncMock, self).__call__(*args, **kwargs)

--- a/tests/table/test_callback.py
+++ b/tests/table/test_callback.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock
+
+from tests.base import AsyncMock, DBTestCase
+from tests.example_apps.music.tables import Band
+
+
+class TestNoCallback(DBTestCase):
+    def test_no_callback(self):
+        """
+        Just check we don't get any "NoneType is not callable" kind of errors
+        when we run a query without setting the callback.
+        """
+        self.insert_row()
+        Band.select(Band.name).run_sync()
+
+
+class TestCallbackSuccesses(DBTestCase):
+    def test_callback_sync(self):
+        self.insert_row()
+
+        callback_handler = Mock()
+        Band.select(Band.name).callback(callback_handler).run_sync()
+        callback_handler.assert_called_once_with(
+            True, [{"name": "Pythonistas"}]
+        )
+
+    def test_callback_async(self):
+        self.insert_row()
+
+        callback_handler = AsyncMock()
+        Band.select(Band.name).callback(callback_handler).run_sync()
+        callback_handler.assert_called_once_with(
+            True, [{"name": "Pythonistas"}]
+        )


### PR DESCRIPTION
resolves #344

here's my initial work on adding callbacks to queries as per #344

i would appreciate a code review before i take this any further! i also have a couple of questions:

1. at this stage you only get a callback when success = True, where & how would you suggest we detect a query failing and invoke the callback with success = False?
2. in `piccolo/query/base.py`, at the end of the `run` function, it branches based on whether there's more than one querystring or not. i was unable to cover the second branch with a test as i couldn't figure out how you'd end up with more than one querystring. would appreciate some pointers on how that bit works.

i look forward to hearing your thoughts.