### PR TITLE
add `TransactionType` to `SQLiteEngine`

### DIFF
--- a/docs/src/piccolo/engines/sqlite_engine.rst
+++ b/docs/src/piccolo/engines/sqlite_engine.rst
@@ -23,3 +23,11 @@ Source
 .. currentmodule:: piccolo.engine.sqlite
 
 .. autoclass:: SQLiteEngine
+
+-------------------------------------------------------------------------------
+
+Production tips
+---------------
+
+If you're planning on using SQLite in production with Piccolo, with lots of
+concurrent queries, then here are some :ref:`useful tips <UsingSQLitAndAsyncioEffectively>`.

--- a/docs/src/piccolo/query_types/transactions.rst
+++ b/docs/src/piccolo/query_types/transactions.rst
@@ -47,3 +47,14 @@ async.
 If an exception is raised within the body of the context manager, then the
 transaction is automatically rolled back. The exception is still propagated
 though.
+
+-------------------------------------------------------------------------------
+
+Transaction types
+-----------------
+
+SQLite
+~~~~~~
+
+For SQLite you may want to specify the :ref:`transaction type <SQLiteTransactionTypes>`,
+as it can have an effect on how well the database handles concurrent requests.

--- a/docs/src/piccolo/query_types/transactions.rst
+++ b/docs/src/piccolo/query_types/transactions.rst
@@ -48,6 +48,17 @@ If an exception is raised within the body of the context manager, then the
 transaction is automatically rolled back. The exception is still propagated
 though.
 
+``transaction_exists``
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can check whether your code is currently inside a transaction using the
+following:
+
+.. code-block:: python
+
+    >>> Band._meta.db.transaction_exists()
+    True
+
 -------------------------------------------------------------------------------
 
 Transaction types

--- a/docs/src/piccolo/tutorials/index.rst
+++ b/docs/src/piccolo/tutorials/index.rst
@@ -8,3 +8,4 @@ help you solve common problems:
     :maxdepth: 1
 
     ./migrate_existing_project
+    ./using_sqlite_and_asyncio_effectively

--- a/docs/src/piccolo/tutorials/using_sqlite_and_asyncio_effectively.rst
+++ b/docs/src/piccolo/tutorials/using_sqlite_and_asyncio_effectively.rst
@@ -1,0 +1,103 @@
+.. _UsingSQLitAndAsyncioEffectively:
+
+Using SQLite and asyncio effectively
+====================================
+
+When using Piccolo with SQLite, there are some best practices to follow.
+
+asyncio => lots of connections
+------------------------------
+
+With asyncio, we can potentially open lots of database connections, and attempt
+to perform concurrent database writes.
+
+SQLite doesn't support such concurrent behavior as effectively as Postgres, so
+we need to be careful.
+
+One write at a time
+~~~~~~~~~~~~~~~~~~~
+
+SQLite can easily support lots of transactions concurrently if they are reading,
+but only one write can be performed at a time.
+
+-------------------------------------------------------------------------------
+
+.. _SQLiteTransactionTypes:
+
+Transactions
+------------
+
+SQLite has several transaction types, as specified by Piccolo's
+``TransactionType`` enum:
+
+.. currentmodule:: piccolo.engine.sqlite
+
+.. autoclass:: TransactionType
+    :members:
+    :undoc-members:
+
+Which to use?
+~~~~~~~~~~~~~
+
+When creating a transaction, Piccolo uses ``DEFERRED`` by default (to be
+consistent with SQLite).
+
+This means that the first SQL query executed within the transaction determines
+whether it's a **READ** or **WRITE**:
+
+* **READ** - if the first query is a ``SELECT``
+* **WRITE** - if the first query is something like an ``INSERT`` / ``UPDATE`` / ``DELETE``
+
+If a transaction starts off with a ``SELECT``, but then tries to perform an ``INSERT`` / ``UPDATE`` / ``DELETE``,
+SQLite tries to 'promote' the transaction so it can write.
+
+The problem is, if multiple concurrent connections try doing this at the same time,
+SQLite will return a database locked error.
+
+So if you're creating a transaction which you know will perform writes, then
+create an ``IMMEDIATE`` transaction:
+
+.. code-block:: python
+
+    from piccolo.engine.sqlite import TransactionType
+
+    async with Band._meta.db.transaction(
+        transaction_type=TransactionType.immediate
+    ):
+        # We perform a SELECT first, but as it's an IMMEDIATE transaction,
+        # we can later perform writes without getting a database locked
+        # error.
+        if not await Band.exists().where(Band.name == 'Pythonistas'):
+            await Band.objects().create(name="Pythonistas")
+
+Multiple ``IMMEDIATE`` transactions can exist concurrently - SQLite uses a lock
+to make sure only one of them writes at a time.
+
+If your transaction will just be performing ``SELECT`` queries, then just use
+the default ``DEFERRED`` transactions - you will get improved performance, as
+no locking is involved:
+
+.. code-block:: python
+
+    async with Band._meta.db.transaction():
+        bands = await Band.select()
+        managers = await Manager.select()
+
+-------------------------------------------------------------------------------
+
+timeout
+-------
+
+It's recommended to specify the ``timeout`` argument in :class:`SQLiteEngine <piccolo.engine.sqlite.SQLiteEngine>`.
+
+.. code-block:: python
+
+    DB = SQLiteEngine(timeout=60)
+
+Imagine you have a web app, and each endpoint creates a transaction which runs
+multiple queries. With SQLite, only a single write operation can happen at a
+time, so if several connections are open, they may be queued for a while.
+
+By increasing ``timeout`` it means that queries are less likely to timeout.
+
+To find out more about ``timeout`` see the Python :func:`sqlite3 docs <sqlite3.connect>`.

