### PR TITLE
883 Auto migrations fail when the table is in a schema

### DIFF
--- a/piccolo/apps/migrations/auto/diffable_table.py
+++ b/piccolo/apps/migrations/auto/diffable_table.py
@@ -129,6 +129,7 @@ class DiffableTable:
                 column_class_name=i.column.__class__.__name__,
                 column_class=i.column.__class__,
                 params=i.column._meta.params,
+                schema=self.schema,
             )
             for i in sorted(
                 {ColumnComparison(column=column) for column in self.columns}
@@ -145,6 +146,7 @@ class DiffableTable:
                 column_name=i.column._meta.name,
                 db_column_name=i.column._meta.db_column_name,
                 tablename=value.tablename,
+                schema=self.schema,
             )
             for i in sorted(
                 {ColumnComparison(column=column) for column in value.columns}
@@ -184,6 +186,7 @@ class DiffableTable:
                         old_params=old_params,
                         column_class=column.__class__,
                         old_column_class=existing_column.__class__,
+                        schema=self.schema,
                     )
                 )
 

--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -27,6 +27,7 @@ class AddColumnClass:
     column: Column
     table_class_name: str
     tablename: str
+    schema: t.Optional[str]
 
 
 @dataclass
@@ -206,6 +207,7 @@ class MigrationManager:
         old_tablename: str,
         new_class_name: str,
         new_tablename: str,
+        schema: t.Optional[str] = None,
     ):
         self.rename_tables.append(
             RenameTable(
@@ -213,6 +215,7 @@ class MigrationManager:
                 old_tablename=old_tablename,
                 new_class_name=new_class_name,
                 new_tablename=new_tablename,
+                schema=schema,
             )
         )
 
@@ -225,6 +228,7 @@ class MigrationManager:
         column_class_name: str = "",
         column_class: t.Optional[t.Type[Column]] = None,
         params: t.Dict[str, t.Any] = None,
+        schema: t.Optional[str] = None,
     ):
         """
         Add a new column to the table.
@@ -255,6 +259,7 @@ class MigrationManager:
                 column=column,
                 tablename=tablename,
                 table_class_name=table_class_name,
+                schema=schema,
             )
         )
 
@@ -264,6 +269,7 @@ class MigrationManager:
         tablename: str,
         column_name: str,
         db_column_name: t.Optional[str] = None,
+        schema: t.Optional[str] = None,
     ):
         self.drop_columns.append(
             DropColumn(
@@ -271,6 +277,7 @@ class MigrationManager:
                 column_name=column_name,
                 db_column_name=db_column_name or column_name,
                 tablename=tablename,
+                schema=schema,
             )
         )
 
@@ -282,6 +289,7 @@ class MigrationManager:
         new_column_name: str,
         old_db_column_name: t.Optional[str] = None,
         new_db_column_name: t.Optional[str] = None,
+        schema: t.Optional[str] = None,
     ):
         self.rename_columns.append(
             RenameColumn(
@@ -291,6 +299,7 @@ class MigrationManager:
                 new_column_name=new_column_name,
                 old_db_column_name=old_db_column_name or old_column_name,
                 new_db_column_name=new_db_column_name or new_column_name,
+                schema=schema,
             )
         )
 
@@ -304,6 +313,7 @@ class MigrationManager:
         old_params: t.Dict[str, t.Any] = None,
         column_class: t.Optional[t.Type[Column]] = None,
         old_column_class: t.Optional[t.Type[Column]] = None,
+        schema: t.Optional[str] = None,
     ):
         """
         All possible alterations aren't currently supported.
@@ -322,6 +332,7 @@ class MigrationManager:
                 old_params=old_params,
                 column_class=column_class,
                 old_column_class=old_column_class,
+                schema=schema,
             )
         )
 
@@ -403,7 +414,10 @@ class MigrationManager:
 
             _Table: t.Type[Table] = create_table_class(
                 class_name=table_class_name,
-                class_kwargs={"tablename": alter_columns[0].tablename},
+                class_kwargs={
+                    "tablename": alter_columns[0].tablename,
+                    "schema": alter_columns[0].schema,
+                },
             )
 
             for alter_column in alter_columns:
@@ -635,7 +649,10 @@ class MigrationManager:
 
                 _Table: t.Type[Table] = create_table_class(
                     class_name=table_class_name,
-                    class_kwargs={"tablename": columns[0].tablename},
+                    class_kwargs={
+                        "tablename": columns[0].tablename,
+                        "schema": columns[0].schema,
+                    },
                 )
 
                 for column in columns:
