### PR TITLE
added `OrderByRaw`

### DIFF
--- a/docs/src/piccolo/query_clauses/order_by.rst
+++ b/docs/src/piccolo/query_clauses/order_by.rst
@@ -25,6 +25,14 @@ To order by descending:
         ascending=False
     )
 
+You can specify the column name as a string if you prefer:
+
+.. code-block:: python
+
+    await Band.select().order_by(
+        'name'
+    )
+
 You can order by multiple columns, and even use joins:
 
 .. code-block:: python
@@ -33,3 +41,47 @@ You can order by multiple columns, and even use joins:
         Band.name,
         Band.manager.name
     )
+
+-------------------------------------------------------------------------------
+
+Advanced
+--------
+
+Ascending and descending
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to order by multiple columns, with some ascending, and some
+descending, then you can do so using multiple ``order_by`` statements:
+
+
+.. code-block:: python
+
+    await Band.select().order_by(
+        Band.name,
+    ).order_by(
+        Band.popularity,
+        ascending=False
+    )
+
+``OrderByRaw``
+~~~~~~~~~~~~~~
+
+SQL's ``ORDER BY`` clause is surprisingly rich in functionality, and there may
+be situations where you want to specify the ``ORDER BY`` explicitly using SQL.
+To do this use ``OrderByRaw``.
+
+In the example below, we are ordering the results randomly:
+
+.. code-block:: python
+
+    from piccolo.query import OrderByRaw
+
+    await Band.select(Band.name).order_by(
+        OrderByRaw('random()'),
+    )
+
+The above is equivalent to the following SQL:
+
+.. code-block:: sql
+
+    SELECT "band"."name" FROM band ORDER BY random() ASC

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -159,6 +159,12 @@ def populate():
     rustaceans = Band(name="Rustaceans", manager=graydon.id, popularity=500)
     rustaceans.save().run_sync()
 
+    anders = Manager(name="Anders")
+    anders.save().run_sync()
+
+    c_sharps = Band(name="C-Sharps", popularity=700, manager=anders.id)
+    c_sharps.save().run_sync()
+
     venue = Venue(name="Amazing Venue", capacity=5000)
     venue.save().run_sync()
 

--- a/piccolo/query/__init__.py
+++ b/piccolo/query/__init__.py
@@ -18,3 +18,26 @@ from .methods import (
     TableExists,
     Update,
 )
+from .mixins import OrderByRaw
+
+__all__ = [
+    "Alter",
+    "Avg",
+    "Count",
+    "Create",
+    "CreateIndex",
+    "Delete",
+    "DropIndex",
+    "Exists",
+    "Insert",
+    "Max",
+    "Min",
+    "Objects",
+    "OrderByRaw",
+    "Query",
+    "Raw",
+    "Select",
+    "Sum",
+    "TableExists",
+    "Update",
+]