--- a/piccolo/columns/m2m.py
+++ b/piccolo/columns/m2m.py
@@ -293,7 +293,7 @@ class M2MAddRelated:
         transaction, or wrapped in a new transaction.
         """
         engine = self.rows[0]._meta.db
-        if not engine.transaction_exists():
+        if engine.transaction_exists():
             await self._run()
         else:
             async with engine.transaction():

--- a/piccolo/columns/m2m.py
+++ b/piccolo/columns/m2m.py
@@ -254,39 +254,50 @@ class M2MAddRelated:
             for i, j in self.extra_column_values.items()
         }
 
-    async def run(self):
+    async def _run(self):
         rows = self.rows
         unsaved = [i for i in rows if not i._exists_in_db]
 
-        async with rows[0]._meta.db.transaction():
-            if unsaved:
-                await rows[0].__class__.insert(*unsaved).run()
+        if unsaved:
+            await rows[0].__class__.insert(*unsaved).run()
 
-            joining_table = self.m2m._meta.resolved_joining_table
+        joining_table = self.m2m._meta.resolved_joining_table
 
-            joining_table_rows = []
+        joining_table_rows = []
 
-            for row in rows:
-                joining_table_row = joining_table(**self.extra_column_values)
-                setattr(
-                    joining_table_row,
-                    self.m2m._meta.primary_foreign_key._meta.name,
-                    getattr(
-                        self.target_row,
-                        self.target_row._meta.primary_key._meta.name,
-                    ),
-                )
-                setattr(
-                    joining_table_row,
-                    self.m2m._meta.secondary_foreign_key._meta.name,
-                    getattr(
-                        row,
-                        row._meta.primary_key._meta.name,
-                    ),
-                )
-                joining_table_rows.append(joining_table_row)
+        for row in rows:
+            joining_table_row = joining_table(**self.extra_column_values)
+            setattr(
+                joining_table_row,
+                self.m2m._meta.primary_foreign_key._meta.name,
+                getattr(
+                    self.target_row,
+                    self.target_row._meta.primary_key._meta.name,
+                ),
+            )
+            setattr(
+                joining_table_row,
+                self.m2m._meta.secondary_foreign_key._meta.name,
+                getattr(
+                    row,
+                    row._meta.primary_key._meta.name,
+                ),
+            )
+            joining_table_rows.append(joining_table_row)
 
-            return await joining_table.insert(*joining_table_rows).run()
+        return await joining_table.insert(*joining_table_rows).run()
+
+    async def run(self):
+        """
+        Run the queries, making sure they are either within an existing
+        transaction, or wrapped in a new transaction.
+        """
+        engine = self.rows[0]._meta.db
+        if not engine.transaction_exists():
+            await self._run()
+        else:
+            async with engine.transaction():
+                await self._run()
 
     def run_sync(self):
         return run_sync(self.run())

--- a/piccolo/engine/base.py
+++ b/piccolo/engine/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import logging
 import typing as t
 from abc import ABCMeta, abstractmethod
@@ -19,7 +20,10 @@ class Batch:
     pass
 
 
-class Engine(metaclass=ABCMeta):
+TransactionClass = t.TypeVar("TransactionClass")
+
+
+class Engine(t.Generic[TransactionClass], metaclass=ABCMeta):
 
     __slots__ = ()
 
@@ -116,3 +120,20 @@ class Engine(metaclass=ABCMeta):
         The database driver doesn't implement connection pooling.
         """
         self._connection_pool_warning()
