### PR TITLE
JSON schema - indicate that a column is `timestamptz`

### DIFF
--- a/piccolo/utils/pydantic.py
+++ b/piccolo/utils/pydantic.py
@@ -18,6 +18,7 @@ from piccolo.columns.column_types import (
     ForeignKey,
     Numeric,
     Text,
+    Timestamptz,
     Varchar,
 )
 from piccolo.table import Table
@@ -297,6 +298,8 @@ def create_pydantic_model(
                 extra["widget"] = "text-area"
             elif isinstance(column, (JSON, JSONB)):
                 extra["widget"] = "json"
+            elif isinstance(column, Timestamptz):
+                extra["widget"] = "timestamptz"
 
         field = pydantic.Field(
             json_schema_extra={"extra": extra},

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -18,6 +18,8 @@ from piccolo.columns import (
     Secret,
     Text,
     Time,
+    Timestamp,
+    Timestamptz,
     Varchar,
 )
 from piccolo.columns.column_types import ForeignKey
@@ -199,6 +201,29 @@ class TestTimeColumn(TestCase):
             ][0]["format"],
             "time",
         )
+
+
+class TestTimestamptzColumn(TestCase):
+    def test_timestamptz_widget(self):
+        """
+        Make sure that we indicate that `Timestamptz` columns require a special
+        widget in Piccolo Admin.
+        """
+
+        class Concert(Table):
+            starts_on_1 = Timestamptz()
+            starts_on_2 = Timestamp()
+
+        pydantic_model = create_pydantic_model(table=Concert)
+
+        properties = pydantic_model.model_json_schema()["properties"]
+
+        self.assertEqual(
+            properties["starts_on_1"]["extra"]["widget"],
+            "timestamptz",
+        )
+
+        self.assertIsNone(properties["starts_on_2"]["extra"].get("widget"))
 
 
 class TestUUIDColumn(TestCase):


### PR DESCRIPTION
When looking at the JSON schema for a table, we can't distinguish between `Timestamp` and `Timestamptz` columns.

This would be useful to know in Piccolo Admin, so we can visually differentiate between timezone-aware timestamps and naive timestamps.