### PR TITLE
fix serialised tables which are in a specific schema

### DIFF
--- a/piccolo/apps/migrations/auto/serialisation.py
+++ b/piccolo/apps/migrations/auto/serialisation.py
@@ -392,9 +392,15 @@ class SerialisedTableType(Definition):
 
         #######################################################################
 
+        schema_str = (
+            "None"
+            if self.table_type._meta.schema is None
+            else f'"{self.table_type._meta.schema}"'
+        )
+
         definition = (
             f"class {self.table_class_name}"
-            f'({UniqueGlobalNames.TABLE}, tablename="{tablename}"): '
+            f'({UniqueGlobalNames.TABLE}, tablename="{tablename}", schema={schema_str}): '  # noqa: E501
             f"{pk_column_name} = {serialised_pk_column}"
         )
 

--- a/tests/apps/migrations/auto/integration/test_migrations.py
+++ b/tests/apps/migrations/auto/integration/test_migrations.py
@@ -115,7 +115,6 @@ class MigrationTestCase(DBTestCase):
         migrations_folder_path = os.path.join(
             temp_directory_path, "piccolo_migrations"
         )
-        print(migrations_folder_path)
         return migrations_folder_path
 
     def _test_migrations(

--- a/tests/apps/migrations/auto/integration/test_migrations.py
+++ b/tests/apps/migrations/auto/integration/test_migrations.py
@@ -115,6 +115,7 @@ class MigrationTestCase(DBTestCase):
         migrations_folder_path = os.path.join(
             temp_directory_path, "piccolo_migrations"
         )
+        print(migrations_folder_path)
         return migrations_folder_path
 
     def _test_migrations(
@@ -1071,6 +1072,7 @@ class TestTargetColumnString(MigrationTestCase):
 
 
 ###############################################################################
+# Testing migrations which involve schemas.
 
 
 @engines_only("postgres", "cockroach")
@@ -1221,3 +1223,47 @@ class TestSameTableName(MigrationTestCase):
                 schema_name=self.new_schema
             ).run_sync(),
         )
+
+
+@engines_only("postgres", "cockroach")
+class TestForeignKey(MigrationTestCase):
+    """
+    Make sure that migrations with foreign keys involving schemas work
+    correctly.
+    """
+
+    schema = "schema_1"
+    schema_manager = SchemaManager()
+
+    def setUp(self) -> None:
+        self.manager = create_table_class(
+            class_name="Manager", class_kwargs={"schema": self.schema}
+        )
+
+        self.band = create_table_class(
+            class_name="Band",
+            class_kwargs={"schema": self.schema},
+            class_members={"manager": ForeignKey(self.manager)},
+        )
+
+    def tearDown(self) -> None:
+        self.schema_manager.drop_schema(
+            self.schema, if_exists=True, cascade=True
+        ).run_sync()
+
+        Migration.alter().drop_table(if_exists=True).run_sync()
+
+    def test_foreign_key(self):
+        self._test_migrations(
+            table_snapshots=[
+                [self.manager, self.band],
+            ],
+        )
+
+        tables_in_schema = self.schema_manager.list_tables(
+            schema_name=self.schema
+        ).run_sync()
+
+        # Make sure that both tables exist (in the correct schemas):
+        for tablename in ("manager", "band"):
+            self.assertIn(tablename, tables_in_schema)

--- a/tests/apps/migrations/auto/test_serialisation.py
+++ b/tests/apps/migrations/auto/test_serialisation.py
@@ -19,7 +19,6 @@ from piccolo.columns.choices import Choice
 from piccolo.columns.column_types import Varchar
 from piccolo.columns.defaults import UUID4, DateNow, TimeNow, TimestampNow
 from piccolo.columns.reference import LazyTableReference
-from tests.base import engine_is
 
 
 class TestUniqueGlobalNamesMeta:
@@ -243,27 +242,15 @@ class TestSerialiseParams(TestCase):
 
             self.assertTrue(len(serialised.extra_definitions) == 1)
 
-            if engine_is("postgres"):
-                self.assertEqual(
-                    serialised.extra_definitions[0].__str__(),
-                    (
-                        'class Manager(Table, tablename="manager"): '
-                        "id = Serial(null=False, primary_key=True, unique=False, "  # noqa: E501
-                        "index=False, index_method=IndexMethod.btree, "
-                        "choices=None, db_column_name='id', secret=False)"
-                    ),
-                )
-
-            if engine_is("cockroach"):
-                self.assertEqual(
-                    serialised.extra_definitions[0].__str__(),
-                    (
-                        'class Manager(Table, tablename="manager"): '
-                        "id = Serial(null=False, primary_key=True, unique=False, "  # noqa: E501
-                        "index=False, index_method=IndexMethod.btree, "
-                        "choices=None, db_column_name='id', secret=False)"
-                    ),
-                )
+            self.assertEqual(
+                serialised.extra_definitions[0].__str__(),
+                (
+                    'class Manager(Table, tablename="manager", schema=None): '
+                    "id = Serial(null=False, primary_key=True, unique=False, "
+                    "index=False, index_method=IndexMethod.btree, "
+                    "choices=None, db_column_name='id', secret=False)"
+                ),
+            )
 
     def test_function(self):
         serialised = serialise_params(params={"default": example_function})


### PR DESCRIPTION
The recent schema changes touch most of the codebase - this is something I overlooked.