+
+    ###########################################################################
+
+    current_transaction: contextvars.ContextVar[t.Optional[TransactionClass]]
+
+    def transaction_exists(self) -> bool:
+        """
+        Find out if a transaction is currently active.
+
+        :returns:
+            ``True`` if a transaction is already active for the current
+            asyncio task. This is useful to know, because nested transactions
+            aren't currently supported, so you can check if an existing
+            transaction is already active, before creating a new one.
+
+        """
+        return self.current_transaction.get() is not None

--- a/piccolo/engine/cockroach.py
+++ b/piccolo/engine/cockroach.py
@@ -1,80 +1,19 @@
 from __future__ import annotations
 
-import contextvars
 import typing as t
 
-from piccolo.engine.exceptions import TransactionError
-from piccolo.query.base import Query
 from piccolo.utils.lazy_loader import LazyLoader
 from piccolo.utils.warnings import Level, colored_warning
 
-from .postgres import Atomic as PostgresAtomic
 from .postgres import PostgresEngine
-from .postgres import Transaction as PostgresTransaction
 
 asyncpg = LazyLoader("asyncpg", globals(), "asyncpg")
-
-if t.TYPE_CHECKING:  # pragma: no cover
-    from asyncpg.pool import Pool
-
-
-###############################################################################
-
-
-class Atomic(PostgresAtomic):
-    """
-    This is useful if you want to build up a transaction programatically, by
-    adding queries to it.
-
-    Usage::
-
-        transaction = engine.atomic()
-        transaction.add(Foo.create_table())
-
-        # Either:
-        transaction.run_sync()
-        await transaction.run()
-
-    """
-
-    def __init__(self, engine: CockroachEngine):
-        self.engine = engine
-        self.queries: t.List[Query] = []
-        super(Atomic, self).__init__(engine)
-
-
-###############################################################################
-
-
-class Transaction(PostgresTransaction):
-    """
-    Used for wrapping queries in a transaction, using a context manager.
-    Currently it's async only.
-
-    Usage::
-
-        async with engine.transaction():
-            # Run some queries:
-            await Band.select().run()
-
-    """
-
-    def __init__(self, engine: CockroachEngine):
-        self.engine = engine
-        if self.engine.transaction_connection.get():
-            raise TransactionError(
-                "A transaction is already active - nested transactions aren't "
-                "currently supported."
-            )
-        super(Transaction, self).__init__(engine)
-
-
-###############################################################################
 
 
 class CockroachEngine(PostgresEngine):
     """
-    An extension of the cockroach backend.
+    An extension of
+    :class:`PostgresEngine <piccolo.engine.postgres.PostgresEngine>`.
     """
 
     engine_type = "cockroach"
@@ -85,23 +24,14 @@ class CockroachEngine(PostgresEngine):
         config: t.Dict[str, t.Any],
         extensions: t.Sequence[str] = (),
         log_queries: bool = False,
-        extra_nodes: t.Dict[str, PostgresEngine] = None,
+        extra_nodes: t.Dict[str, CockroachEngine] = None,
     ) -> None:
