### PR TITLE
Return querystring string cast when casting Combination

### DIFF
--- a/piccolo/columns/combination.py
+++ b/piccolo/columns/combination.py
@@ -41,7 +41,7 @@ class Combination(CombinableMixin):
         )
 
     def __str__(self):
-        self.querystring.__str__()
+        return self.querystring.__str__()
 
 
 class And(Combination):


### PR DESCRIPTION
Ran into this problem locally while trying to debug an And combination.