@@ -662,7 +679,11 @@ class MigrationManager:
             )
 
             _Table: t.Type[Table] = create_table_class(
-                class_name=class_name, class_kwargs={"tablename": tablename}
+                class_name=class_name,
+                class_kwargs={
+                    "tablename": tablename,
+                    "schema": rename_table.schema,
+                },
             )
 
             await self._run_query(
@@ -680,7 +701,10 @@ class MigrationManager:
 
             _Table: t.Type[Table] = create_table_class(
                 class_name=table_class_name,
-                class_kwargs={"tablename": columns[0].tablename},
+                class_kwargs={
+                    "tablename": columns[0].tablename,
+                    "schema": columns[0].schema,
+                },
             )
 
             for rename_column in columns:
@@ -746,7 +770,10 @@ class MigrationManager:
 
                 _Table: t.Type[Table] = create_table_class(
                     class_name=add_column.table_class_name,
-                    class_kwargs={"tablename": add_column.tablename},
+                    class_kwargs={
+                        "tablename": add_column.tablename,
+                        "schema": add_column.schema,
+                    },
                 )
 
                 await self._run_query(
@@ -765,7 +792,10 @@ class MigrationManager:
                 # sets up the columns correctly.
                 _Table: t.Type[Table] = create_table_class(
                     class_name=add_columns[0].table_class_name,
-                    class_kwargs={"tablename": add_columns[0].tablename},
+                    class_kwargs={
+                        "tablename": add_columns[0].tablename,
+                        "schema": add_columns[0].schema,
+                    },
                     class_members={
                         add_column.column._meta.name: add_column.column
                         for add_column in add_columns

--- a/piccolo/apps/migrations/auto/operations.py
+++ b/piccolo/apps/migrations/auto/operations.py
@@ -10,6 +10,7 @@ class RenameTable:
     old_tablename: str
     new_class_name: str
     new_tablename: str
+    schema: t.Optional[str] = None
 
 
 @dataclass
@@ -28,6 +29,7 @@ class RenameColumn:
     new_column_name: str
     old_db_column_name: str
     new_db_column_name: str
+    schema: t.Optional[str] = None
 
 
 @dataclass
@@ -40,6 +42,7 @@ class AlterColumn:
     old_params: t.Dict[str, t.Any]
     column_class: t.Optional[t.Type[Column]] = None
     old_column_class: t.Optional[t.Type[Column]] = None
+    schema: t.Optional[str] = None
 
 
 @dataclass
@@ -48,6 +51,7 @@ class DropColumn:
     column_name: str
     db_column_name: str
     tablename: str
+    schema: t.Optional[str] = None
 
 
 @dataclass
@@ -58,3 +62,4 @@ class AddColumn:
     column_class_name: str
     column_class: t.Type[Column]
     params: t.Dict[str, t.Any]
+    schema: t.Optional[str] = None

--- a/piccolo/apps/migrations/auto/schema_differ.py
+++ b/piccolo/apps/migrations/auto/schema_differ.py
@@ -191,6 +191,7 @@ class SchemaDiffer:
                                 old_tablename=drop_table.tablename,
                                 new_class_name=new_table.class_name,
                                 new_tablename=new_table.tablename,
+                                schema=new_table.schema,
                             )
                         )
                         break
@@ -212,6 +213,7 @@ class SchemaDiffer:
                                 old_tablename=drop_table.tablename,
                                 new_class_name=new_table.class_name,
                                 new_tablename=new_table.tablename,
+                                schema=new_table.schema,
                             )
                         )
                         break
@@ -288,6 +290,7 @@ class SchemaDiffer:
                                 new_column_name=add_column.column_name,
                                 old_db_column_name=drop_column.db_column_name,
                                 new_db_column_name=add_column.db_column_name,
+                                schema=add_column.schema,
                             )
                         )
                         break
@@ -516,8 +519,14 @@ class SchemaDiffer:
                         )
                     )
 
+                schema_str = (
+                    "None"
+                    if alter_column.schema is None
+                    else f'"{alter_column.schema}"'
+                )
+
                 response.append(
-                    f"manager.alter_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{alter_column.column_name}', db_column_name='{alter_column.db_column_name}', params={new_params.params}, old_params={old_params.params}, column_class={column_class}, old_column_class={old_column_class})"  # noqa: E501
+                    f"manager.alter_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{alter_column.column_name}', db_column_name='{alter_column.db_column_name}', params={new_params.params}, old_params={old_params.params}, column_class={column_class}, old_column_class={old_column_class}, schema={schema_str})"  # noqa: E501
                 )
 
         return AlterStatements(
@@ -543,8 +552,12 @@ class SchemaDiffer:
                 ):
                     continue
 