-        if extra_nodes is None:
-            extra_nodes = {}
-
-        self.config = config
-        self.extensions = extensions
-        self.log_queries = log_queries
-        self.extra_nodes = extra_nodes
-        self.pool: t.Optional[Pool] = None
-        database_name = config.get("database", "Unknown")
-        self.transaction_connection = contextvars.ContextVar(
-            f"pg_transaction_connection_{database_name}", default=None
+        super().__init__(
+            config=config,
+            extensions=extensions,
+            log_queries=log_queries,
+            extra_nodes=extra_nodes,
         )
-        super(
-            PostgresEngine, self
-        ).__init__()  # lgtm[py/super-not-enclosing-class]
 
     async def prep_database(self):
         try:

--- a/piccolo/engine/postgres.py
+++ b/piccolo/engine/postgres.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from piccolo.engine.base import Batch, Engine
 from piccolo.engine.exceptions import TransactionError
 from piccolo.query.base import DDL, Query
+from piccolo.query.methods.objects import Create, GetOrCreate
 from piccolo.querystring import QueryString
 from piccolo.utils.lazy_loader import LazyLoader
 from piccolo.utils.sync import run_sync
@@ -98,52 +99,30 @@ class Atomic:
     def add(self, *query: Query):
         self.queries += list(query)
 
-    async def _run_queries(self, connection):
-        async with connection.transaction():
-            for query in self.queries:
-                if isinstance(query, Query):
-                    for querystring in query.querystrings:
-                        _query, args = querystring.compile_string(
-                            engine_type=self.engine.engine_type
-                        )
-                        await connection.execute(_query, *args)
-                elif isinstance(query, DDL):
-                    for ddl in query.ddl:
-                        await connection.execute(ddl)
-
-        self.queries = []
-
-    async def _run_in_pool(self):
-        if not self.engine.pool:
-            raise ValueError("No pool is currently active.")
-
-        async with self.engine.pool.acquire() as connection:
-            await self._run_queries(connection)
-
-    async def _run_in_new_connection(self):
-        connection = await asyncpg.connect(**self.engine.config)
+    async def run(self):
         try:
-            await self._run_queries(connection)
-        except asyncpg.exceptions.PostgresError as exception:
-            await connection.close()
-            raise exception
-
-        await connection.close()
-
-    async def run(self, in_pool=True):
-        if in_pool and self.engine.pool:
-            await self._run_in_pool()
-        else:
-            await self._run_in_new_connection()
+            async with self.engine.transaction():
+                for query in self.queries:
+                    if isinstance(query, (Query, DDL, Create, GetOrCreate)):
+                        await query.run()
+                    else:
+                        raise ValueError("Unrecognised query")
+            self.queries = []
+        except Exception as exception:
+            self.queries = []
+            raise exception from exception
 
     def run_sync(self):
-        return run_sync(self._run_in_new_connection())
+        return run_sync(self.run())
+
+    def __await__(self):
+        return self.run().__await__()
 
 
 ###############################################################################
 
 
-class Transaction:
+class PostgresTransaction:
     """
     Used for wrapping queries in a transaction, using a context manager.
     Currently it's async only.
@@ -160,7 +139,7 @@ class Transaction:
 
     def __init__(self, engine: PostgresEngine):
         self.engine = engine
-        if self.engine.transaction_connection.get():
+        if self.engine.current_transaction.get():
             raise TransactionError(
                 "A transaction is already active - nested transactions aren't "
                 "currently supported."
@@ -174,7 +153,7 @@ class Transaction:
 
         self.transaction = self.connection.transaction()
         await self.transaction.start()
-        self.context = self.engine.transaction_connection.set(self.connection)
+        self.context = self.engine.current_transaction.set(self)
 
     async def commit(self):
         await self.transaction.commit()
@@ -193,7 +172,7 @@ class Transaction:
         else:
             await self.connection.close()
 
-        self.engine.transaction_connection.reset(self.context)
+        self.engine.current_transaction.reset(self.context)
 
         return exception is None
 
@@ -201,9 +180,9 @@ class Transaction:
 ###############################################################################
 
 
-class PostgresEngine(Engine):
+class PostgresEngine(Engine[t.Optional[PostgresTransaction]]):
     """
-    Used to connect to Postgresql.
+    Used to connect to PostgreSQL.
 
     :param config:
         The config dictionary is passed to the underlying database adapter,
@@ -262,7 +241,7 @@ class PostgresEngine(Engine):
         "log_queries",
         "extra_nodes",
         "pool",
-        "transaction_connection",
+        "current_transaction",
     )
 
     engine_type = "postgres"
@@ -273,7 +252,7 @@ class PostgresEngine(Engine):
         config: t.Dict[str, t.Any],
         extensions: t.Sequence[str] = ("uuid-ossp",),
         log_queries: bool = False,
-        extra_nodes: t.Dict[str, PostgresEngine] = None,
+        extra_nodes: t.Mapping[str, PostgresEngine] = None,
     ) -> None:
         if extra_nodes is None:
             extra_nodes = {}
@@ -284,8 +263,8 @@ class PostgresEngine(Engine):
         self.extra_nodes = extra_nodes
         self.pool: t.Optional[Pool] = None
         database_name = config.get("database", "Unknown")
