### PR TITLE
Fixes Piccolo backwards raw migrations

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -771,7 +771,12 @@ class MigrationManager:
         async with engine.transaction():
 
             if not self.preview:
-                for raw in self.raw:
+                if direction == "backwards":
+                    raw_list = self.raw_backwards
+                else:
+                    raw_list = self.raw
+
+                for raw in raw_list:
                     if inspect.iscoroutinefunction(raw):
                         await raw()
                     else:

--- a/tests/apps/migrations/auto/test_migration_manager.py
+++ b/tests/apps/migrations/auto/test_migration_manager.py
@@ -121,18 +121,24 @@ class TestMigrationManager(DBTestCase):
         class HasRun(Exception):
             pass
 
+        class HasRunBackwards(Exception):
+            pass
+
         def run():
             raise HasRun("I was run!")
 
+        def run_back():
+            raise HasRunBackwards("I was run backwards!")
+
         manager = MigrationManager()
         manager.add_raw(run)
-        manager.add_raw_backwards(run)
+        manager.add_raw_backwards(run_back)
 
         with self.assertRaises(HasRun):
             asyncio.run(manager.run())
 
         # Reverse
-        with self.assertRaises(HasRun):
+        with self.assertRaises(HasRunBackwards):
             asyncio.run(manager.run(backwards=True))
 
     def test_raw_coroutine(self):
@@ -143,18 +149,24 @@ class TestMigrationManager(DBTestCase):
         class HasRun(Exception):
             pass
 
+        class HasRunBackwards(Exception):
+            pass
+
         async def run():
             raise HasRun("I was run!")
 
+        async def run_back():
+            raise HasRunBackwards("I was run backwards!")
+
         manager = MigrationManager()
         manager.add_raw(run)
-        manager.add_raw_backwards(run)
+        manager.add_raw_backwards(run_back)
 
         with self.assertRaises(HasRun):
             asyncio.run(manager.run())
 
         # Reverse
-        with self.assertRaises(HasRun):
+        with self.assertRaises(HasRunBackwards):
             asyncio.run(manager.run(backwards=True))
 
     @postgres_only


### PR DESCRIPTION
Previously, Piccolo would just run the forwards raw migrations again instead of running the `raw_backwards` migrations on the `MigrationManager`. This patch forces Piccolo to explicitly run forwards or backwards raw migrations. It includes two modifications to existing unit tests, which were also incorrect.