### PR TITLE
`PROTECTED_TABLENAMES` just triggers a warning

### DIFF
--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -257,9 +257,10 @@ class Table(metaclass=TableMetaclass):
             schema, tablename = tablename.split(".", maxsplit=1)
 
         if tablename in PROTECTED_TABLENAMES:
-            raise ValueError(
-                f"{tablename} is a protected name, please give your table a "
-                "different name."
+            warnings.warn(
+                "We recommend giving your table a different name as "
+                f"`{tablename}` is a reserved keyword. It will still work "
+                "though."
             )
 
         columns: t.List[Column] = []

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -58,6 +58,10 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from piccolo.columns import Selectable
 
 PROTECTED_TABLENAMES = ("user",)
+TABLENAME_WARNING = (
+    "We recommend giving your table a different name as `{tablename}` is a "
+    "reserved keyword. It should still work, but avoid if possible."
+)
 
 
 TABLE_REGISTRY: t.List[t.Type[Table]] = []
@@ -257,11 +261,7 @@ class Table(metaclass=TableMetaclass):
             schema, tablename = tablename.split(".", maxsplit=1)
 
         if tablename in PROTECTED_TABLENAMES:
-            warnings.warn(
-                "We recommend giving your table a different name as "
-                f"`{tablename}` is a reserved keyword. It will still work "
-                "though."
-            )
+            warnings.warn(TABLENAME_WARNING.format(tablename=tablename))
 
         columns: t.List[Column] = []
         default_columns: t.List[Column] = []

--- a/tests/table/test_metaclass.py
+++ b/tests/table/test_metaclass.py
@@ -9,7 +9,7 @@ from piccolo.columns.column_types import (
     ForeignKey,
     Varchar,
 )
-from piccolo.table import Table
+from piccolo.table import TABLENAME_WARNING, Table
 from tests.example_apps.music.tables import Band
 
 
@@ -22,15 +22,21 @@ class TestMetaClass(TestCase):
         Some tablenames are forbidden because they're reserved words in the
         database, and can potentially cause issues.
         """
-        with self.assertRaises(ValueError):
+        expected_warning = TABLENAME_WARNING.format(tablename="user")
+
+        with patch("piccolo.table.warnings") as warnings:
 
             class User(Table):
                 pass
 
-        with self.assertRaises(ValueError):
+            warnings.warn.assert_called_with(expected_warning)
+
+        with patch("piccolo.table.warnings") as warnings:
 
             class MyUser(Table, tablename="user"):
                 pass
+
+            warnings.warn.assert_called_with(expected_warning)
 
     def test_help_text(self):
         """


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/849

Rather than removing the `PROTECTED_TABLENAMES` check, it now just emits a warning rather than raising an exception. I did some testing, and a table called `user` works find in Piccolo, but I think a warning is still valid, as when writing raw SQL queries against a table called `user` it could still lead to bugs if not careful.

Remaining tasks:

- [x] Update tests