-        self.transaction_connection = contextvars.ContextVar(
-            f"pg_transaction_connection_{database_name}", default=None
+        self.current_transaction = contextvars.ContextVar(
+            f"pg_current_transaction_{database_name}", default=None
         )
         super().__init__()
 
@@ -451,9 +430,11 @@ class PostgresEngine(Engine):
             print(querystring)
 
         # If running inside a transaction:
-        connection = self.transaction_connection.get()
-        if connection:
-            return await connection.fetch(query, *query_args)
+        current_transaction = self.current_transaction.get()
+        if current_transaction:
+            return await current_transaction.connection.fetch(
+                query, *query_args
+            )
         elif in_pool and self.pool:
             return await self._run_in_pool(query, query_args)
         else:
@@ -464,9 +445,9 @@ class PostgresEngine(Engine):
             print(ddl)
 
         # If running inside a transaction:
-        connection = self.transaction_connection.get()
-        if connection:
-            return await connection.fetch(ddl)
+        current_transaction = self.current_transaction.get()
+        if current_transaction:
+            return await current_transaction.connection.fetch(ddl)
         elif in_pool and self.pool:
             return await self._run_in_pool(ddl)
         else:
@@ -475,5 +456,5 @@ class PostgresEngine(Engine):
     def atomic(self) -> Atomic:
         return Atomic(engine=self)
 
-    def transaction(self) -> Transaction:
-        return Transaction(engine=self)
+    def transaction(self) -> PostgresTransaction:
+        return PostgresTransaction(engine=self)

--- a/piccolo/engine/sqlite.py
+++ b/piccolo/engine/sqlite.py
@@ -602,11 +602,13 @@ class SQLiteEngine(Engine):
             query=ddl,
         )
 
-    def atomic(self) -> Atomic:
-        return Atomic(engine=self)
+    def atomic(
+        self, transaction_type: TransactionType = TransactionType.deferred
+    ) -> Atomic:
+        return Atomic(engine=self, transaction_type=transaction_type)
 
     def transaction(
-        self, transaction_type: TransactionType = TransactionType.immediate
+        self, transaction_type: TransactionType = TransactionType.deferred
     ) -> Transaction:
         """
         Create a new database transaction. See :class:`Transaction`.

--- a/tests/engine/test_transaction.py
+++ b/tests/engine/test_transaction.py
@@ -135,6 +135,25 @@ class TestTransaction(TestCase):
         self.assertNotEqual(txids, next_txids)
 
 
+class TestTransactionExists(TestCase):
+    def test_exists(self):
+        """
+        Make sure we can detect when code is within a transaction.
+        """
+        engine = t.cast(SQLiteEngine, Manager._meta.db)
+
+        async def run_inside_transaction():
+            async with engine.transaction():
+                return engine.transaction_exists()
+
+        self.assertTrue(asyncio.run(run_inside_transaction()))
+
+        async def run_outside_transaction():
+            return engine.transaction_exists()
+
+        self.assertFalse(asyncio.run(run_outside_transaction()))
+
+
 @engines_only("sqlite")
 class TestTransactionType(TestCase):
     def setUp(self):
@@ -143,7 +162,7 @@ class TestTransactionType(TestCase):
     def tearDown(self):
         Manager.alter().drop_table().run_sync()
 
-    def test_transaction_type(self):
+    def test_transaction(self):
         """
         With SQLite, we can specify the transaction type. This helps when
         we want to do concurrent writes, to avoid locking the database.
@@ -169,6 +188,38 @@ class TestTransactionType(TestCase):
             """
             await asyncio.gather(
                 *[run_transaction(name=name) for name in manager_names]
+            )
+
+        asyncio.run(run_all())
+
+        # Make sure it all ran effectively.
+        self.assertListEqual(
+            Manager.select(Manager.name)
+            .order_by(Manager.name)
+            .output(as_list=True)
+            .run_sync(),
+            manager_names,
+        )
+
+    def test_atomic(self):
+        """
+        Similar to above, but with ``Atomic``.
+        """
+        engine = t.cast(SQLiteEngine, Manager._meta.db)
+
+        async def run_atomic(name: str):
+            atomic = engine.atomic(transaction_type=TransactionType.immediate)
+            atomic.add(Manager.objects().get_or_create(Manager.name == name))
+            await atomic.run()
+
+        manager_names = [f"Manager_{i}" for i in range(1, 10)]
+
+        async def run_all():
+            """
+            Run all of the transactions concurrently.
+            """
+            await asyncio.gather(
+                *[run_atomic(name=name) for name in manager_names]
             )
 
         asyncio.run(run_all())


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/687
Fixes https://github.com/piccolo-orm/piccolo/issues/674

When using SQLite with asyncio, it's important to be able to specify the transaction type, to avoid database locks. This PR lets you specify the transaction type.

Remaining tasks:

- [x] Need improved docs for using SQLite / asyncio / transactions together effectively.
- [x] Mention the value of using `timeout` with `SQLiteEngine` in the docs.
- [x] Update unit tests

## Additional changes

In addition to adding `TransactionType:

* `add_m2m` should now work within an existing transaction.
* added `transaction_exists` to the engine, so you can find out if currently inside a transaction.
* Streamlined the code for `Atomic` - which now works with `get_or_create` queries.
* Improved the docstring for `SQLiteEngine`.
* Simplified `CockroachEngine`