### PR TITLE
add support for `returning` to insert

### DIFF
--- a/docs/src/piccolo/getting_started/index.rst
+++ b/docs/src/piccolo/getting_started/index.rst
@@ -10,5 +10,6 @@ Getting Started
     ./installing_piccolo
     ./playground
     ./setup_postgres
+    ./setup_sqlite
     ./example_schema
     ./sync_and_async

--- a/docs/src/piccolo/getting_started/setup_sqlite.rst
+++ b/docs/src/piccolo/getting_started/setup_sqlite.rst
@@ -1,0 +1,28 @@
+.. _set_up_sqlite:
+
+Setup SQLite
+============
+
+Installation
+------------
+
+The good news is SQLite is good to go out of the box with Python.
+
+Some Piccolo features are only available with newer SQLite versions.
+
+.. _check_sqlite_version:
+
+Check version
+-------------
+
+To check which SQLite version you're using, simply open a Python terminal, and
+do the following:
+
+.. code-block:: python
+
+    >>> import sqlite3
+    >>> sqlite3.sqlite_version
+    '3.39.0'
+
+The easiest way to upgrade your SQLite version is to install the latest version
+of Python.

--- a/docs/src/piccolo/query_clauses/index.rst
+++ b/docs/src/piccolo/query_clauses/index.rst
@@ -6,18 +6,25 @@ Query Clauses
 Query clauses are used to modify a query by making it more specific, or
 by modifying the return values.
 
+
 .. toctree::
     :maxdepth: 1
+    :caption: Essential
 
     ./first
-    ./distinct
-    ./group_by
     ./limit
-    ./offset
     ./order_by
-    ./output
-    ./callback
     ./where
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Advanced
+
     ./batch
+    ./callback
+    ./distinct
     ./freeze
+    ./group_by
+    ./offset
+    ./output
     ./returning

--- a/docs/src/piccolo/query_clauses/returning.rst
+++ b/docs/src/piccolo/query_clauses/returning.rst
@@ -5,6 +5,7 @@ returning
 
 You can use the ``returning`` clause with the following queries:
 
+* :ref:`Insert`
 * :ref:`Update`
 
 By default, an update query returns an empty list, but using the ``returning``
@@ -19,6 +20,19 @@ clause you can retrieve values from the updated rows.
     ... ).returning(Band.id, Band.name)
     [{'id': 1, 'name': 'Pythonistas Tribute Band'}]
 
+Similarly, for an insert query - we can retrieve some of the values from the
+inserted rows:
+
+.. code-block:: python
+
+    >>> await Manager.insert(
+    ...     Manager(name="Maz"),
+    ...     Manager(name="Graydon")
+    ... ).returning(Manager.id, Manager.name)
+
+    [{'id': 1, 'name': 'Maz'}, {'id': 1, 'name': 'Graydon'}]
+
 .. warning:: This works for all versions of Postgres, but only
     `SQLite 3.35.0 <https://www.sqlite.org/lang_returning.html>`_ and above
-    support the returning clause.
+    support the returning clause. See the :ref:`docs <check_sqlite_version>` on
+    how to check your SQLite version.

--- a/piccolo/engine/base.py
+++ b/piccolo/engine/base.py
@@ -42,6 +42,10 @@ class Engine(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_version_sync(self) -> float:
+        pass
+
+    @abstractmethod
     async def prep_database(self):
         pass
 

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -321,6 +321,9 @@ class PostgresEngine(Engine):
                 version_string=version_string
             )
 
+    def get_version_sync(self) -> float:
+        return run_sync(self.get_version())
+
     async def prep_database(self):
         for extension in self.extensions:
             try:

--- a/piccolo/engine/sqlite.py
+++ b/piccolo/engine/sqlite.py
@@ -347,9 +347,13 @@ class SQLiteEngine(Engine):
     See the `SQLite docs <https://docs.python.org/3/library/sqlite3.html#sqlite3.connect>`_
     for more info.
 
