### PR TITLE
Handle large fixtures

### DIFF
--- a/piccolo/utils/list.py
+++ b/piccolo/utils/list.py
@@ -25,3 +25,37 @@ def flatten(
             _items.append(item)
 
     return _items
+
+
+def batch(
+    data: t.List[ElementType], chunk_size: int
+) -> t.List[t.List[ElementType]]:
+    """
+    Breaks the list down into sublists of the given ``chunk_size``. The last
+    sublist may have fewer elements than ``chunk_size``::
+
+        >>> batch(['a', 'b', 'c'], 2)
+        [['a', 'b'], ['c']]
+
+    :param data:
+        The data to break up into sublists.
+    :param chunk_size:
+        How large each sublist should be.
+
+    """
+    # TODO: Replace with itertools.batch when available:
+    # https://docs.python.org/3.12/library/itertools.html#itertools.batched
+
+    if chunk_size <= 0:
+        raise ValueError("`chunk_size` must be greater than 0.")
+
+    row_count = len(data)
+
+    iterations = int(row_count / chunk_size)
+    if row_count % chunk_size > 0:
+        iterations += 1
+
+    return [
+        data[(i * chunk_size) : ((i + 1) * chunk_size)]  # noqa: E203
+        for i in range(0, iterations)
+    ]

--- a/tests/utils/test_list.py
+++ b/tests/utils/test_list.py
@@ -1,8 +1,28 @@
+import string
 from unittest import TestCase
 
-from piccolo.utils.list import flatten
+from piccolo.utils.list import batch, flatten
 
 
 class TestFlatten(TestCase):
     def test_flatten(self):
         self.assertListEqual(flatten(["a", ["b", "c"]]), ["a", "b", "c"])
+
+
+class TestBatch(TestCase):
+    def test_batch(self):
+        self.assertListEqual(
+            batch([i for i in string.ascii_lowercase], chunk_size=5),
+            [
+                ["a", "b", "c", "d", "e"],
+                ["f", "g", "h", "i", "j"],
+                ["k", "l", "m", "n", "o"],
+                ["p", "q", "r", "s", "t"],
+                ["u", "v", "w", "x", "y"],
+                ["z"],
+            ],
+        )
+
+    def test_zero(self):
+        with self.assertRaises(ValueError):
+            batch([1, 2, 3], chunk_size=0)


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/733

If the fixtures contains a large number of rows, we could get an error the from the database adapter.

We now insert the rows in sensibly sized chunks.