### PR TITLE
initial implementation for `DISTINCT ON`

### DIFF
--- a/docs/src/piccolo/query_clauses/distinct.rst
+++ b/docs/src/piccolo/query_clauses/distinct.rst
@@ -13,3 +13,63 @@ You can use ``distinct`` clauses with the following queries:
     [{'title': 'Pythonistas'}]
 
 This is equivalent to ``SELECT DISTINCT name FROM band`` in SQL.
+
+on
+--
+
+Using the ``on`` parameter we can create ``DISTINCT ON`` queries.
+
+.. note:: Postgres and CockroachDB only. For more info, see the `Postgres docs <https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT>`_.
+
+If we have the following table:
+
+.. code-block:: python
+
+    class Album(Table):
+        band = Varchar()
+        title = Varchar()
+        release_date = Date()
+
+With this data in the database:
+
+.. csv-table:: Albums
+   :file: ./distinct/albums.csv
+   :header-rows: 1
+
+To get the latest album for each band, we can do so with a query like this:
+
+.. code-block:: python
+
+    >>> await Album.select().distinct(
+    ...     on=[Album.band]
+    ... ).order_by(
+    ...     Album.band
+    ... ).order_by(
+    ...     Album.release_date,
+    ...     ascending=False
+    ... )
+
+    [
+        {
+            'id': 2,
+            'band': 'Pythonistas',
+            'title': 'Py album 2022',
+            'release_date': '2022-12-01'
+        },
+        {
+            'id': 4,
+            'band': 'Rustaceans',
+            'title': 'Rusty album 2022',
+            'release_date': '2022-12-01'
+        },
+    ]
+
+The first column specified in ``on`` must match the first column specified in
+``order_by``, otherwise a :class:`DistinctOnError <piccolo.query.mixins.DistinctOnError>` will be raised.
+
+Source
+~~~~~~
+
+.. currentmodule:: piccolo.query.mixins
+
+.. autoclass:: DistinctOnError