+    :param log_queries:
+        If ``True``, all SQL and DDL statements are printed out before being
+        run. Useful for debugging.
+
     """  # noqa: E501
 
-    __slots__ = ("connection_kwargs", "transaction_connection")
+    __slots__ = ("connection_kwargs", "transaction_connection", "log_queries")
 
     engine_type = "sqlite"
     min_version_number = 3.25
@@ -357,6 +361,7 @@ class SQLiteEngine(Engine):
     def __init__(
         self,
         path: str = "piccolo.sqlite",
+        log_queries: bool = False,
         detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
         isolation_level=None,
         **connection_kwargs,
@@ -368,6 +373,7 @@ class SQLiteEngine(Engine):
                 "isolation_level": isolation_level,
             }
         )
+        self.log_queries = log_queries
         self.connection_kwargs = connection_kwargs
 
         self.transaction_connection = contextvars.ContextVar(
@@ -510,6 +516,9 @@ class SQLiteEngine(Engine):
         Connection pools aren't currently supported - the argument is there
         for consistency with other engines.
         """
+        if self.log_queries:
+            print(querystring)
+
         query, query_args = querystring.compile_string(
             engine_type=self.engine_type
         )
@@ -537,6 +546,9 @@ class SQLiteEngine(Engine):
         Connection pools aren't currently supported - the argument is there
         for consistency with other engines.
         """
+        if self.log_queries:
+            print(ddl)
+
         # If running inside a transaction:
         connection = self.transaction_connection.get()
         if connection:

--- a/piccolo/engine/sqlite.py
+++ b/piccolo/engine/sqlite.py
@@ -471,7 +471,7 @@ class SQLiteEngine(Engine):
                     # of SQLite.
                     assert table is not None
                     pk = await self._get_inserted_pk(cursor, table)
-                    return [{table._meta.primary_key._meta.name: pk}]
+                    return [{table._meta.primary_key._meta.db_column_name: pk}]
                 else:
                     return await cursor.fetchall()
 
@@ -492,14 +492,16 @@ class SQLiteEngine(Engine):
 
         connection.row_factory = dict_factory
         async with connection.execute(query, args) as cursor:
+            response = await cursor.fetchall()
+
             if query_type == "insert" and self.get_version_sync() < 3.35:
                 # We can't use the RETURNING clause on older versions
                 # of SQLite.
                 assert table is not None
                 pk = await self._get_inserted_pk(cursor, table)
-                return [{table._meta.primary_key._meta.name: pk}]
+                return [{table._meta.primary_key._meta.db_column_name: pk}]
             else:
-                return await cursor.fetchall()
+                return response
 
     async def run_querystring(
         self, querystring: QueryString, in_pool: bool = False

--- a/piccolo/query/methods/insert.py
+++ b/piccolo/query/methods/insert.py
@@ -50,7 +50,7 @@ class Insert(Query):
 
     @property
     def default_querystrings(self) -> t.Sequence[QueryString]:
-        base = f"INSERT INTO {self.table._meta.tablename}"
+        base = f'INSERT INTO "{self.table._meta.tablename}"'
         columns = ",".join(
             f'"{i._meta.db_column_name}"' for i in self.table._meta.columns
         )

--- a/piccolo/query/methods/insert.py
+++ b/piccolo/query/methods/insert.py
@@ -58,6 +58,7 @@ class Insert(Query):
             query,
             *[i.querystring for i in self.add_delegate._add],
             query_type="insert",
+            table=self.table,
         )
 
         engine_type = self.engine_type

--- a/piccolo/query/methods/insert.py
+++ b/piccolo/query/methods/insert.py
@@ -42,7 +42,9 @@ class Insert(Query):
             setattr(
                 table_instance,
                 self.table._meta.primary_key._meta.name,
-                row.get(self.table._meta.primary_key._meta.name, None),
+                row.get(
+                    self.table._meta.primary_key._meta.db_column_name, None
+                ),
             )
             table_instance._exists_in_db = True
 

--- a/piccolo/query/methods/insert.py
+++ b/piccolo/query/methods/insert.py
@@ -73,6 +73,7 @@ class Insert(Query):
                         querystring,
                         self.returning_delegate._returning.querystring,
                         query_type="insert",
+                        table=self.table,
                     )
                 ]
 

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -79,7 +79,7 @@ class OrderBy:
 class Returning:
     __slots__ = ("columns",)
 
-    columns: t.Iterable[Column]
+    columns: t.List[Column]
 
     @property
     def querystring(self) -> QueryString:
@@ -207,7 +207,7 @@ class ReturningDelegate:
     _returning: t.Optional[Returning] = None
 
     def returning(self, columns: t.Sequence[Column]):
-        self._returning = Returning(columns=columns)
+        self._returning = Returning(columns=list(columns))
 
 
 @dataclass

--- a/piccolo/querystring.py
+++ b/piccolo/querystring.py
@@ -66,10 +66,21 @@ class QueryString:
         table: t.Optional[t.Type[Table]] = None,
     ) -> None:
         """
