### PR TITLE
version pin fastapi

### DIFF
--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -14,6 +14,7 @@ ROUTERS = ["starlette", "fastapi", "blacksheep", "xpresso", "starlite"]
 ROUTER_DEPENDENCIES = {
     "starlite": ["starlite>=1.46.0"],
     "xpresso": ["xpresso==0.43.0", "di==0.72.1"],
+    "fastapi": ["fastapi==0.88.0"],
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/749

FasAPI has some breaking changes in version `0.89.0`, so version pinning to `0.88.0` for now.

This is a temporary fix - would be better to fix the ASGI template so it works with the most recent FastAPI version.