### PR TITLE
`get_or_create` with null values

### DIFF
--- a/piccolo/columns/combination.py
+++ b/piccolo/columns/combination.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import typing as t
 
-from piccolo.columns.operators.comparison import ComparisonOperator, Equal
+from piccolo.columns.operators.comparison import (
+    ComparisonOperator,
+    Equal,
+    IsNull,
+)
 from piccolo.custom_types import Combinable, Iterable
 from piccolo.querystring import QueryString
 from piccolo.utils.sql_values import convert_to_sql_value
@@ -52,18 +56,22 @@ class And(Combination):
         This is used by `get_or_create` to know which values to assign if
         the row doesn't exist in the database.
 
-        For example, if we have:
+        For example, if we have::
 
-        (Band.name == 'Pythonistas') & (Band.popularity == 1000)
+            (Band.name == 'Pythonistas') & (Band.popularity == 1000)
 
-        We will return {Band.name: 'Pythonistas', Band.popularity: 1000}.
+        We will return::
+
+            {Band.name: 'Pythonistas', Band.popularity: 1000}.
 
         If the operator is anything besides equals, we don't return it, for
-        example:
+        example::
 
-        (Band.name == 'Pythonistas') & (Band.popularity > 1000)
+            (Band.name == 'Pythonistas') & (Band.popularity > 1000)
 
-        Returns {Band.name: 'Pythonistas'}
+        Returns::
+
+            {Band.name: 'Pythonistas'}
 
         """
         output = {}
@@ -71,6 +79,8 @@ class And(Combination):
             if isinstance(combinable, Where):
                 if combinable.operator == Equal:
                     output[combinable.column] = combinable.value
+                elif combinable.operator == IsNull:
+                    output[combinable.column] = None
             elif isinstance(combinable, And):
                 output.update(combinable.get_column_values())
 

--- a/tests/columns/test_combination.py
+++ b/tests/columns/test_combination.py
@@ -36,3 +36,21 @@ class TestWhere(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Band.name.not_in([])
+
+
+class TestAnd(unittest.TestCase):
+    def test_get_column_values(self):
+        """
+        Make sure that we can extract the column values from an ``And``.
+
+        There was a bug with ``None`` values not working:
+
+        https://github.com/piccolo-orm/piccolo/issues/715
+
+        """
+        And_ = (Band.manager.is_null()) & (Band.name == "Pythonistas")
+        column_values = And_.get_column_values()
+
+        self.assertDictEqual(
+            column_values, {Band.name: "Pythonistas", Band.manager: None}
+        )


### PR DESCRIPTION
Make sure that `get_or_create` works correctly with null values.

Fixes https://github.com/piccolo-orm/piccolo/issues/715