### PR TITLE
Improved UX for renaming tables

### DIFF
--- a/piccolo/apps/migrations/auto/schema_differ.py
+++ b/piccolo/apps/migrations/auto/schema_differ.py
@@ -104,10 +104,6 @@ class AlterStatements:
         return self
 
 
-def optional_str_repr(value: t.Optional[str]) -> str:
-    return f"'{value}'" if value else "None"
-
-
 @dataclass
 class SchemaDiffer:
     """


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/834

If Piccolo detects a renamed table in an auto migration, it asks the user for confirmation. When lots of tables have been renamed, Piccolo is now more intelligent about when to ask for confirmation.