### PR TITLE
add support for choices with `Array` columns

### DIFF
--- a/docs/src/piccolo/schema/advanced.rst
+++ b/docs/src/piccolo/schema/advanced.rst
@@ -140,6 +140,42 @@ By using choices, you get the following benefits:
 * Improved storage efficiency (we can store ``'l'`` instead of ``'large'``).
 * Piccolo Admin support
 
+``Array`` columns
+~~~~~~~~~~~~~~~~~
+
+You can also use choices with :class:`Array <piccolo.columns.column_types.Array>`
+columns.
+
+.. code-block:: python
+
+    class Ticket(Table):
+        class Extras(str, enum.Enum):
+            drink = "drink"
+            snack = "snack"
+            program = "program"
+
+        extras = Array(Varchar(), choices=Extras)
+
+Note how you pass ``choices`` to ``Array``, and not the ``base_column``:
+
+.. code-block:: python
+
+    # CORRECT:
+    Array(Varchar(), choices=Extras)
+
+    # INCORRECT:
+    Array(Varchar(choices=Extras))
+
+We can then use the ``Enum`` in our queries:
+
+.. code-block:: python
+
+    >>> await Ticket.insert(
+    ...     Ticket(extras=[Extras.drink, Extras.snack]),
+    ...     Ticket(extras=[Extras.program]),
+    ... )
+
+
 -------------------------------------------------------------------------------
 
 Reflection

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -570,6 +570,11 @@ class Column(Selectable):
         """
         Make sure the choices value has values of the allowed_type.
         """
+        if getattr(self, "_validated_choices", None):
+            # If it has previously been validated by a subclass, don't
+            # validate again.
+            return True
+
         for element in choices:
             if isinstance(element.value, allowed_type):
                 continue
@@ -581,6 +586,8 @@ class Column(Selectable):
                 raise ValueError(
                     f"{element.name} doesn't have the correct type"
                 )
+
+        self._validated_choices = True
 
         return True
 

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -2472,8 +2472,15 @@ class Array(Column):
 
         self._validate_default(default, (list, None))
 
+        choices = kwargs.get("choices")
+        if choices is not None:
+            self._validate_choices(
+                choices, allowed_type=base_column.value_type
+            )
+            self._validated_choices = True
+
         # Usually columns are given a name by the Table metaclass, but in this
-        # case we have to assign one manually.
+        # case we have to assign one manually to the base column.
         base_column._meta._name = base_column.__class__.__name__
 
         self.base_column = base_column

--- a/piccolo/utils/sql_values.py
+++ b/piccolo/utils/sql_values.py
@@ -35,5 +35,7 @@ def convert_to_sql_value(value: t.Any, column: Column) -> t.Any:
         return value.value
     elif isinstance(column, (JSON, JSONB)) and not isinstance(value, str):
         return None if value is None else dump_json(value)
+    elif isinstance(value, list):
+        return [convert_to_sql_value(value=i, column=column) for i in value]
     else:
         return value

--- a/piccolo/utils/sql_values.py
+++ b/piccolo/utils/sql_values.py
@@ -5,6 +5,7 @@ import typing as t
 from enum import Enum
 
 from piccolo.utils.encoding import dump_json
+from piccolo.utils.warnings import colored_warning
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from piccolo.columns import Column
@@ -37,6 +38,11 @@ def convert_to_sql_value(value: t.Any, column: Column) -> t.Any:
     elif isinstance(column, (JSON, JSONB)) and not isinstance(value, str):
         return None if value is None else dump_json(value)
     elif isinstance(value, list):
+        if len(value) > 100:
+            colored_warning(
+                "When using large lists, consider bypassing the ORM and "
+                "using SQL directly for improved performance."
+            )
         # Attempt to do this as performantly as possible.
         func = functools.partial(convert_to_sql_value, column=column)
         return list(map(func, value))

--- a/piccolo/utils/sql_values.py
+++ b/piccolo/utils/sql_values.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import typing as t
 from enum import Enum
 
@@ -36,6 +37,8 @@ def convert_to_sql_value(value: t.Any, column: Column) -> t.Any:
     elif isinstance(column, (JSON, JSONB)) and not isinstance(value, str):
         return None if value is None else dump_json(value)
     elif isinstance(value, list):
-        return [convert_to_sql_value(value=i, column=column) for i in value]
+        # Attempt to do this as performantly as possible.
+        func = functools.partial(convert_to_sql_value, column=column)
+        return list(map(func, value))
     else:
         return value

--- a/tests/columns/test_choices.py
+++ b/tests/columns/test_choices.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from piccolo.columns.column_types import Array, Varchar
 from piccolo.table import Table
+from tests.base import engines_only
 from tests.example_apps.music.tables import Shirt
 
 
@@ -84,7 +85,12 @@ class Ticket(Table):
     extras = Array(Varchar(), choices=Extras)
 
 
+@engines_only("postgres", "sqlite")
 class TestArrayChoices(TestCase):
+    """
+    🐛 Cockroach bug: https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
+    """  # noqa: E501
+
     def setUp(self):
         Ticket.create_table().run_sync()
 