-        Example template: "WHERE {} = {}"
+        :param template:
+            The SQL query, with curly brackets as placeholders for any values::
 
-        The query type is sometimes used by the engine to modify how the query
-        is run.
+                "WHERE {} = {}"
+
+        :param args:
+            The values to insert (one value is needed for each set of curly
+            braces in the template).
+        :param query_type:
+            The query type is sometimes used by the engine to modify how the
+            query is run. For example, INSERT queries on old SQLite versions.
+        :param table:
+            Sometimes the ``piccolo.engine.base.Engine`` needs access to the
+            table that the query is being run on.
+
         """
         self.template = template
         self.args = args

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -386,7 +386,7 @@ class Table(metaclass=TableMetaclass):
         cls = self.__class__
 
         if not self._exists_in_db:
-            return cls.insert().add(self)
+            return cls.insert(self).returning(cls._meta.primary_key)
 
         # Pre-existing row - update
         if columns is None:
@@ -846,7 +846,7 @@ class Table(metaclass=TableMetaclass):
             )
 
         """
-        query = Insert(table=cls)
+        query = Insert(table=cls).returning(cls._meta.primary_key)
         if rows:
             query.add(*rows)
         return query

--- a/tests/engine/test_pool.py
+++ b/tests/engine/test_pool.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import tempfile
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 
 from piccolo.engine.postgres import PostgresEngine
 from piccolo.engine.sqlite import SQLiteEngine

--- a/tests/engine/test_pool.py
+++ b/tests/engine/test_pool.py
@@ -89,28 +89,29 @@ class TestConnectionPoolWarning(TestCase):
     async def _create_pool(self):
         sqlite_file = os.path.join(tempfile.gettempdir(), "engine.sqlite")
         engine = SQLiteEngine(path=sqlite_file)
-        await engine.start_connection_pool()
-        await engine.close_connection_pool()
 
-    @patch("piccolo.engine.base.colored_warning")
-    def test_warnings(self, colored_warning: MagicMock):
+        with patch("piccolo.engine.base.colored_warning") as colored_warning:
+            await engine.start_connection_pool()
+            await engine.close_connection_pool()
+
+            self.assertEqual(
+                colored_warning.call_args_list,
+                [
+                    call(
+                        "Connection pooling is not supported for sqlite.",
+                        stacklevel=3,
+                    ),
+                    call(
+                        "Connection pooling is not supported for sqlite.",
+                        stacklevel=3,
+                    ),
+                ],
+            )
+
+    def test_warnings(self):
         """
         Make sure that when trying to start and close a connection pool with
         SQLite, a warning is printed out, as connection pools aren't currently
         supported.
         """
         asyncio.run(self._create_pool())
-
-        self.assertEqual(
-            colored_warning.call_args_list,
-            [
-                call(
-                    "Connection pooling is not supported for sqlite.",
-                    stacklevel=3,
-                ),
-                call(
-                    "Connection pooling is not supported for sqlite.",
-                    stacklevel=3,
-                ),
-            ],
-        )

--- a/tests/table/test_alter.py
+++ b/tests/table/test_alter.py
@@ -3,14 +3,25 @@ from __future__ import annotations
 import typing as t
 from unittest import TestCase
 
+import pytest
+
 from piccolo.columns import BigInt, Integer, Numeric, Varchar
 from piccolo.columns.base import Column
 from piccolo.columns.column_types import ForeignKey, Text
 from piccolo.table import Table
-from tests.base import DBTestCase, postgres_only
+from tests.base import (
+    DBTestCase,
+    engine_version_lt,
+    is_running_sqlite,
+    postgres_only,
+)
 from tests.example_apps.music.tables import Band, Manager
 
 
+@pytest.mark.skipif(
+    is_running_sqlite() and engine_version_lt(3.25),
+    reason="SQLite version not supported",
+)
 class TestRenameColumn(DBTestCase):
     def _test_rename(
         self,


### PR DESCRIPTION
Supersedes this PR: https://github.com/piccolo-orm/piccolo/pull/203

Fixes https://github.com/piccolo-orm/piccolo/issues/171

Adds support for the `returning` clause with `Insert`:

```python
>>> await Manager.insert(
...    Manager(name="Maz"),
...    Manager(name="Guido")
... ).returning(Manager.id, Manger.name)
[{'id': 1, 'name': 'Maz'}, {'id': 2, 'name': 'Guido'}]
```




