### PR TITLE
clarify Piccolo's support for SQLite

### DIFF
--- a/docs/src/piccolo/getting_started/database_support.rst
+++ b/docs/src/piccolo/getting_started/database_support.rst
@@ -4,10 +4,15 @@ Database Support
 ================
 
 `Postgres <https://www.postgresql.org/>`_ is the primary database which Piccolo
-was designed for.
+was designed for. It's robust, feature rich, and a great choice for most projects.
 
-`CockroachDB <https://www.cockroachlabs.com/>`_ is in experimental beta.
+`CockroachDB <https://www.cockroachlabs.com/>`_ is also supported. It's designed
+to be scalable and fault tolerant, and is mostly compatible with Postgres.
+There may be some minor features not supported, but it's OK to use.
 
-Limited `SQLite <https://www.sqlite.org/index.html>`_ support is available,
-mostly to enable tooling like the :ref:`playground <Playground>`. Postgres is the only database we
-recommend for use in production with Piccolo.
+`SQLite <https://www.sqlite.org/index.html>`_ support was originally added to
+enable tooling like the :ref:`playground <Playground>`, but over time we've
+added more and more support. Many people successfully use SQLite and Piccolo
+together in production. The main missing feature is support for
+:ref:`automatic database migrations <AutoMigrations>` due to SQLite's limited
+support for ``ALTER TABLE`` ``DDL`` statements.


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/767

The documentation is confusing, as it underplays our support for SQLite (which at this point is very robust, and can be used in production).