### PR TITLE
Simplify `create_pydantic_model`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,7 +86,7 @@ jobs:
         strategy:
             matrix:
                 python-version: ["3.8", "3.9", "3.10", "3.11"]
-                postgres-version: [10, 11, 12, 13, 14, 15]
+                postgres-version: [11, 12, 13, 14, 15, 16]
 
         # Service containers to run with `container-job`
         services:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,14 @@ All of the changes from 0.120.0 merged into the v1 branch.
 
 -------------------------------------------------------------------------------
 
+0.121.0
+-------
+
+Modified the ``BaseUser.login`` logic so all code paths take the same time.
+Thanks to @Skelmis for this.
+
+-------------------------------------------------------------------------------
+
 0.120.0
 -------
 

--- a/piccolo/apps/user/tables.py
+++ b/piccolo/apps/user/tables.py
@@ -212,7 +212,10 @@ class BaseUser(Table, tablename="piccolo_user"):
             .run()
         )
         if not response:
-            # No match found
+            # No match found. We still call hash_password
+            # here to mitigate the ability to enumerate
+            # users via response timings
+            cls.hash_password(password)
             return None
 
         stored_password = response["password"]


### PR DESCRIPTION
Simplifying `create_pydantic_model` for v1.

The main thing is all additional fields added to the JSON schema are namespaced under `extra`.

This makes things a lot easier to understand, and means we're less likely to clash with anything in JSON schema in the future.