### PR TITLE
fix _get_related_readable typo

### DIFF
--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -654,7 +654,7 @@ class Table(metaclass=TableMetaclass):
         for readable_column in readable.columns:
             output_column = column
             for fk in readable_column._meta.call_chain:
-                output_column = getattr(column, fk._meta.name)
+                output_column = getattr(output_column, fk._meta.name)
             output_column = getattr(output_column, readable_column._meta.name)
             output_columns.append(output_column)
 

--- a/tests/table/instance/test_get_related_readable.py
+++ b/tests/table/instance/test_get_related_readable.py
@@ -1,7 +1,9 @@
 import decimal
 from unittest import TestCase
 
-from piccolo.table import create_db_tables_sync, drop_db_tables_sync
+from piccolo.columns import ForeignKey, Varchar
+from piccolo.columns.readable import Readable
+from piccolo.table import Table, create_db_tables_sync, drop_db_tables_sync
 from tests.example_apps.music.tables import (
     Band,
     Concert,
@@ -10,7 +12,48 @@ from tests.example_apps.music.tables import (
     Venue,
 )
 
-TABLES = [Band, Concert, Manager, Venue, Ticket]
+
+class ThingOne(Table):
+    name = Varchar(length=300, null=False)
+
+
+class ThingTwo(Table):
+    name = Varchar(length=300, null=False)
+    thing_one = ForeignKey(references=ThingOne)
+
+
+class ThingThree(Table):
+    name = Varchar(length=300, null=False)
+    thing_two = ForeignKey(references=ThingTwo)
+
+    @classmethod
+    def get_readable(cls):
+        return Readable(
+            template="three name: %s - two name: %s - one name: %s",
+            columns=[
+                cls.name,
+                cls.thing_two.name,
+                cls.thing_two.thing_one.name,
+            ],
+        )
+
+
+class ThingFour(Table):
+    name = Varchar(length=300, null=False)
+    thing_three = ForeignKey(references=ThingThree)
+
+
+TABLES = [
+    Band,
+    Concert,
+    Manager,
+    Venue,
+    Ticket,
+    ThingOne,
+    ThingTwo,
+    ThingThree,
+    ThingFour,
+]
 
 
 class TestGetRelatedReadable(TestCase):
@@ -44,6 +87,17 @@ class TestGetRelatedReadable(TestCase):
             price=decimal.Decimal(50.0), concert=concert
         ).run_sync()
 
+        thing_one = ThingOne.insert(ThingOne(name="thing_one")).run_sync()
+        thing_two = ThingTwo.insert(
+            ThingTwo(name="thing_two", thing_one=thing_one[0]["id"])
+        ).run_sync()
+        thing_three = ThingThree.insert(
+            ThingThree(name="thing_three", thing_two=thing_two[0]["id"])
+        ).run_sync()
+        ThingFour.insert(
+            ThingFour(name="thing_four", thing_three=thing_three[0]["id"])
+        ).run_sync()
+
     def tearDown(self):
         drop_db_tables_sync(*TABLES)
 
@@ -66,7 +120,8 @@ class TestGetRelatedReadable(TestCase):
 
         # Now try something much more complex.
         response = Ticket.select(
-            Ticket.id, Ticket._get_related_readable(Ticket.concert)
+            Ticket.id,
+            Ticket._get_related_readable(Ticket.concert),
         ).run_sync()
         self.assertEqual(
             response,
@@ -77,6 +132,21 @@ class TestGetRelatedReadable(TestCase):
                         "Pythonistas and Rustaceans at Royal Albert Hall, "
                         "capacity 5900"
                     ),
+                }
+            ],
+        )
+
+        # A really complex references chain from Piccolo Admin issue #170
+        response = ThingFour.select(
+            ThingFour._get_related_readable(ThingFour.thing_three)
+        ).run_sync()
+        self.assertEqual(
+            response,
+            [
+                {
+                    "thing_three_readable": (
+                        "three name: thing_three - two name: thing_two - one name: thing_one"  # noqa: E501
+                    )
                 }
             ],
         )


### PR DESCRIPTION
Fix for very subtle typo in `_get_related_readable` causing [Piccolo Admin issue](https://github.com/piccolo-orm/piccolo_admin/issues/170)