--- a/docs/src/piccolo/query_clauses/distinct/albums.csv
+++ b/docs/src/piccolo/query_clauses/distinct/albums.csv
@@ -1,0 +1,5 @@
+id,band,title,release_date
+1,Pythonistas,Py album 2021,2021-12-01
+2,Pythonistas,Py album 2022,2022-12-01
+3,Rustaceans,Rusty album 2021,2021-12-01
+4,Rustaceans,Rusty album 2022,2022-12-01

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -136,8 +136,7 @@ def populate():
     """
     for _table in reversed(TABLES):
         try:
-            if _table.table_exists().run_sync():
-                _table.alter().drop_table().run_sync()
+            _table.alter().drop_table(if_exists=True).run_sync()
         except Exception as e:
             print(e)
 
@@ -184,10 +183,26 @@ def populate():
         *[DiscountCode({DiscountCode.code: uuid.uuid4()}) for _ in range(5)]
     ).run_sync()
 
-    recording_studio = RecordingStudio(
-        name="Abbey Road", facilities={"restaurant": True, "mixing_desk": True}
-    )
-    recording_studio.save().run_sync()
+    RecordingStudio.insert(
+        RecordingStudio(
+            {
+                RecordingStudio.name: "Abbey Road",
+                RecordingStudio.facilities: {
+                    "restaurant": True,
+                    "mixing_desk": True,
+                },
+            }
+        ),
+        RecordingStudio(
+            {
+                RecordingStudio.name: "Electric Lady",
+                RecordingStudio.facilities: {
+                    "restaurant": False,
+                    "mixing_desk": True,
+                },
+            },
+        ),
+    ).run_sync()
 
 
 def run(

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -180,8 +180,9 @@ def populate():
     ticket = Ticket(concert=concert.id, price=Decimal("50.0"))
     ticket.save().run_sync()
 
-    discount_code = DiscountCode(code=uuid.uuid4())
-    discount_code.save().run_sync()
+    DiscountCode.insert(
+        *[DiscountCode({DiscountCode.code: uuid.uuid4()}) for _ in range(5)]
+    ).run_sync()
 
     recording_studio = RecordingStudio(
         name="Abbey Road", facilities={"restaurant": True, "mixing_desk": True}

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -358,7 +358,7 @@ class Select(Query[TableInstance, t.List[t.Dict[str, t.Any]]]):
     ) -> Self:
         if on is not None and self.engine_type not in (
             "postgres",
-            "coackroach",
+            "cockroach",
         ):
             raise ValueError(
                 "Only Postgres and Cockroach supports DISTINCT ON"

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -735,9 +735,14 @@ class Select(Query[TableInstance, t.List[t.Dict[str, t.Any]]]):
         args: t.List[t.Any] = []
 
         query = "SELECT"
-        if self.distinct_delegate._distinct:
+
+        distinct = self.distinct_delegate._distinct
+        if distinct:
+            if distinct.on:
+                distinct.validate_on(self.order_by_delegate._order_by)
+
             query += "{}"
-            args.append(self.distinct_delegate._distinct.querystring)
+            args.append(distinct.querystring)
 
         query += f" {columns_str} FROM {self.table._meta.tablename}"
 

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -353,8 +353,18 @@ class Select(Query[TableInstance, t.List[t.Dict[str, t.Any]]]):
         self.columns_delegate.columns(*_columns)
         return self
 
-    def distinct(self: Self) -> Self:
-        self.distinct_delegate.distinct()
+    def distinct(
+        self: Self, *, on: t.Optional[t.Sequence[Column]] = None
+    ) -> Self:
+        if on is not None and self.engine_type not in (
+            "postgres",
+            "coackroach",
+        ):
+            raise ValueError(
+                "Only Postgres and Cockroach supports DISTINCT ON"
+            )
+
+        self.distinct_delegate.distinct(enabled=True, on=on)
         return self
 
     def group_by(self: Self, *columns: t.Union[Column, str]) -> Self:
@@ -722,17 +732,17 @@ class Select(Query[TableInstance, t.List[t.Dict[str, t.Any]]]):
 
         #######################################################################
 
-        select = (
-            "SELECT DISTINCT" if self.distinct_delegate._distinct else "SELECT"
-        )
-        query = f"{select} {columns_str} FROM {self.table._meta.tablename}"
+        args: t.List[t.Any] = []
+
+        query = "SELECT"
+        if self.distinct_delegate._distinct:
+            query += "{}"
+            args.append(self.distinct_delegate._distinct.querystring)
+
+        query += f" {columns_str} FROM {self.table._meta.tablename}"
 
         for join in joins:
             query += f" {join}"
-
-        #######################################################################
-
-        args: t.List[t.Any] = []
 
         if self.as_of_delegate._as_of:
             query += "{}"

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -287,7 +287,9 @@ class AsOfDelegate:
 @dataclass
 class DistinctDelegate:
 
-    _distinct: Distinct = Distinct(enabled=False, on=None)
+    _distinct: Distinct = field(
+        default_factory=lambda: Distinct(enabled=False, on=None)
+    )
 
     def distinct(
         self, enabled: bool, on: t.Optional[t.Sequence[Column]] = None

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -292,7 +292,7 @@ class DistinctDelegate:
     def distinct(
         self, enabled: bool, on: t.Optional[t.Sequence[Column]] = None
     ):
-        if not isinstance(on, collections.abc.Sequence):
+        if on and not isinstance(on, collections.abc.Sequence):
             # Check a sequence is passed in, otherwise the user will get some
             # unuseful errors later on.
             raise ValueError("`on` must be a sequence")

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -20,6 +20,10 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 class DistinctOnError(ValueError):
+    """
+    Raised when ``DISTINCT ON`` queries are malformed.
+    """
+
     pass
 
 

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -297,7 +297,7 @@ class DistinctDelegate:
         if on and not isinstance(on, collections.abc.Sequence):
             # Check a sequence is passed in, otherwise the user will get some
             # unuseful errors later on.
-            raise ValueError("`on` must be a sequence")
+            raise ValueError("`on` must be a sequence of `Column` instances")
 
         self._distinct = Distinct(enabled=enabled, on=on)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ ENGINE = engine_finder()
 
 
 async def drop_tables():
-    for table in [
+    tables = [
         "ticket",
         "concert",
         "venue",
@@ -21,13 +21,26 @@ async def drop_tables():
         "instrument",
         "mega_table",
         "small_table",
-    ]:
-        await ENGINE._run_in_new_connection(f"DROP TABLE IF EXISTS {table}")
+    ]
+    assert ENGINE
+
+    if ENGINE.engine_type == "sqlite":
+        # SQLite doesn't allow us to drop more than one table at a time.
+        for table in tables:
+            await ENGINE._run_in_new_connection(
+                f"DROP TABLE IF EXISTS {table}"
+            )
+    else:
+        table_str = ", ".join(tables)
+        await ENGINE._run_in_new_connection(
+            f"DROP TABLE IF EXISTS {table_str} CASCADE"
+        )
 
 
 def pytest_sessionstart(session):
     """
-    Make sure all the tables have been dropped.
+    Make sure all the tables have been dropped, just in case a previous test
+    run was aborted part of the way through.
 
     https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_configure
     """


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/812

Inspired by https://github.com/piccolo-orm/piccolo/compare/master...sinisaos:piccolo:distinct_on_clause by @sinisaos 

Remaining tasks:

- [x] Make sure a `ValueError` is raised if being used by SQLite
- [x] ~~Make sure joins work (should be OK, as we need to specify the same column for order_by for it to work anyway)~~
- [x] Use a different example table, to make it consistent with other tests
- [x] Adapt docs from @sinisaos PR
- [x] Add test to make sure passing in something other than a sequence raises an error.