### PR TITLE
`JSONB` `as_alias` fix when using joins

### DIFF
--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -6,6 +6,7 @@ import datetime
 import sys
 import uuid
 from decimal import Decimal
+from enum import Enum
 
 from piccolo.columns import (
     JSON,
@@ -47,8 +48,14 @@ class Concert(Table):
 
 
 class Ticket(Table):
+    class TicketType(Enum):
+        sitting = "sitting"
+        standing = "standing"
+        premium = "premium"
+
     concert = ForeignKey(Concert)
     price = Numeric(digits=(5, 2))
+    ticket_type = Varchar(choices=TicketType, default=TicketType.standing)
 
 
 class DiscountCode(Table):

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -2227,21 +2227,19 @@ class JSONB(JSON):
         instance.json_operator = f"-> '{key}'"
         return instance
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        select_string = self._meta.get_full_name(
-            just_alias=just_alias, include_quotes=True
-        )
-        if self.json_operator is not None:
-            return (
-                f"{select_string} {self.json_operator}"
-                if self.alias is None
-                else f"{select_string} {self.json_operator} AS {self.alias}"
-            )
+    def get_select_string(
+        self, engine_type: str, with_alias: bool = True
+    ) -> str:
+        select_string = self._meta.get_full_name(with_alias=False)
 
-        if self.alias is None:
-            return select_string
-        else:
-            return f"{select_string} AS {self.alias}"
+        if self.json_operator is not None:
+            select_string += f" {self.json_operator}"
+
+        if with_alias:
+            alias = self._alias or self._meta.get_default_alias()
+            select_string += f' AS "{alias}"'
+
+        return select_string
 
     def eq(self, value) -> Where:
         """
@@ -2489,15 +2487,17 @@ class Array(Column):
         else:
             raise ValueError("Only integers can be used for indexing.")
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        select_string = self._meta.get_full_name(
-            just_alias=just_alias, include_quotes=True
-        )
+    def get_select_string(self, engine_type: str, with_alias=True) -> str:
+        select_string = self._meta.get_full_name(with_alias=False)
 
         if isinstance(self.index, int):
-            return f"{select_string}[{self.index}]"
-        else:
-            return select_string
+            select_string += f"[{self.index}]"
+
+        if with_alias:
+            alias = self._alias or self._meta.get_default_alias()
+            select_string += f' AS "{alias}"'
+
+        return select_string
 
     def any(self, value: t.Any) -> Where:
         """

--- a/piccolo/columns/m2m.py
+++ b/piccolo/columns/m2m.py
@@ -55,7 +55,7 @@ class M2MSelect(Selectable):
             for column in columns
         )
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
+    def get_select_string(self, engine_type: str, with_alias=True) -> str:
         m2m_table_name = self.m2m._meta.resolved_joining_table._meta.tablename
         m2m_relationship_name = self.m2m._meta.name
 

--- a/piccolo/columns/readable.py
+++ b/piccolo/columns/readable.py
@@ -24,7 +24,7 @@ class Readable(Selectable):
     @property
     def _columns_string(self) -> str:
         return ", ".join(
-            i._meta.get_full_name(just_alias=True) for i in self.columns
+            i._meta.get_full_name(with_alias=False) for i in self.columns
         )
 
     def _get_string(self, operator: str) -> str:
@@ -41,7 +41,7 @@ class Readable(Selectable):
     def postgres_string(self) -> str:
         return self._get_string(operator="FORMAT")
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
+    def get_select_string(self, engine_type: str, with_alias=True) -> str:
         try:
             return getattr(self, f"{engine_type}_string")
         except AttributeError as e:

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -86,13 +86,10 @@ class Query:
 
             json_column_names = []
             for column in json_columns:
-                if column.alias is not None:
-                    json_column_names.append(column.alias)
+                if column._alias is not None:
+                    json_column_names.append(column._alias)
                 elif column.json_operator is not None:
-                    # If no alias is specified, then the default column name
-                    # that Postgres gives when using the `->` operator is
-                    # `?column?`.
-                    json_column_names.append("?column?")
+                    json_column_names.append(column._meta.name)
                 elif len(column._meta.call_chain) > 0:
                     json_column_names.append(
                         column.get_select_string(

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -62,13 +62,13 @@ class Avg(Selectable):
             self.column = column
         else:
             raise ValueError("Column type must be numeric to run the query.")
-        self.alias = alias
+        self._alias = alias
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(
-            just_alias=just_alias, include_quotes=True
-        )
-        return f"AVG({column_name}) AS {self.alias}"
+    def get_select_string(
+        self, engine_type: str, with_alias: bool = True
+    ) -> str:
+        column_name = self.column._meta.get_full_name(with_alias=False)
+        return f'AVG({column_name}) AS "{self._alias}"'
 
 
 class Count(Selectable):
@@ -100,16 +100,16 @@ class Count(Selectable):
         self, column: t.Optional[Column] = None, alias: str = "count"
     ):
         self.column = column
-        self.alias = alias
+        self._alias = alias
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
+    def get_select_string(
+        self, engine_type: str, with_alias: bool = True
+    ) -> str:
         if self.column is None:
             column_name = "*"
         else:
-            column_name = self.column._meta.get_full_name(
-                just_alias=just_alias, include_quotes=True
-            )
-        return f"COUNT({column_name}) AS {self.alias}"
+            column_name = self.column._meta.get_full_name(with_alias=False)
+        return f'COUNT({column_name}) AS "{self._alias}"'
 
 
 class Max(Selectable):
@@ -136,13 +136,13 @@ class Max(Selectable):
 
     def __init__(self, column: Column, alias: str = "max"):
         self.column = column
-        self.alias = alias
+        self._alias = alias
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(
-            just_alias=just_alias, include_quotes=True
-        )
-        return f"MAX({column_name}) AS {self.alias}"
+    def get_select_string(
+        self, engine_type: str, with_alias: bool = True
+    ) -> str:
+        column_name = self.column._meta.get_full_name(with_alias=False)
+        return f'MAX({column_name}) AS "{self._alias}"'
 
 
 class Min(Selectable):
@@ -167,13 +167,13 @@ class Min(Selectable):
 
     def __init__(self, column: Column, alias: str = "min"):
         self.column = column
-        self.alias = alias
+        self._alias = alias
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(
-            just_alias=just_alias, include_quotes=True
-        )
-        return f"MIN({column_name}) AS {self.alias}"
+    def get_select_string(
+        self, engine_type: str, with_alias: bool = True
+    ) -> str:
+        column_name = self.column._meta.get_full_name(with_alias=False)
+        return f'MIN({column_name}) AS "{self._alias}"'
 
 
 class Sum(Selectable):
@@ -203,13 +203,13 @@ class Sum(Selectable):
             self.column = column
         else:
             raise ValueError("Column type must be numeric to run the query.")
-        self.alias = alias
+        self._alias = alias
 
-    def get_select_string(self, engine_type: str, just_alias=False) -> str:
-        column_name = self.column._meta.get_full_name(
-            just_alias=just_alias, include_quotes=True
-        )
-        return f"SUM({column_name}) AS {self.alias}"
+    def get_select_string(
+        self, engine_type: str, with_alias: bool = True
+    ) -> str:
+        column_name = self.column._meta.get_full_name(with_alias=False)
+        return f'SUM({column_name}) AS "{self._alias}"'
 
 
 class Select(Query):

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -66,7 +66,7 @@ class OrderBy:
     def querystring(self) -> QueryString:
         order = "ASC" if self.ascending else "DESC"
         columns_names = ", ".join(
-            i._meta.get_full_name(just_alias=True) for i in self.columns
+            i._meta.get_full_name(with_alias=False) for i in self.columns
         )
 
         return QueryString(f" ORDER BY {columns_names} {order}")
@@ -438,7 +438,7 @@ class GroupBy:
     @property
     def querystring(self) -> QueryString:
         columns_names = ", ".join(
-            i._meta.get_full_name(just_alias=True) for i in self.columns
+            i._meta.get_full_name(with_alias=False) for i in self.columns
         )
 
         return QueryString(f" GROUP BY {columns_names}")

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -618,8 +618,7 @@ class Table(metaclass=TableMetaclass):
                         break
 
         alias_names = {
-            column._meta.name: getattr(column, "alias", None)
-            for column in filtered_columns
+            column._meta.name: column._alias for column in filtered_columns
         }
 
         output = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ async def drop_tables():
         "my_table",
         "recording_studio",
         "shirt",
+        "instrument",
         "mega_table",
         "small_table",
     ]:


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/552

Queries which did a join, and used `as_alias` with a `JSONB` column were failing due to a syntax error.

```python
class User(Table, tablename="my_user"):
    name = Varchar(length=120)
    config = JSONB(default={})


class Subscriber(Table, tablename="subscriber"):
    name = Varchar(length=120)
    user = ForeignKey(references=User)


async def main():
    # This was failing:
    results = await Subscriber.select(
        Subscriber.name,
        Subscriber.user.config.as_alias("config")
    )
```

The logic for generating the SQL for a `JSONB` column was a bit complex, and has been simplified.
