### PR TITLE
tweak docs for Pydantic base class

### DIFF
--- a/docs/src/piccolo/serialization/index.rst
+++ b/docs/src/piccolo/serialization/index.rst
@@ -157,11 +157,12 @@ By default the primary key column isn't included - you can add it using:
 ``pydantic_config_class``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can specify a custom class to use as base for the pydantic model's config.
+You can specify a custom class to use as the base for the Pydantic model's config.
 This class should be a subclass of ``pydantic.BaseConfig``.
+
 For example, let's set the ``extra`` parameter to tell pydantic how to treat
 extra fields (that is, fields that would not otherwise be in the generated model).
-The allowed values are::
+The allowed values are:
 
 * ``'ignore'`` (default): silently ignore extra fields
 * ``'allow'``: accept the extra fields and assigns them to the model
@@ -174,7 +175,10 @@ So if we want to disallow extra fields, we can do:
     class MyPydanticConfig(pydantic.BaseConfig):
         extra = 'forbid'
 
-    model = create_pydantic_model(table=MyTable, pydantic_config_class=MyPydanticConfig, ...)
+    model = create_pydantic_model(
+        table=MyTable,
+        pydantic_config_class=MyPydanticConfig
+    )
 
 
 Required fields
@@ -187,7 +191,7 @@ argument of :class:`Column <piccolo.columns.base.Column>`. For example:
 
     class Band(Table):
         name = Varchar(required=True)
-    
+
     BandModel = create_pydantic_model(Band)
 
     # Omitting the field raises an error:
@@ -202,7 +206,7 @@ all fields to be optional.
 
     class Band(Table):
         name = Varchar(required=True)
-    
+
     BandFilterModel = create_pydantic_model(
         Band,
         all_optional=True,
@@ -222,12 +226,12 @@ add additional fields, and to override existing fields.
 
     class Band(Table):
         name = Varchar(required=True)
-    
+
     BandModel = create_pydantic_model(Band)
 
     class CustomBandModel(BandModel):
         genre: str
-    
+
     >>> CustomBandModel(name="Pythonistas", genre="Rock")
 
 Source

--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -90,7 +90,7 @@ def create_pydantic_model(
     deserialize_json: bool = False,
     recursion_depth: int = 0,
     max_recursion_depth: int = 5,
-    pydantic_config_class: t.Type[pydantic.BaseConfig] = pydantic.BaseConfig,
+    pydantic_config_class: t.Optional[t.Type[pydantic.BaseConfig]] = None,
     **schema_extra_kwargs,
 ) -> t.Type[pydantic.BaseModel]:
     """
@@ -134,9 +134,8 @@ def create_pydantic_model(
     :param max_recursion_depth:
         If using nested models, this specifies the max amount of recursion.
     :param pydantic_config_class:
-        Config class to use as base for the generated pydantic model
-        (default: ``pydantic.BaseConfig``). You can create your own
-        subclass of ``pydantic.BaseConfig`` and pass it here.
+        Config class to use as base for the generated pydantic model. You can
+        create your own subclass of ``pydantic.BaseConfig`` and pass it here.
     :param schema_extra_kwargs:
         This can be used to add additional fields to the schema. This is
         very useful when using Pydantic's JSON Schema features. For example:
@@ -306,7 +305,11 @@ def create_pydantic_model(
 
         columns[column_name] = (_type, field)
 
-    class CustomConfig(Config, pydantic_config_class):  # type: ignore
+    base_classes: t.List[t.Type[pydantic.BaseConfig]] = [Config]
+    if pydantic_config_class:
+        base_classes.append(pydantic_config_class)
+
+    class CustomConfig(*base_classes):  # type: ignore
         schema_extra = {
             "help_text": table._meta.help_text,
             **schema_extra_kwargs,


### PR DESCRIPTION
I had to tweak the docs slightly, because the Sphinx output breaks when the default value is a class.

```python
# the repr of a class has angled brackets, which cause havoc with HTML templates
pydantic_config_class: t.Type[pydantic.BaseConfig] = pydantic.BaseConfig,
```