### PR TITLE
feat: bring password hashing inline with industry best practices

### DIFF
--- a/piccolo/apps/user/tables.py
+++ b/piccolo/apps/user/tables.py
@@ -215,10 +215,10 @@ class BaseUser(Table, tablename="piccolo_user"):
 
         stored_password = response["password"]
 
-        algorithm, iterations, salt, hashed = cls.split_stored_password(
+        algorithm, iterations_, salt, hashed = cls.split_stored_password(
             stored_password
         )
-        iterations = int(iterations)
+        iterations = int(iterations_)
 
         if cls.hash_password(password, salt, iterations) == stored_password:
             if iterations != cls._pbkdf2_iteration_count:

--- a/piccolo/apps/user/tables.py
+++ b/piccolo/apps/user/tables.py
@@ -49,6 +49,8 @@ class BaseUser(Table, tablename="piccolo_user"):
 
     _min_password_length = 6
     _max_password_length = 128
+    # The number of hash iterations recommended by OWASP:
+    # https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
     _pbkdf2_iteration_count = 600_000
 
     def __init__(self, **kwargs):
@@ -221,6 +223,9 @@ class BaseUser(Table, tablename="piccolo_user"):
         iterations = int(iterations_)
 
         if cls.hash_password(password, salt, iterations) == stored_password:
+            # If the password was hashed in an earlier Piccolo version, update
+            # it so it's hashed with the currently recommended number of
+            # iterations:
             if iterations != cls._pbkdf2_iteration_count:
                 await cls.update_password(username, password)
 

--- a/piccolo/apps/user/tables.py
+++ b/piccolo/apps/user/tables.py
@@ -220,10 +220,7 @@ class BaseUser(Table, tablename="piccolo_user"):
         )
         iterations = int(iterations)
 
-        if (
-            cls.hash_password(password, salt, iterations)
-            == stored_password
-        ):
+        if cls.hash_password(password, salt, iterations) == stored_password:
             if iterations != cls._pbkdf2_iteration_count:
                 await cls.update_password(username, password)
 


### PR DESCRIPTION
This pull request accomplishes two things:
- Brings Piccolo's internal password hashing inline with industry best practices. See [here](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2) for more information
- Implements the functionality required to automatically migrate hashes to the newest iteration count upon login

This pull request does not propose a solution to the storage of legacy hashes