### PR TITLE
update Litestar template to use create_pydantic_model

### DIFF
--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -11,9 +11,6 @@ from jinja2 import Environment, FileSystemLoader
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates/app/")
 SERVERS = ["uvicorn", "Hypercorn"]
 ROUTERS = ["starlette", "fastapi", "blacksheep", "litestar"]
-ROUTER_DEPENDENCIES = {
-    "litestar": ["litestar==2.0.0a3"],
-}
 
 
 def print_instruction(message: str):
@@ -54,7 +51,7 @@ def new(root: str = ".", name: str = "piccolo_project"):
 
     template_context = {
         "router": router,
-        "router_dependencies": ROUTER_DEPENDENCIES.get(router) or [router],
+        "router_dependencies": [router],
         "server": get_server(),
         "project_identifier": name.replace(" ", "_").lower(),
     }

--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -11,6 +11,9 @@ from jinja2 import Environment, FileSystemLoader
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates/app/")
 SERVERS = ["uvicorn", "Hypercorn"]
 ROUTERS = ["starlette", "fastapi", "blacksheep", "litestar"]
+ROUTER_DEPENDENCIES = {
+    "fastapi": ["fastapi<0.100.0"],
+}
 
 
 def print_instruction(message: str):
@@ -51,7 +54,7 @@ def new(root: str = ".", name: str = "piccolo_project"):
 
     template_context = {
         "router": router,
-        "router_dependencies": [router],
+        "router_dependencies": ROUTER_DEPENDENCIES.get(router) or [router],
         "server": get_server(),
         "project_identifier": name.replace(" ", "_").lower(),
     }

--- a/piccolo/apps/asgi/commands/templates/app/_litestar_app.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/_litestar_app.py.jinja
@@ -1,18 +1,27 @@
 import typing as t
 
-from piccolo.engine import engine_finder
-from piccolo_admin.endpoints import create_admin
-from litestar import Litestar, asgi, delete, get, patch, post
-from litestar.static_files import StaticFilesConfig
-from litestar.template import TemplateConfig
-from litestar.contrib.jinja import JinjaTemplateEngine
-from litestar.contrib.piccolo_orm import PiccoloORMPlugin
-from litestar.exceptions import NotFoundException
-from litestar.types import Receive, Scope, Send
-
 from home.endpoints import home
 from home.piccolo_app import APP_CONFIG
 from home.tables import Task
+from litestar import Litestar, asgi, delete, get, patch, post
+from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.exceptions import NotFoundException
+from litestar.static_files import StaticFilesConfig
+from litestar.template import TemplateConfig
+from litestar.types import Receive, Scope, Send
+from piccolo.engine import engine_finder
+from piccolo.utils.pydantic import create_pydantic_model
+from piccolo_admin.endpoints import create_admin
+
+TaskModelIn: t.Any = create_pydantic_model(
+    table=Task,
+    model_name="TaskModelIn",
+)
+TaskModelOut: t.Any = create_pydantic_model(
+    table=Task,
+    include_default_columns=True,
+    model_name="TaskModelOut",
+)
 
 
 # mounting Piccolo Admin
@@ -22,29 +31,27 @@ async def admin(scope: "Scope", receive: "Receive", send: "Send") -> None:
 
 
 @get("/tasks", tags=["Task"])
-async def tasks() -> t.List[Task]:
-    tasks = await Task.select().order_by(Task.id, ascending=False)
-    return tasks
+async def tasks() -> t.List[TaskModelOut]:
+    return await Task.select().order_by(Task.id, ascending=False)
 
 
 @post("/tasks", tags=["Task"])
-async def create_task(data: Task) -> Task:
-    task = Task(**data.to_dict())
+async def create_task(data: TaskModelIn) -> TaskModelOut:
+    task = Task(**data.dict())
     await task.save()
-    return task
+    return task.to_dict()
 
 
 @patch("/tasks/{task_id:int}", tags=["Task"])
-async def update_task(task_id: int, data: Task) -> Task:
+async def update_task(task_id: int, data: TaskModelIn) -> TaskModelOut:
     task = await Task.objects().get(Task.id == task_id)
     if not task:
         raise NotFoundException("Task does not exist")
-    for key, value in data.to_dict().items():
-        task.id = task_id
+    for key, value in data.dict().items():
         setattr(task, key, value)
 
     await task.save()
-    return task
+    return task.to_dict()
 
 
 @delete("/tasks/{task_id:int}", tags=["Task"])
@@ -80,7 +87,6 @@ app = Litestar(
         update_task,
         delete_task,
     ],
-    plugins=[PiccoloORMPlugin()],
     template_config=TemplateConfig(
         directory="home/templates", engine=JinjaTemplateEngine
     ),

--- a/piccolo/apps/asgi/commands/templates/app/home/_litestar_endpoints.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/home/_litestar_endpoints.py.jinja
@@ -10,7 +10,7 @@ ENVIRONMENT = jinja2.Environment(
 )
 
 
-@get(path="/", include_in_schema=False)
+@get(path="/", include_in_schema=False, sync_to_thread=False)
 def home(request: Request) -> Response:
     template = ENVIRONMENT.get_template("home.html.jinja")
     content = template.render(title="Piccolo + ASGI")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,5 +4,4 @@ Jinja2>=2.11.0
 targ>=0.3.7
 inflection>=0.5.1
 typing-extensions>=4.3.0
-pydantic==1.10.11
-pydantic[email]>=1.6
+pydantic[email]>=1.6,<2.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,4 +4,5 @@ Jinja2>=2.11.0
 targ>=0.3.7
 inflection>=0.5.1
 typing-extensions>=4.3.0
+pydantic==1.10.11
 pydantic[email]>=1.6


### PR DESCRIPTION
Related to #858. I also pinned Pydantic to version `1.10.11` which is the last version before V2 because we are not ready for `Pydantic V2` yet.