### PR TITLE
Playground: Option to use ipython profile

### DIFF
--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -264,6 +264,6 @@ def run(
         print("\n")
         conf_args = {}
     else:
-        conf_args = {"colors": "Neutral", "mouse_support": True}
+        conf_args = {"colors": "neutral"}
 
     IPython.embed(using=_asyncio_runner, **conf_args)

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -261,6 +261,9 @@ def run(
             "More info: https://ipython.org/ipython-doc/3/config/intro.html#"
         )
         print("\n")
+        # To try this out, set `c.TerminalInteractiveShell.colors = "Linux"`
+        # in `~/.ipython/profile_default/ipython_config.py` to set the terminal
+        # color.
         conf_args = {}
     else:
         conf_args = {"colors": "neutral"}

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -24,6 +24,7 @@ from piccolo.columns.readable import Readable
 from piccolo.engine import PostgresEngine, SQLiteEngine
 from piccolo.engine.base import Engine
 from piccolo.table import Table
+from piccolo.utils.warnings import colored_string
 
 
 class Manager(Table):
@@ -231,25 +232,23 @@ def run(
         db = SQLiteEngine()
     for _table in TABLES:
         _table._meta._db = db
-    print("Tables:\n")
+
+    print(colored_string("\nTables:\n"))
 
     for _table in TABLES:
         print(_table._table_str(abbreviated=True))
-        print("\n")
+        print("")
 
-    print("Try it as a query builder:")
-    print("Band.select().run_sync()")
-    print("Band.select(Band.name).run_sync()")
-    print("Band.select(Band.name, Band.manager.name).run_sync()")
+    print(colored_string("Try it as a query builder:"))
+    print("await Band.select()")
+    print("await Band.select(Band.name)")
+    print("await Band.select(Band.name, Band.manager.name)")
     print("\n")
 
-    print("Try it as an ORM:")
-    print(
-        "b = Band.objects().where(Band.name == 'Pythonistas').first()."
-        "run_sync()"
-    )
+    print(colored_string("Try it as an ORM:"))
+    print("b = await Band.objects().where(Band.name == 'Pythonistas').first()")
     print("b.popularity = 10000")
-    print("b.save().run_sync()")
+    print("await b.save()")
     print("\n")
 
     populate()

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -254,7 +254,7 @@ def run(
 
     populate()
 
-    from IPython.core.interactiveshell import _asyncio_runner  # type: ignore
+    from IPython.core.interactiveshell import _asyncio_runner
 
     if ipython_profile:
         print("Using user ipython profile")

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -255,15 +255,15 @@ def run(
     populate()
 
     from IPython.core.interactiveshell import _asyncio_runner  # type: ignore
-    from traitlets.config import get_config
 
-    if not ipython_profile:
-        conf = get_config()
-        conf.InteractiveShellEmbed.colors = "Neutral"
-    else:
+    if ipython_profile:
         print("Using user ipython profile")
-        print("For details, see: https://ipython.org/ipython-doc/3/config/intro.html#ipythondir")
+        print(
+            "More info: https://ipython.org/ipython-doc/3/config/intro.html#"
+        )
         print("\n")
-        conf = None
+        conf_args = {}
+    else:
+        conf_args = {"colors": "Neutral", "mouse_support": True}
 
-    IPython.embed(using=_asyncio_runner, config=conf)
+    IPython.embed(using=_asyncio_runner, **conf_args)

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -208,7 +208,9 @@ def run(
     :param port:
         Postgres port
     :param ipython_profile:
-        Make this True to use your own IPython profile. Located at ~/.ipython/
+        Set to true to use your own IPython profile. Located at ~/.ipython/.
+        For more info see the IPython docs
+        https://ipython.readthedocs.io/en/stable/config/intro.html.
     """
     try:
         import IPython
@@ -256,11 +258,7 @@ def run(
     from IPython.core.interactiveshell import _asyncio_runner
 
     if ipython_profile:
-        print("Using user ipython profile")
-        print(
-            "More info: https://ipython.org/ipython-doc/3/config/intro.html#"
-        )
-        print("\n")
+        print(colored_string("Using your IPython profile\n"))
         # To try this out, set `c.TerminalInteractiveShell.colors = "Linux"`
         # in `~/.ipython/profile_default/ipython_config.py` to set the terminal
         # color.

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -189,6 +189,7 @@ def run(
     database: str = "piccolo_playground",
     host: str = "localhost",
     port: int = 5432,
+    ipython_profile: bool = False,
 ):
     """
     Creates a test database to play with.
@@ -205,6 +206,8 @@ def run(
         Postgres host
     :param port:
         Postgres port
+    :param ipython_profile:
+        Make this True to use your own IPython profile. Located at ~/.ipython/
     """
     try:
         import IPython
@@ -252,5 +255,15 @@ def run(
     populate()
 
     from IPython.core.interactiveshell import _asyncio_runner  # type: ignore
+    from traitlets.config import get_config
 
-    IPython.embed(using=_asyncio_runner)
+    if not ipython_profile:
+        conf = get_config()
+        conf.InteractiveShellEmbed.colors = "Neutral"
+    else:
+        print("Using user ipython profile")
+        print("For details, see: https://ipython.org/ipython-doc/3/config/intro.html#ipythondir")
+        print("\n")
+        conf = None
+
+    IPython.embed(using=_asyncio_runner, config=conf)

--- a/piccolo/main.py
+++ b/piccolo/main.py
@@ -104,10 +104,11 @@ def main():
                     aliases=command.aliases,
                 )
 
-        if "migrations" not in sys.argv:
+        if not {"playground", "migrations"}.intersection(set(sys.argv)):
             # Show a warning if any migrations haven't been run.
             # Don't run it if it looks like the user is running a migration
-            # command, as this information is redundant.
+            # command, or using the playground, as this information is
+            # redundant.
 
             try:
                 havent_ran_count = run_sync(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ module = [
     "colorama",
     "dateutil",
     "IPython",
+    "IPython.core.interactiveshell",
     "jinja2",
     "orjson",
     "aiosqlite"


### PR DESCRIPTION
I started the piccolo playground locally and noticed that there was no syntax highlighting. Did I do something wrong?

Unless I misunderstood. It seems that when you start the playground, it creates an embedded ipython shell with the default config. I think this means IPython will use the user's own config. But if there is None, it will still use the default config because the playground embed instance doesn't specify a config. This mean no syntax highlighting

These changes will make it so that by default, running playground will start the embedded shell with syntax highlighting. This also overrides the user config (which is at ~/.ipython/profile_.....).

So to give user the option to use their own, i've added a param to allow that