### PR TITLE
update docs for running migrations

### DIFF
--- a/docs/src/piccolo/migrations/running.rst
+++ b/docs/src/piccolo/migrations/running.rst
@@ -4,9 +4,6 @@ Running migrations
 .. hint:: To see all available options for these commands, use the ``--help``
     flag, for example ``piccolo migrations forwards --help``.
 
-.. hint:: To see the SQL queries of a migration without actually running them , use the ``--preview``
-    flag, for example: ``piccolo migrations forwards my_app --preview``  or  ``piccolo migrations backwards 2018-09-04T19:44:09 --preview``.
-
 Forwards
 --------
 
@@ -15,6 +12,30 @@ When the migration is run, the forwards function is executed. To do this:
 .. code-block:: bash
 
     piccolo migrations forwards my_app
+
+
+Multiple apps
+~~~~~~~~~~~~~
+
+If you have multiple apps you can run them all using:
+
+.. code-block:: bash
+
+    piccolo migrations forwards all
+
+Fake
+~~~~
+
+We can 'fake' running a migration - we record that it ran in the database
+without actually running it.
+
+.. code-block:: bash
+
+    piccolo migrations forwards my_app 2022-09-04T19:44:09 --fake
+
+This is useful if we started from an existing database using
+``piccolo schema generate``, and the initial migration we generated is for
+tables which already exist, hence we fake run it.
 
 -------------------------------------------------------------------------------
 
@@ -26,13 +47,33 @@ migration:
 
 .. code-block:: bash
 
-    piccolo migrations backwards my_app 2018-09-04T19:44:09
+    piccolo migrations backwards my_app 2022-09-04T19:44:09
 
 Piccolo will then reverse the migrations for the given app, starting with the
 most recent migration, up to and including the migration with the specified ID.
 
 You can try going forwards and backwards a few times to make sure it works as
 expected.
+
+-------------------------------------------------------------------------------
+
+Preview
+-------
+
+To see the SQL queries of a migration without actually running them, use the
+``--preview`` flag.
+
+This works when running migrations forwards:
+
+.. code-block:: bash
+
+    piccolo migrations forwards my_app --preview
+
+Or backwards:
+
+.. code-block:: bash
+
+    piccolo migrations backwards 2022-09-04T19:44:09 --preview
 
 -------------------------------------------------------------------------------
 
@@ -44,3 +85,24 @@ You can easily check which migrations have and haven't ran using the following:
 .. code-block:: bash
 
     piccolo migrations check
+
+-------------------------------------------------------------------------------
+
+Source
+------
+
+These are the underlying Python functions which are called, so you can see
+all available options. These functions are convered into a CI using
+`targ <http://targ.readthedocs.io/>`_.
+
+.. currentmodule:: piccolo.apps.migrations.commands.forwards
+
+.. autofunction:: forwards
+
+.. currentmodule:: piccolo.apps.migrations.commands.backwards
+
+.. autofunction:: backwards
+
+.. currentmodule:: piccolo.apps.migrations.commands.check
+
+.. autofunction:: check


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/862

Some of the migrations functionality is only documented in docstrings - we should add some of this to the main docs.