### PR TITLE
Expose pydantic config class to user

### DIFF
--- a/docs/src/piccolo/serialization/index.rst
+++ b/docs/src/piccolo/serialization/index.rst
@@ -154,6 +154,29 @@ By default the primary key column isn't included - you can add it using:
 
     BandModel = create_pydantic_model(Band, include_default_columns=True)
 
+``pydantic_config_class``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can specify a custom class to use as base for the pydantic model's config.
+This class should be a subclass of ``pydantic.BaseConfig``.
+For example, let's set the ``extra`` parameter to tell pydantic how to treat
+extra fields (that is, fields that would not otherwise be in the generated model).
+The allowed values are::
+
+* ``'ignore'`` (default): silently ignore extra fields
+* ``'allow'``: accept the extra fields and assigns them to the model
+* ``'forbid'``: fail validation if extra fields are present
+
+So if we want to disallow extra fields, we can do:
+
+.. code-block:: python
+
+    class MyPydanticConfig(pydantic.BaseConfig):
+        extra = 'forbid'
+
+    model = create_pydantic_model(table=MyTable, pydantic_config_class=MyPydanticConfig, ...)
+
+
 Required fields
 ~~~~~~~~~~~~~~~
 

--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -90,6 +90,7 @@ def create_pydantic_model(
     deserialize_json: bool = False,
     recursion_depth: int = 0,
     max_recursion_depth: int = 5,
+    pydantic_config_class: t.Type[pydantic.BaseConfig] = pydantic.BaseConfig,
     **schema_extra_kwargs,
 ) -> t.Type[pydantic.BaseModel]:
     """
@@ -132,6 +133,10 @@ def create_pydantic_model(
         Not to be set by the user - used internally to track recursion.
     :param max_recursion_depth:
         If using nested models, this specifies the max amount of recursion.
+    :param pydantic_config_class:
+        Config class to use as base for the generated pydantic model
+        (default: ``pydantic.BaseConfig``). You can create your own
+        subclass of ``pydantic.BaseConfig`` and pass it here.
     :param schema_extra_kwargs:
         This can be used to add additional fields to the schema. This is
         very useful when using Pydantic's JSON Schema features. For example:
@@ -301,7 +306,7 @@ def create_pydantic_model(
 
         columns[column_name] = (_type, field)
 
-    class CustomConfig(Config):
+    class CustomConfig(Config, pydantic_config_class):  # type: ignore
         schema_extra = {
             "help_text": table._meta.help_text,
             **schema_extra_kwargs,


### PR DESCRIPTION
`create_pydantic_model` accepts a new argument specifying the base class
to use for the generated model config.

Should partially fix #467.
