### PR TITLE
make `Atomic` work with a connection pool

### DIFF
--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -114,15 +114,11 @@ class Atomic:
         self.queries = []
 
     async def _run_in_pool(self):
-        pool = await self.engine.get_pool()
-        connection = await pool.acquire()
+        if not self.engine.pool:
+            raise ValueError("No pool is currently active.")
 
-        try:
+        async with self.engine.pool.acquire() as connection:
             await self._run_queries(connection)
-        except Exception:
-            pass
-        finally:
-            await pool.release(connection)
 
     async def _run_in_new_connection(self):
         connection = await asyncpg.connect(**self.engine.config)

--- a/tests/engine/test_transaction.py
+++ b/tests/engine/test_transaction.py
@@ -1,6 +1,9 @@
 import asyncio
 from unittest import TestCase
 
+from piccolo.engine.postgres import Atomic
+from piccolo.table import drop_db_tables_sync
+from piccolo.utils.sync import run_sync
 from tests.example_apps.music.tables import Band, Manager
 
 from ..base import postgres_only
@@ -11,31 +14,62 @@ class TestAtomic(TestCase):
         """
         Make sure queries in a transaction aren't committed if a query fails.
         """
-        transaction = Band._meta.db.atomic()
-        transaction.add(
+        atomic = Band._meta.db.atomic()
+        atomic.add(
             Manager.create_table(),
             Band.create_table(),
             Band.raw("MALFORMED QUERY ... SHOULD ERROR"),
         )
         try:
-            transaction.run_sync()
+            atomic.run_sync()
         except Exception:
             pass
         self.assertTrue(not Band.table_exists().run_sync())
         self.assertTrue(not Manager.table_exists().run_sync())
 
     def test_succeeds(self):
-        transaction = Band._meta.db.atomic()
-        transaction.add(Manager.create_table(), Band.create_table())
-        transaction.run_sync()
+        """
+        Make sure that when atomic is run successfully the database is modified
+        accordingly.
+        """
+        atomic = Band._meta.db.atomic()
+        atomic.add(Manager.create_table(), Band.create_table())
+        atomic.run_sync()
 
         self.assertTrue(Band.table_exists().run_sync())
         self.assertTrue(Manager.table_exists().run_sync())
 
-        transaction.add(
-            Band.alter().drop_table(), Manager.alter().drop_table()
-        )
-        transaction.run_sync()
+        drop_db_tables_sync(Band, Manager)
+
+    @postgres_only
+    def test_pool(self):
+        """
+        Make sure atomic works correctly when a connection pool is active.
+        """
+
+        async def run():
+            """
+            We have to run this async function, so we can use a connection
+            pool.
+            """
+            engine = Band._meta.db
+            await engine.start_connection_pool()
+
+            atomic: Atomic = engine.atomic()
+            atomic.add(
+                Manager.create_table(),
+                Band.create_table(),
+            )
+
+            await atomic.run()
+            await engine.close_connection_pool()
+
+        run_sync(run())
+
+        self.assertTrue(Band.table_exists().run_sync())
+        self.assertTrue(Manager.table_exists().run_sync())
+
+        drop_db_tables_sync(Band, Manager)
 
 
 class TestTransaction(TestCase):


### PR DESCRIPTION
There was a typo in `Atomic` meaning it wouldn't work when a connection pool was active. Added unit tests to cover this use case.

Fixes https://github.com/piccolo-orm/piccolo/issues/543