### PR TITLE
CockroachDB: Hash Sharded Indexes. (#622)

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -497,6 +497,7 @@ class MigrationManager:
 
                 index = params.get("index")
                 index_method = params.get("index_method")
+                sharded = params.get("sharded")
                 if index is None:
                     if index_method is not None:
                         # If the index value hasn't changed, but the
@@ -513,6 +514,7 @@ class MigrationManager:
                             _Table.create_index(
                                 [column],
                                 method=index_method,
+                                sharded=sharded,
                                 if_not_exists=True,
                             )
                         )
@@ -525,9 +527,11 @@ class MigrationManager:
                     column._meta.db_column_name = alter_column.db_column_name
 
                     if index is True:
-                        kwargs = (
-                            {"method": index_method} if index_method else {}
-                        )
+                        kwargs = {}
+                        if index_method:
+                            kwargs["method"] = index_method
+                        if sharded:
+                            kwargs["sharded"] = sharded
                         await self._run_query(
                             _Table.create_index(
                                 [column], if_not_exists=True, **kwargs

--- a/piccolo/query/methods/create.py
+++ b/piccolo/query/methods/create.py
@@ -51,6 +51,7 @@ class Create(DDL):
                         columns=[column],
                         method=column._meta.index_method,
                         if_not_exists=self.if_not_exists,
+                        sharded=column._meta.sharded,
                     ).ddl
                 )
 

--- a/piccolo/query/methods/create_index.py
+++ b/piccolo/query/methods/create_index.py
@@ -17,11 +17,13 @@ class CreateIndex(DDL):
         columns: t.List[t.Union[Column, str]],
         method: IndexMethod = IndexMethod.btree,
         if_not_exists: bool = False,
+        sharded: bool = False,
         **kwargs,
     ):
         self.columns = columns
         self.method = method
         self.if_not_exists = if_not_exists
+        self.sharded = sharded
         super().__init__(table, **kwargs)
 
     @property
@@ -59,10 +61,14 @@ class CreateIndex(DDL):
         tablename = self.table._meta.tablename
         method_name = self.method.value
         column_names_str = ", ".join([f'"{i}"' for i in self.column_names])
+        sharded = ""
+        if self.sharded:
+            sharded = " USING HASH "
         return [
             (
                 f"{self.prefix} {index_name} ON {tablename} USING "
                 f"{method_name} ({column_names_str})"
+                f"{sharded}"
             )
         ]
 

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -1129,6 +1129,7 @@ class Table(metaclass=TableMetaclass):
         columns: t.List[t.Union[Column, str]],
         method: IndexMethod = IndexMethod.btree,
         if_not_exists: bool = False,
