### PR TITLE
added `Array.cat`

### DIFF
--- a/docs/src/piccolo/query_types/update.rst
+++ b/docs/src/piccolo/query_types/update.rst
@@ -152,6 +152,12 @@ Likewise, we can decrease the values by 1 day:
         force=True
     )
 
+Array columns
+~~~~~~~~~~~~~
+
+You can append values to an array (Postgres only). See :meth:`cat <piccolo.columns.column_types.Array.cat>`.
+
+
 What about null values?
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/src/piccolo/schema/column_types.rst
+++ b/docs/src/piccolo/schema/column_types.rst
@@ -331,3 +331,9 @@ all
 ===
 
 .. automethod:: Array.all
+
+===
+cat
+===
+
+.. automethod:: Array.cat

--- a/tests/columns/test_array.py
+++ b/tests/columns/test_array.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from piccolo.columns.column_types import Array, Integer
 from piccolo.table import Table
-from tests.base import postgres_only
+from tests.base import postgres_only, sqlite_only
 
 
 class MyTable(Table):
@@ -20,7 +20,7 @@ class TestArrayDefault(TestCase):
         self.assertTrue(column.default is list)
 
 
-class TestArrayPostgres(TestCase):
+class TestArray(TestCase):
     """
     Make sure an Array column can be created.
     """
@@ -96,4 +96,42 @@ class TestArrayPostgres(TestCase):
             .first()
             .run_sync(),
             None,
+        )
+
+    @postgres_only
+    def test_cat(self):
+        """
+        Make sure values can be appended to an array.
+        """
+        MyTable(value=[1, 1, 1]).save().run_sync()
+
+        MyTable.update(
+            {MyTable.value: MyTable.value.cat([2])}, force=True
+        ).run_sync()
+
+        self.assertEqual(
+            MyTable.select().run_sync(), [{"id": 1, "value": [1, 1, 1, 2]}]
+        )
+
+        # Try plus symbol
+
+        MyTable.update(
+            {MyTable.value: MyTable.value.cat([3])}, force=True
+        ).run_sync()
+
+        self.assertEqual(
+            MyTable.select().run_sync(), [{"id": 1, "value": [1, 1, 1, 2, 3]}]
+        )
+
+    @sqlite_only
+    def test_cat_sqlite(self):
+        """
+        If using SQLite then an exception should be raised currently.
+        """
+        with self.assertRaises(ValueError) as manager:
+            MyTable.value.cat([2])
+
+        self.assertEqual(
+            str(manager.exception),
+            "Only Postgres supports array appending currently.",
         )

--- a/tests/columns/test_array.py
+++ b/tests/columns/test_array.py
@@ -116,11 +116,22 @@ class TestArray(TestCase):
         # Try plus symbol
 
         MyTable.update(
-            {MyTable.value: MyTable.value.cat([3])}, force=True
+            {MyTable.value: MyTable.value + [3]}, force=True
         ).run_sync()
 
         self.assertEqual(
             MyTable.select().run_sync(), [{"id": 1, "value": [1, 1, 1, 2, 3]}]
+        )
+
+        # Make sure non-list values work
+
+        MyTable.update(
+            {MyTable.value: MyTable.value + 4}, force=True
+        ).run_sync()
+
+        self.assertEqual(
+            MyTable.select().run_sync(),
+            [{"id": 1, "value": [1, 1, 1, 2, 3, 4]}],
         )
 
     @sqlite_only


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/590

You can now append items to an array in an update query:

```python
await Ticket.update({
    Ticket.seat_numbers: Ticket.seat_numbers + [1000]
}).where(Ticket.id == 1)
```