### PR TITLE
Update ASGI requirements

### DIFF
--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -10,15 +10,11 @@ from jinja2 import Environment, FileSystemLoader
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates/app/")
 SERVERS = ["uvicorn", "Hypercorn"]
-ADMIN_DEPENDENCIES = ["piccolo_admin>=1.0.0"]
 ROUTER_DEPENDENCIES = {
-    "starlette": ["starlette", *ADMIN_DEPENDENCIES],
-    "fastapi": ["fastapi>=0.100.0", *ADMIN_DEPENDENCIES],
-    "blacksheep": ["blacksheep", *ADMIN_DEPENDENCIES],
-    "litestar": ["litestar", *ADMIN_DEPENDENCIES],
-    # We don't currently use Piccolo Admin with esmerald, due to dependency
-    # conflicts with FastAPI. We'll revisit this at some point in the future
-    # when newer versions of FastAPI are released (DT - 12th December 2023).
+    "starlette": ["starlette"],
+    "fastapi": ["fastapi>=0.100.0"],
+    "blacksheep": ["blacksheep"],
+    "litestar": ["litestar"],
     "esmerald": ["esmerald"],
 }
 ROUTERS = list(ROUTER_DEPENDENCIES.keys())

--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -10,10 +10,18 @@ from jinja2 import Environment, FileSystemLoader
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates/app/")
 SERVERS = ["uvicorn", "Hypercorn"]
-ROUTERS = ["starlette", "fastapi", "blacksheep", "litestar", "esmerald"]
+ADMIN_DEPENDENCIES = ["piccolo_admin>=1.0.0"]
 ROUTER_DEPENDENCIES = {
-    "fastapi": ["fastapi>=0.100.0"],
+    "starlette": ["starlette", *ADMIN_DEPENDENCIES],
+    "fastapi": ["fastapi>=0.100.0", *ADMIN_DEPENDENCIES],
+    "blacksheep": ["blacksheep", *ADMIN_DEPENDENCIES],
+    "litestar": ["litestar", *ADMIN_DEPENDENCIES],
+    # We don't currently use Piccolo Admin with esmerald, due to dependency
+    # conflicts with FastAPI. We'll revisit this at some point in the future
+    # when newer versions of FastAPI are released (DT - 12th December 2023).
+    "esmerald": ["esmerald"],
 }
+ROUTERS = list(ROUTER_DEPENDENCIES.keys())
 
 
 def print_instruction(message: str):

--- a/piccolo/apps/asgi/commands/templates/app/_esmerald_app.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/_esmerald_app.py.jinja
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from piccolo.utils.pydantic import create_pydantic_model
 from piccolo.engine import engine_finder
+from piccolo_admin.endpoints import create_admin
 
 from esmerald import (
     Esmerald,
@@ -92,7 +93,15 @@ class TaskAPIView(APIView):
 app = Esmerald(
     routes=[
         Gateway("/", handler=home),
-        Gateway("/tasks", handler=TaskAPIView)
+        Gateway("/tasks", handler=TaskAPIView),
+        Include(
+            "/admin/",
+            create_admin(
+                tables=APP_CONFIG.table_classes,
+                # Required when running under HTTPS:
+                # allowed_hosts=['my_site.com']
+            ),
+        ),
     ],
     static_files_config=StaticFilesConfig(path="/static", directory=Path("static")),
     on_startup=[open_database_connection_pool],

--- a/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
@@ -2,5 +2,4 @@
 {{ router_dependency }}
 {% endfor -%}
 {{ server }}
-piccolo[postgres]
-piccolo_admin
+piccolo[postgres]>=1.0.0

--- a/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
@@ -3,3 +3,4 @@
 {% endfor -%}
 {{ server }}
 piccolo[postgres]>=1.0.0
+piccolo_admin>=1.0.0

--- a/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
@@ -2,7 +2,6 @@
 {{ router_dependency }}
 {% endfor -%}
 {{ server }}
-jinja2
 piccolo[postgres]
 piccolo_admin
 requests

--- a/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/requirements.txt.jinja
@@ -4,4 +4,3 @@
 {{ server }}
 piccolo[postgres]
 piccolo_admin
-requests


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/pull/907

* Removing `jinja2` as it's already a direct dependency of Piccolo
* Removing `requests` as I don't think it's needed any more (I think this was for Starlette at some point)
* Not installing `piccolo_admin` for `esmerald`