### PR TITLE
Update migration docs and tests

### DIFF
--- a/docs/src/piccolo/migrations/create.rst
+++ b/docs/src/piccolo/migrations/create.rst
@@ -21,15 +21,20 @@ First, let's create an empty migration:
 
     piccolo migrations new my_app
 
-This creates a new migration file in the migrations folder of the app. The
-migration filename is a timestamp:
+This creates a new migration file in the migrations folder of the app. By
+default, the migration filename is the name of the app, followed by a timestamp,
+but you can rename it to anything you want:
 
 .. code-block:: bash
 
     piccolo_migrations/
-        2022-02-26T17-38-44-758593.py
+        my_app_2022_12_06T13_58_23_024723.py
 
-.. hint:: You can rename this file if you like to make it more memorable.
+.. note::
+    We changed the naming convention for migration files in version ``0.102.0``
+    (previously they were like ``2022-12-06T13-58-23-024723.py``). As mentioned,
+    the name isn't important - change it to anything you want. The new format
+    was chosen because a Python file should start with a letter by convention.
 
 The contents of an empty migration file looks like this:
 

--- a/docs/src/piccolo/migrations/running.rst
+++ b/docs/src/piccolo/migrations/running.rst
@@ -3,6 +3,7 @@ Running migrations
 
 .. hint:: To see all available options for these commands, use the ``--help``
     flag, for example ``piccolo migrations forwards --help``.
+
 .. hint:: To see the SQL queries of a migration without actually running them , use the ``--preview``
     flag, for example: ``piccolo migrations forwards my_app --preview``  or  ``piccolo migrations backwards 2018-09-04T19:44:09 --preview``.
 
@@ -20,11 +21,15 @@ When the migration is run, the forwards function is executed. To do this:
 Reversing migrations
 --------------------
 
-To reverse the migration, run this:
+To reverse the migration, run the following command, specifying the ID of a
+migration:
 
 .. code-block:: bash
 
-    piccolo migrations backwards 2018-09-04T19:44:09
+    piccolo migrations backwards my_app 2018-09-04T19:44:09
+
+Piccolo will then reverse the migrations for the given app, starting with the
+most recent migration, up to and including the migration with the specified ID.
 
 You can try going forwards and backwards a few times to make sure it works as
 expected.

--- a/piccolo/apps/migrations/commands/new.py
+++ b/piccolo/apps/migrations/commands/new.py
@@ -90,7 +90,7 @@ def _generate_migration_meta(app_config: AppConfig) -> NewMigrationMeta:
     cleaned_app_name = "".join(
         [
             i
-            for i in app_config.app_name.lower().replace('-', '_')
+            for i in app_config.app_name.lower().replace("-", "_")
             if i in VALID_PYTHON_MODULE_CHARACTERS
         ]
     )

--- a/tests/apps/migrations/commands/test_new.py
+++ b/tests/apps/migrations/commands/test_new.py
@@ -72,9 +72,28 @@ class TestGenerateMigrationMeta(TestCase):
             second=20,
             microsecond=3000,
         )
+
+        # Try with an app name which already contains valid characters for a
+        # Python module.
         migration_meta = _generate_migration_meta(
             app_config=AppConfig(
                 app_name="app_name",
+                migrations_folder_path="/tmp/",
+            )
+        )
+        self.assertEqual(
+            migration_meta.migration_filename,
+            "app_name_2022_01_10t07_15_20_003000",
+        )
+        self.assertEqual(
+            migration_meta.migration_path,
+            "/tmp/app_name_2022_01_10t07_15_20_003000.py",
+        )
+
+        # Try with an app name with invalid characters for a Python module.
+        migration_meta = _generate_migration_meta(
+            app_config=AppConfig(
+                app_name="App-Name!",
                 migrations_folder_path="/tmp/",
             )
         )


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/711

We changed the naming of new migration files so they follow Python conventions (start with a letter, and then only include `_`, `0-9`, and `a-z`.

https://github.com/piccolo-orm/piccolo/pull/712

This PR adds some extra tests for the new migration file names, and updates the docs for migrations.

