### PR TITLE
`Table.__init__` `_data` argument

### DIFF
--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -52,12 +52,22 @@ columns.
 Creating objects
 ----------------
 
+You can pass the column values using kwargs:
+
 .. code-block:: python
 
     >>> band = Band(name="C-Sharps", popularity=100)
     >>> await band.save()
 
-This can also be done like this:
+Alternatively, you can pass in a dictionary, which is friendlier to static
+analysis tools like Mypy (it can easily detect typos in the column names):
+
+.. code-block:: python
+
+    >>> band = Band({Band.name: "C-Sharps", Band.popularity: 100})
+    >>> await band.save()
+
+We also have this shortcut which combines the above into a single line:
 
 .. code-block:: python
 

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -126,14 +126,14 @@ class Query:
                         ]
                     else:
                         raw = [
-                            self.table(**columns, exists_in_db=True)
+                            self.table(**columns, _exists_in_db=True)
                             for columns in raw
                         ]
                 elif raw is not None:
                     if output._output.nested:
                         raw = make_nested_object(raw, self.table)
                     else:
-                        raw = self.table(**raw, exists_in_db=True)
+                        raw = self.table(**raw, _exists_in_db=True)
             elif type(raw) is list:
                 if output._output.as_list:
                     if len(raw) == 0:

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -306,7 +306,12 @@ class Table(metaclass=TableMetaclass):
         **kwargs,
     ):
         """
-        Assigns any default column values to the class.
+        The constructor can be used to assign column values.
+
+        .. note::
+            The ``_data``, ``_ignore_missing``, and ``_exists_in_db``
+            arguments are prefixed with an underscore to help prevent a clash
+            with a column name which might be passed in via kwargs.
 
         :param _data:
             There's two ways of passing in the data for each column. Firstly,

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -300,29 +300,50 @@ class Table(metaclass=TableMetaclass):
 
     def __init__(
         self,
-        ignore_missing: bool = False,
-        exists_in_db: bool = False,
+        _data: t.Dict[Column, t.Any] = None,
+        _ignore_missing: bool = False,
+        _exists_in_db: bool = False,
         **kwargs,
     ):
         """
         Assigns any default column values to the class.
 
-        :param ignore_missing:
+        :param _data:
+            There's two ways of passing in the data for each column. Firstly,
+            you can use kwargs::
+
+                Band(name="Pythonistas")
+
+            Secondly, you can pass in a dictionary which maps column classes to
+            values::
+
+                Band({Band.name: 'Pythonistas'})
+
+            The advantage of this second approach is it's more strongly typed,
+            and linters such as flake8 or MyPy will more easily detect typos.
+
+        :param _ignore_missing:
             If ``False`` a ``ValueError`` will be raised if any column values
             haven't been provided.
-        :param exists_in_db:
+        :param _exists_in_db:
             Used internally to track whether this row exists in the database.
 
         """
-        self._exists_in_db = exists_in_db
+        _data = _data or {}
+
+        self._exists_in_db = _exists_in_db
 
         for column in self._meta.columns:
-            value = kwargs.pop(column._meta.name, ...)
+            value = _data.get(column, ...)
 
-            if value is ...:
-                value = kwargs.pop(
-                    t.cast(str, column._meta.db_column_name), ...
-                )
+            if kwargs:
+                if value is ...:
+                    value = kwargs.pop(column._meta.name, ...)
+
+                if value is ...:
+                    value = kwargs.pop(
+                        t.cast(str, column._meta.db_column_name), ...
+                    )
 
             if value is ...:
                 value = column.get_default_value()
@@ -333,7 +354,7 @@ class Table(metaclass=TableMetaclass):
                 if (
                     (value is None)
                     and (not column._meta.null)
-                    and not ignore_missing
+                    and not _ignore_missing
                 ):
                     raise ValueError(f"{column._meta.name} wasn't provided")
 

--- a/piccolo/testing/model_builder.py
+++ b/piccolo/testing/model_builder.py
@@ -103,7 +103,7 @@ class ModelBuilder:
         minimal: bool = False,
         persist: bool = True,
     ) -> Table:
-        model = table_class(ignore_missing=True)
+        model = table_class(_ignore_missing=True)
         defaults = {} if not defaults else defaults
 
         for column, value in defaults.items():

--- a/tests/table/test_constructor.py
+++ b/tests/table/test_constructor.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+
+from tests.example_apps.music.tables import Band
+
+
+class TestConstructor(TestCase):
+    def test_data_parameter(self):
+        """
+        Make sure the _data parameter works.
+        """
+        band = Band({Band.name: "Pythonistas"})
+        self.assertEqual(band.name, "Pythonistas")
+
+    def test_kwargs(self):
+        """
+        Make sure kwargs works.
+        """
+        band = Band(name="Pythonistas")
+        self.assertEqual(band.name, "Pythonistas")
+
+    def test_mix(self):
+        """
+        Make sure the _data paramter and kwargs works together (it's unlikely
+        people will do this, but just in case).
+        """
+        band = Band({Band.name: "Pythonistas"}, popularity=1000)
+        self.assertEqual(band.name, "Pythonistas")
+        self.assertEqual(band.popularity, 1000)


### PR DESCRIPTION
One of the design goals for Piccolo is to make it work well with modern IDEs like VSCode - with good tab completion support.

When you want to insert a row, Piccolo works like most other ORMs:

```python
class Manager(Table):
    name = Varchar()


await Manager(name='Guido').save()
```

The problem is, we could accidentally mistype a column name:

```python
await Manager(namee='Guido').save()
```

This will cause an `Exception` at runtime, but linters and type checkers won't recognise the problem. A workaround is to create something like a MyPy plugin, but it only helps people using MyPy. Creating a plugin for each tool is a pain.

We've used a dictionary pattern in other parts of Piccolo, and I like it quite a bit:

```python
# A dictionary lets us directly map a column to a value.
await Manager.update({Manager.name: 'Guido Junior'}).where(Manager.name == 'Guido')
```

This PR adds something similar to `Table.__init__`:

```python
# These two are identical

# Using a dictionary
await Manager({Manager.name: 'Guido'}).save()

# Using kwargs
await Manager(name='Guido').save()
```