--- a/tests/columns/test_choices.py
+++ b/tests/columns/test_choices.py
@@ -1,8 +1,18 @@
-from tests.base import DBTestCase
+import enum
+from unittest import TestCase
+
+from piccolo.columns.column_types import Array, Varchar
+from piccolo.table import Table
 from tests.example_apps.music.tables import Shirt
 
 
-class TestChoices(DBTestCase):
+class TestChoices(TestCase):
+    def setUp(self):
+        Shirt.create_table().run_sync()
+
+    def tearDown(self):
+        Shirt.alter().drop_table().run_sync()
+
     def _insert_shirts(self):
         Shirt.insert(
             Shirt(size=Shirt.Size.small),
@@ -63,3 +73,70 @@ class TestChoices(DBTestCase):
         )
         self.assertEqual(len(shirts), 1)
         self.assertEqual(shirts[0].size, "s")
+
+
+class Ticket(Table):
+    class Extras(str, enum.Enum):
+        drink = "drink"
+        snack = "snack"
+        program = "program"
+
+    extras = Array(Varchar(), choices=Extras)
+
+
+class TestArrayChoices(TestCase):
+    def setUp(self):
+        Ticket.create_table().run_sync()
+
+    def tearDown(self):
+        Ticket.alter().drop_table().run_sync()
+
+    def test_string(self):
+        """
+        Make sure strings can be passed in as choices.
+        """
+        ticket = Ticket(extras=["drink", "snack", "program"])
+        ticket.save().run_sync()
+
+        self.assertListEqual(
+            Ticket.select(Ticket.extras).run_sync(),
+            [{"extras": ["drink", "snack", "program"]}],
+        )
+
+    def test_enum(self):
+        """
+        Make sure enums can be passed in as choices.
+        """
+        ticket = Ticket(
+            extras=[
+                Ticket.Extras.drink,
+                Ticket.Extras.snack,
+                Ticket.Extras.program,
+            ]
+        )
+        ticket.save().run_sync()
+
+        self.assertListEqual(
+            Ticket.select(Ticket.extras).run_sync(),
+            [{"extras": ["drink", "snack", "program"]}],
+        )
+
+    def test_invalid_choices(self):
+        """
+        Make sure an invalid choices Enum is rejected.
+        """
+        with self.assertRaises(ValueError) as manager:
+
+            class Ticket(Table):
+                # This will be rejected, because the values are ints, and the
+                # Array's base_column is Varchar.
+                class Extras(int, enum.Enum):
+                    drink = 1
+                    snack = 2
+                    program = 3
+
+                extras = Array(Varchar(), choices=Extras)
+
+        self.assertEqual(
+            manager.exception.__str__(), "drink doesn't have the correct type"
+        )

--- a/tests/utils/test_sql_values.py
+++ b/tests/utils/test_sql_values.py
@@ -1,5 +1,8 @@
+import time
 from enum import Enum
 from unittest import TestCase
+
+import pytest
 
 from piccolo.columns.column_types import JSON, JSONB, Array, Integer, Varchar
 from piccolo.table import Table
@@ -80,3 +83,19 @@ class TestConvertToSQLValue(TestCase):
             ),
             ["r", "g", "b"],
         )
+
+    @pytest.mark.speed
+    def test_convert_large_list(self):
+        """
+        Large lists are problematic. We need to check each value in the list,
+        but as efficiently as possible.
+        """
+        start = time.time()
+
+        convert_to_sql_value(
+            value=[i for i in range(1000)],
+            column=Array(Varchar()),
+        )
+
+        duration = time.time() - start
+        print(duration)

--- a/tests/utils/test_sql_values.py
+++ b/tests/utils/test_sql_values.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from unittest import TestCase
 
-from piccolo.columns.column_types import JSON, JSONB, Integer, Varchar
+from piccolo.columns.column_types import JSON, JSONB, Array, Integer, Varchar
 from piccolo.table import Table
 from piccolo.utils.sql_values import convert_to_sql_value
 
@@ -48,10 +48,10 @@ class TestConvertToSQLValue(TestCase):
         """
 
         class Colour(Enum):
-            red = "red"
+            red = "r"
 
         self.assertEqual(
-            convert_to_sql_value(value=Colour.red, column=Varchar()), "red"
+            convert_to_sql_value(value=Colour.red, column=Varchar()), "r"
         )
 
     def test_other(self):
@@ -61,4 +61,22 @@ class TestConvertToSQLValue(TestCase):
         self.assertEqual(
             convert_to_sql_value(value=1, column=Integer()),
             1,
+        )
+
+    def test_convert_enum_list(self):
+        """
+        It's possible to have a list of enums when using ``Array`` columns.
+        """
+
+        class Colour(Enum):
+            red = "r"
+            green = "g"
+            blue = "b"
+
+        self.assertEqual(
+            convert_to_sql_value(
+                value=[Colour.red, Colour.green, Colour.blue],
+                column=Array(Varchar()),
+            ),
+            ["r", "g", "b"],
         )


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/702

There were some issues before when specifying choices for `Array` columns, and it wasn't clear which of these to use:

```python
Array(Varchar(choices=SomeEnum))
Array(Varchar(), choices=SomeEnum))
```

This PR adds a bunch of tests, and updates the docs to make it clear that this is what you should do:

```python
Array(Varchar(), choices=SomeEnum))
```