+                schema_str = (
+                    "None" if column.schema is None else f'"{column.schema}"'
+                )
+
                 response.append(
-                    f"manager.drop_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{column.column_name}', db_column_name='{column.db_column_name}')"  # noqa: E501
+                    f"manager.drop_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{column.column_name}', db_column_name='{column.db_column_name}', schema={schema_str})"  # noqa: E501
                 )
         return AlterStatements(statements=response)
 
@@ -585,8 +598,14 @@ class SchemaDiffer:
                     )
                 )
 
+                schema_str = (
+                    "None"
+                    if add_column.schema is None
+                    else f'"{add_column.schema}"'
+                )
+
                 response.append(
-                    f"manager.add_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{add_column.column_name}', db_column_name='{add_column.db_column_name}', column_class_name='{add_column.column_class_name}', column_class={column_class.__name__}, params={str(cleaned_params)})"  # noqa: E501
+                    f"manager.add_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{add_column.column_name}', db_column_name='{add_column.db_column_name}', column_class_name='{add_column.column_class_name}', column_class={column_class.__name__}, params={str(cleaned_params)}, schema={schema_str})"  # noqa: E501
                 )
         return AlterStatements(
             statements=response,
@@ -647,8 +666,12 @@ class SchemaDiffer:
                     )
                 )
 
+                schema_str = (
+                    "None" if table.schema is None else f'"{table.schema}"'
+                )
+
                 response.append(
-                    f"manager.add_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{column._meta.name}', db_column_name='{column._meta.db_column_name}', column_class_name='{column.__class__.__name__}', column_class={column.__class__.__name__}, params={str(cleaned_params)})"  # noqa: E501
+                    f"manager.add_column(table_class_name='{table.class_name}', tablename='{table.tablename}', column_name='{column._meta.name}', db_column_name='{column._meta.db_column_name}', column_class_name='{column.__class__.__name__}', column_class={column.__class__.__name__}, params={str(cleaned_params)}, schema={schema_str})"  # noqa: E501
                 )
         return AlterStatements(
             statements=response,

--- a/tests/apps/migrations/auto/test_schema_differ.py
+++ b/tests/apps/migrations/auto/test_schema_differ.py
@@ -46,7 +46,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(new_table_columns.statements) == 1)
         self.assertEqual(
             new_table_columns.statements[0],
-            "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})",  # noqa
+            "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False}, schema=None)",  # noqa
         )
 
     def test_drop_table(self):
@@ -92,7 +92,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.rename_tables.statements) == 1)
         self.assertEqual(
             schema_differ.rename_tables.statements[0],
-            "manager.rename_table(old_class_name='Band', old_tablename='band', new_class_name='Act', new_tablename='act')",  # noqa: E501
+            "manager.rename_table(old_class_name='Band', old_tablename='band', new_class_name='Act', new_tablename='act', schema=None)",  # noqa: E501
         )
 
         self.assertEqual(schema_differ.create_tables.statements, [])
@@ -165,7 +165,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.add_columns.statements) == 1)
         self.assertEqual(
             schema_differ.add_columns.statements[0],
-            "manager.add_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})",  # noqa: E501
+            "manager.add_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False}, schema=None)",  # noqa: E501
         )
 
     def test_drop_column(self):
@@ -200,7 +200,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.drop_columns.statements) == 1)
         self.assertEqual(
             schema_differ.drop_columns.statements[0],
-            "manager.drop_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre')",  # noqa: E501
+            "manager.drop_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre', schema=None)",  # noqa: E501
         )
 
     def test_rename_column(self):
@@ -238,7 +238,7 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.rename_columns.statements,
             [
-                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='title', new_column_name='name', old_db_column_name='title', new_db_column_name='name')"  # noqa: E501
+                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='title', new_column_name='name', old_db_column_name='title', new_db_column_name='name', schema=None)"  # noqa: E501
             ],
         )
 
@@ -249,13 +249,13 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.add_columns.statements,
             [
-                "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})"  # noqa: E501
+                "manager.add_column(table_class_name='Band', tablename='band', column_name='name', db_column_name='name', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False}, schema=None)"  # noqa: E501
             ],
         )
         self.assertEqual(
             schema_differ.drop_columns.statements,
             [
-                "manager.drop_column(table_class_name='Band', tablename='band', column_name='title', db_column_name='title')"  # noqa: E501
+                "manager.drop_column(table_class_name='Band', tablename='band', column_name='title', db_column_name='title', schema=None)"  # noqa: E501
             ],
         )
         self.assertTrue(schema_differ.rename_columns.statements == [])