--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -15,6 +15,7 @@ from piccolo.query.mixins import (
     LimitDelegate,
     OffsetDelegate,
     OrderByDelegate,
+    OrderByRaw,
     OutputDelegate,
     PrefetchDelegate,
     WhereDelegate,
@@ -213,8 +214,19 @@ class Objects(Query):
     def create(self, **columns: t.Any):
         return Create(table_class=self.table, columns=columns)
 
-    def order_by(self, *columns: Column, ascending=True) -> Objects:
-        self.order_by_delegate.order_by(*columns, ascending=ascending)
+    def order_by(
+        self,
+        *columns: t.Union[Column, str, OrderByRaw],
+        ascending: bool = True,
+    ) -> Objects:
+        _columns: t.List[t.Union[Column, OrderByRaw]] = []
+        for column in columns:
+            if isinstance(column, str):
+                _columns.append(self.table._meta.get_column_by_name(column))
+            else:
+                _columns.append(column)
+
+        self.order_by_delegate.order_by(*_columns, ascending=ascending)
         return self
 
     def where(self, *where: Combinable) -> Objects:

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import typing as t
 from dataclasses import dataclass, field
 from enum import Enum, auto
@@ -74,20 +75,40 @@ class Offset:
 
 
 @dataclass
-class OrderBy:
+class OrderByRaw:
+    __slots__ = ("sql",)
+
+    sql: str
+
+
+@dataclass
+class OrderByItem:
     __slots__ = ("columns", "ascending")
 
-    columns: t.Sequence[Column]
+    columns: t.Sequence[t.Union[Column, OrderByRaw]]
     ascending: bool
+
+
+@dataclass
+class OrderBy:
+    order_by_items: t.List[OrderByItem] = field(default_factory=list)
 
     @property
     def querystring(self) -> QueryString:
-        order = "ASC" if self.ascending else "DESC"
-        columns_names = ", ".join(
-            i._meta.get_full_name(with_alias=False) for i in self.columns
-        )
+        order_by_strings: t.List[str] = []
+        for order_by_item in self.order_by_items:
+            order = "ASC" if order_by_item.ascending else "DESC"
+            for column in order_by_item.columns:
+                if isinstance(column, Column):
+                    expression = column._meta.get_full_name(with_alias=False)
+                elif isinstance(column, OrderByRaw):
+                    expression = column.sql
+                else:
+                    raise ValueError("Unrecognised order_by")
 
-        return QueryString(f" ORDER BY {columns_names} {order}")
+                order_by_strings.append(f"{expression} {order}")
+
+        return QueryString(f" ORDER BY {', '.join(order_by_strings)}")
 
     def __str__(self):
         return self.querystring.__str__()
@@ -184,15 +205,27 @@ class WhereDelegate:
 @dataclass
 class OrderByDelegate:
 
-    _order_by: t.Optional[OrderBy] = None
+    _order_by: OrderBy = field(default_factory=OrderBy)
 
     def get_order_by_columns(self) -> t.List[Column]:
-        return list(self._order_by.columns) if self._order_by else []
+        """
+        Used to work out which columns are needed for joins.
+        """
+        return [
+            i
+            for i in itertools.chain(
+                *[i.columns for i in self._order_by.order_by_items]
+            )
+            if isinstance(i, Column)
+        ]
 
-    def order_by(self, *columns: Column, ascending=True):
+    def order_by(self, *columns: t.Union[Column, OrderByRaw], ascending=True):
         if len(columns) < 1:
             raise ValueError("At least one column must be passed to order_by.")
-        self._order_by = OrderBy(columns, ascending)
+
+        self._order_by.order_by_items.append(
+            OrderByItem(columns=columns, ascending=ascending)
+        )
 
 
 @dataclass

--- a/tests/example_apps/music/tables.py
+++ b/tests/example_apps/music/tables.py
@@ -28,31 +28,18 @@ class Manager(Table):
         return Readable(template="%s", columns=[cls.name])
 
 
-if engine.engine_type != "cockroach":  # type: ignore
+class Band(Table):
+    name = Varchar(length=50)
+    manager = ForeignKey(Manager, null=True)
+    popularity = (
+        BigInt(default=0)
+        if engine and engine.engine_type == "cockroach"
+        else Integer(default=0)
+    )
 
-    class Band(Table):  # type: ignore
-        name = Varchar(length=50)
-        manager = ForeignKey(Manager, null=True)
-        popularity = Integer(default=0)
-
-        @classmethod
-        def get_readable(cls) -> Readable:
-            return Readable(template="%s", columns=[cls.name])
-
-else:
-
-    class Band(Table):  # type: ignore
-        """
-        Special version for Cockroach.
-        """
-
-        name = Varchar(length=50)
-        manager = ForeignKey(Manager, null=True)
-        popularity = BigInt(default=0)
-
-        @classmethod
-        def get_readable(cls) -> Readable:
-            return Readable(template="%s", columns=[cls.name])
+    @classmethod
+    def get_readable(cls) -> Readable:
+        return Readable(template="%s", columns=[cls.name])
 
 
 ###############################################################################

--- a/tests/query/mixins/test_columns_delegate.py
+++ b/tests/query/mixins/test_columns_delegate.py
@@ -1,7 +1,6 @@
 import time  # For time travel queries.
-from unittest import TestCase
 
-from piccolo.query.mixins import ColumnsDelegate, OrderByDelegate
+from piccolo.query.mixins import ColumnsDelegate
 from tests.base import DBTestCase, engines_only
 from tests.example_apps.music.tables import Band
 
@@ -61,19 +60,3 @@ class TestColumnsDelegate(DBTestCase):
         result = result.run_sync()
 
         self.assertTrue(result.name == "Pythonistas")
-
-
-class TestOrderByDelegate(TestCase):
-    def test_no_columns(self):
-        """
-        An exception should be raised if no columns are passed in.
-        """
-        delegate = OrderByDelegate()
-
-        with self.assertRaises(ValueError) as manager:
-            delegate.order_by()
-
-        self.assertEqual(
-            manager.exception.__str__(),
-            "At least one column must be passed to order_by.",
-        )

--- a/tests/query/mixins/test_order_by_delegate.py
+++ b/tests/query/mixins/test_order_by_delegate.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+
+from piccolo.query.mixins import OrderByDelegate
+
+
+class TestOrderByDelegate(TestCase):
+    def test_no_columns(self):
+        """
+        An exception should be raised if no columns are passed in.
+        """
+        delegate = OrderByDelegate()
+
+        with self.assertRaises(ValueError) as manager:
+            delegate.order_by()
+
+        self.assertEqual(
+            manager.exception.__str__(),
+            "At least one column must be passed to order_by.",
+        )


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/669
Fixes https://github.com/piccolo-orm/piccolo/issues/620

This PR makes quite a few improvements to `order_by` clauses.

It is now possible to combine ascending and descending:

```python
await Band.select(
    Band.popularity,
    Band.name
).order_by(
    Band.popularity
).order_by(
    Band.name,
    ascending=False
)
```

You can also order by anything you want using `OrderByRaw`:

```python
from piccolo.query import OrderByRaw

await Band.select(
    Band.popularity,
    Band.name
).order_by(
    OrderByRaw('random()')
)
```