### PR TITLE
add note about using double quotes when using `pip install` on Windows

### DIFF
--- a/docs/src/piccolo/getting_started/installing_piccolo.rst
+++ b/docs/src/piccolo/getting_started/installing_piccolo.rst
@@ -40,3 +40,7 @@ Now install Piccolo, ideally inside a `virtualenv <https://docs.python-guide.org
     # If you just want Piccolo with all of it's functionality, you might prefer
     # to use this:
     pip install 'piccolo[all]'
+
+.. hint::
+    On Windows, you may need to use double quotes instead. For example
+    ``pip install "piccolo[all]"``.


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/752