@@ -319,8 +319,8 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.rename_columns.statements,
             [
-                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='a1', new_column_name='a2', old_db_column_name='a1', new_db_column_name='a2')",  # noqa: E501
-                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='b1', new_column_name='b2', old_db_column_name='b1', new_db_column_name='b2')",  # noqa: E501
+                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='a1', new_column_name='a2', old_db_column_name='a1', new_db_column_name='a2', schema=None)",  # noqa: E501
+                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='b1', new_column_name='b2', old_db_column_name='b1', new_db_column_name='b2', schema=None)",  # noqa: E501
             ],
         )
 
@@ -391,19 +391,19 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.add_columns.statements,
             [
-                "manager.add_column(table_class_name='Band', tablename='band', column_name='b2', db_column_name='b2', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False})"  # noqa: E501
+                "manager.add_column(table_class_name='Band', tablename='band', column_name='b2', db_column_name='b2', column_class_name='Varchar', column_class=Varchar, params={'length': 255, 'default': '', 'null': False, 'primary_key': False, 'unique': False, 'index': False, 'index_method': IndexMethod.btree, 'choices': None, 'db_column_name': None, 'secret': False}, schema=None)"  # noqa: E501
             ],
         )
         self.assertEqual(
             schema_differ.drop_columns.statements,
             [
-                "manager.drop_column(table_class_name='Band', tablename='band', column_name='b1', db_column_name='b1')"  # noqa: E501
+                "manager.drop_column(table_class_name='Band', tablename='band', column_name='b1', db_column_name='b1', schema=None)"  # noqa: E501
             ],
         )
         self.assertEqual(
             schema_differ.rename_columns.statements,
             [
-                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='a1', new_column_name='a2', old_db_column_name='a1', new_db_column_name='a2')",  # noqa: E501
+                "manager.rename_column(table_class_name='Band', tablename='band', old_column_name='a1', new_column_name='a2', old_db_column_name='a1', new_db_column_name='a2', schema=None)",  # noqa: E501
             ],
         )
 
@@ -448,7 +448,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.alter_columns.statements) == 1)
         self.assertEqual(
             schema_differ.alter_columns.statements[0],
-            "manager.alter_column(table_class_name='Ticket', tablename='ticket', column_name='price', db_column_name='price', params={'digits': (4, 2)}, old_params={'digits': (5, 2)}, column_class=Numeric, old_column_class=Numeric)",  # noqa
+            "manager.alter_column(table_class_name='Ticket', tablename='ticket', column_name='price', db_column_name='price', params={'digits': (4, 2)}, old_params={'digits': (5, 2)}, column_class=Numeric, old_column_class=Numeric, schema=None)",  # noqa
         )
 
     def test_db_column_name(self):
@@ -486,7 +486,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.alter_columns.statements) == 1)
         self.assertEqual(
             schema_differ.alter_columns.statements[0],
-            "manager.alter_column(table_class_name='Ticket', tablename='ticket', column_name='price', db_column_name='custom', params={'digits': (4, 2)}, old_params={'digits': (5, 2)}, column_class=Numeric, old_column_class=Numeric)",  # noqa
+            "manager.alter_column(table_class_name='Ticket', tablename='ticket', column_name='price', db_column_name='custom', params={'digits': (4, 2)}, old_params={'digits': (5, 2)}, column_class=Numeric, old_column_class=Numeric, schema=None)",  # noqa
         )
 
     def test_alter_default(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -174,16 +174,18 @@ class DBTestCase(TestCase):
     # Postgres specific utils
 
     def get_postgres_column_definition(
-        self, tablename: str, column_name: str
+        self, tablename: str, column_name: str, schema: str = "public"
     ) -> RowMeta:
         query = """
             SELECT {columns} FROM information_schema.columns
             WHERE table_name = '{tablename}'
             AND table_catalog = 'piccolo'
+            AND table_schema = '{schema}'
             AND column_name = '{column_name}'
         """.format(
             columns=RowMeta.get_column_name_str(),
             tablename=tablename,
+            schema=schema,
             column_name=column_name,
         )
         response = self.run_sync(query)


### PR DESCRIPTION
Fixes https://github.com/piccolo-orm/piccolo/issues/883

When using auto migrations to move a table to a schema other than 'public', subsequent migrations could sometimes fail.