### PR TITLE
add link to source code from docs

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -64,6 +64,7 @@ html_theme = "piccolo_theme"
 html_short_title = "Piccolo"
 html_show_sphinx = False
 globaltoc_maxdepth = 3
+html_theme_options = {"source_url": "https://github.com/piccolo-orm/piccolo/"}
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/requirements/doc-requirements.txt
+++ b/requirements/doc-requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==4.4.0
-piccolo-theme>=0.3.0
+Sphinx==5.1.1
+piccolo-theme>=0.12.0
 sphinx-autobuild==2021.3.14


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/600

<img width="499" alt="Screenshot 2022-08-27 at 11 43 04" src="https://user-images.githubusercontent.com/350976/187026691-979808ce-9af6-4095-bcfb-0198a2bf7c18.png">
