### PR TITLE
fix `snapshot` typos

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -337,7 +337,7 @@ class MigrationManager:
         if app_name is None:
             app_name = self.app_name
 
-        diffable_table = await BaseMigrationManager().get_table_from_snaphot(
+        diffable_table = await BaseMigrationManager().get_table_from_snapshot(
             app_name=app_name,
             table_class_name=table_class_name,
             max_migration_id=migration_id,

--- a/piccolo/apps/migrations/commands/base.py
+++ b/piccolo/apps/migrations/commands/base.py
@@ -114,7 +114,7 @@ class BaseMigrationManager(Finder):
         else:
             return migration_managers
 
-    async def get_table_from_snaphot(
+    async def get_table_from_snapshot(
         self,
         app_name: str,
         table_class_name: str,

--- a/tests/apps/migrations/commands/test_base.py
+++ b/tests/apps/migrations/commands/test_base.py
@@ -43,9 +43,9 @@ class TestGetMigrationModules(TestCase):
 
 class TestGetTableFromSnapshot(TestCase):
     @patch.object(BaseMigrationManager, "get_app_config")
-    def test_get_table_from_snaphot(self, get_app_config: MagicMock):
+    def test_get_table_from_snapshot(self, get_app_config: MagicMock):
         """
-        Test the get_table_from_snaphot method.
+        Test the get_table_from_snapshot method.
         """
         get_app_config.return_value = AppConfig(
             app_name="music",
@@ -55,7 +55,7 @@ class TestGetTableFromSnapshot(TestCase):
         )
 
         table = run_sync(
-            BaseMigrationManager().get_table_from_snaphot(
+            BaseMigrationManager().get_table_from_snapshot(
                 app_name="music", table_class_name="Band"
             )
         )


### PR DESCRIPTION
For some reason I consistently misspelled `snapshot` as `snaphot` ...