+        sharded: bool = False,
     ) -> CreateIndex:
         """
         Create a table index. If multiple columns are specified, this refers
@@ -1144,6 +1145,7 @@ class Table(metaclass=TableMetaclass):
             columns=columns,
             method=method,
             if_not_exists=if_not_exists,
+            sharded=sharded,
         )
 
     @classmethod

--- a/tests/apps/migrations/auto/test_schema_differ.py
+++ b/tests/apps/migrations/auto/test_schema_differ.py
@@ -39,7 +39,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(new_table_columns.statements) == 1)
         self.assertEqual(
             new_table_columns.statements[0],
-            "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})",  # noqa
+            "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False, 'sharded': False})",  # noqa
         )
 
     def test_drop_table(self):
@@ -123,7 +123,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.add_columns.statements) == 1)
         self.assertEqual(
             schema_differ.add_columns.statements[0],
-            "manager.add_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})",  # noqa
+            "manager.add_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False, 'sharded': False})",  # noqa
         )
 
     def test_drop_column(self):
@@ -207,7 +207,7 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.add_columns.statements,
             [
-                "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})"  # noqa: E501
+                "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False, 'sharded': False})"  # noqa: E501
             ],
         )
         self.assertEqual(
@@ -349,7 +349,7 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.add_columns.statements,
             [
-                "manager.add_column(table_class_name='Band', tablename='band', column_name='b2', db_column_name='b2', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})"  # noqa: E501
+                "manager.add_column(table_class_name='Band', tablename='band', column_name='b2', db_column_name='b2', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False, 'sharded': False})"  # noqa: E501
             ],
         )
         self.assertEqual(

--- a/tests/apps/migrations/auto/test_serialisation.py
+++ b/tests/apps/migrations/auto/test_serialisation.py
@@ -250,7 +250,7 @@ class TestSerialiseParams(TestCase):
                         'class Manager(Table, tablename="manager"): '
                         "id = Serial(null=False, primary_key=True, unique=False, "  # noqa: E501
                         "index=False, index_method=IndexMethod.btree, "
-                        "choices=None, db_column_name='id', secret=False)"
+                        "choices=None, db_column_name='id', secret=False, sharded=False)"
                     ),
                 )
 
@@ -261,7 +261,7 @@ class TestSerialiseParams(TestCase):
                         'class Manager(Table, tablename="manager"): '
                         "id = Serial(null=False, primary_key=True, unique=False, "  # noqa: E501
                         "index=False, index_method=IndexMethod.btree, "
-                        "choices=None, db_column_name='id', secret=False)"
+                        "choices=None, db_column_name='id', secret=False, sharded=False)"
                     ),
                 )
 
@@ -312,7 +312,7 @@ class TestSerialiseParams(TestCase):
 
         self.assertEqual(
             serialised.params["base_column"].__repr__(),
-            "Varchar(length=255, default='', null=False, primary_key=False, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name=None, secret=False)",  # noqa: E501
+            "Varchar(length=255, default='', null=False, primary_key=False, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name=None, secret=False, sharded=False)",  # noqa: E501
         )
 
         self.assertEqual(

--- a/tests/table/test_str.py
+++ b/tests/table/test_str.py
@@ -11,8 +11,8 @@ class TestTableStr(TestCase):
                 Manager._table_str(),
                 (
                     "class Manager(Table, tablename='manager'):\n"
-                    "    id = Serial(null=False, primary_key=True, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name='id', secret=False)\n"  # noqa: E501
-                    "    name = Varchar(length=50, default='', null=False, primary_key=False, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name=None, secret=False)\n"  # noqa: E501
+                    "    id = Serial(null=False, primary_key=True, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name='id', secret=False, sharded=False)\n"  # noqa: E501
+                    "    name = Varchar(length=50, default='', null=False, primary_key=False, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name=None, secret=False, sharded=False)\n"  # noqa: E501
                 ),
             )
         else:
@@ -20,8 +20,8 @@ class TestTableStr(TestCase):
                 Manager._table_str(),
                 (
                     "class Manager(Table, tablename='manager'):\n"
-                    "    id = Serial(null=False, primary_key=True, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name='id', secret=False)\n"  # noqa: E501
-                    "    name = Varchar(length=50, default='', null=False, primary_key=False, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name=None, secret=False)\n"  # noqa: E501
+                    "    id = Serial(null=False, primary_key=True, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name='id', secret=False, sharded=False)\n"  # noqa: E501
+                    "    name = Varchar(length=50, default='', null=False, primary_key=False, unique=False, index=False, index_method=IndexMethod.btree, choices=None, db_column_name=None, secret=False, sharded=False)\n"  # noqa: E501
                 ),
             )
 


### PR DESCRIPTION
Issue: https://github.com/piccolo-orm/piccolo/issues/622

Implements "Sharding for Sequential Indexes" as noted in: https://github.com/piccolo-orm/piccolo/issues/607

Major performance feature for "sequential data" for clusters (timestamps, etc).
* Article: https://www.cockroachlabs.com/blog/hash-sharded-indexes-unlock-linear-scaling-for-sequential-workloads/
* Video: https://www.youtube.com/watch?v=JlT_Co_wYFo
* Reference manual: https://www.cockroachlabs.com/docs/stable/hash-sharded-indexes.html