### PR TITLE
`ForeignKey` static typing

### DIFF
--- a/docs/src/piccolo/query_types/joins.rst
+++ b/docs/src/piccolo/query_types/joins.rst
@@ -26,8 +26,44 @@ And a ``where`` clause which uses joins:
 
 Left joins are used.
 
-join_on
--------
+Improved static typing
+----------------------
+
+You can optionally modify the above queries slightly for powerful static typing
+support from tools like Mypy and Pylance:
+
+.. code-block:: python
+
+    await Band.select(Band.name, Band.manager._.name)
+
+Notice how we use ``._.`` instead of ``.`` after each foreign key. An easy way
+to remember this is ``._.`` looks a bit like a connector in a diagram.
+
+Static type checkers now know that we're referencing the ``name`` column on the
+``Manager`` table, which has many advantages:
+
+* Autocompletion of column names.
+* Easier code navigation (command + click on column names to navigate to the
+  column definition).
+* Most importantly, the detection of typos in column names.
+
+This works, no matter how many joins are performed. For example:
+
+.. code-block:: python
+
+    await Concert.select(
+        Concert.band_1._.name,
+        Concert.band_1._.manager._.name,
+    )
+
+.. note:: You may wonder why this syntax is required. We're operating within
+    the limits of Python's typing support, which is still fairly young. In the
+    future we will hopefully be able to offer identical static typing support
+    for ``Band.manager.name`` and ``Band.manager._.name``. But even then,
+    the ``._.`` syntax will still be supported.
+
+``join_on``
+-----------
 
 Joins are usually performed using ``ForeignKey`` columns, though there may be
 situations where you want to join using a column which isn't a ``ForeignKey``.

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -77,9 +77,12 @@ class OnUpdate(str, Enum):
         return self.__str__()
 
 
+ReferencedTable = t.TypeVar("ReferencedTable", bound='Table')
+
+
 @dataclass
-class ForeignKeyMeta:
-    references: t.Union[t.Type[Table], LazyTableReference]
+class ForeignKeyMeta(t.Generic[ReferencedTable]):
+    references: t.Union[t.Type[ReferencedTable], LazyTableReference]
     on_delete: OnDelete
     on_update: OnUpdate
     target_column: t.Union[Column, str, None]
@@ -121,15 +124,15 @@ class ForeignKeyMeta:
         else:
             raise ValueError("Unable to resolve target_column.")
 
-    def copy(self) -> ForeignKeyMeta:
+    def copy(self) -> ForeignKeyMeta[ReferencedTable]:
         kwargs = self.__dict__.copy()
         kwargs.update(proxy_columns=self.proxy_columns.copy())
         return self.__class__(**kwargs)
 
-    def __copy__(self) -> ForeignKeyMeta:
+    def __copy__(self) -> ForeignKeyMeta[ReferencedTable]:
         return self.copy()
 
-    def __deepcopy__(self, memo) -> ForeignKeyMeta:
+    def __deepcopy__(self, memo) -> ForeignKeyMeta[ReferencedTable]:
         """
         We override deepcopy, as it's too slow if it has to recreate
         everything.

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -77,7 +77,7 @@ class OnUpdate(str, Enum):
         return self.__str__()
 
 
-ReferencedTable = t.TypeVar("ReferencedTable", bound='Table')
+ReferencedTable = t.TypeVar("ReferencedTable", bound="Table")
 
 
 @dataclass

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -14,6 +14,7 @@ from piccolo.columns.column_types import (
     Array,
     Email,
     ForeignKey,
+    ReferencedTable,
     Secret,
     Serial,
 )
@@ -558,9 +559,19 @@ class Table(metaclass=TableMetaclass):
         """
         return Refresh(instance=self, columns=columns)
 
+    @t.overload
     def get_related(
-        self: TableInstance, foreign_key: t.Union[ForeignKey, str]
-    ) -> First[Table]:
+        self, foreign_key: ForeignKey[ReferencedTable]
+    ) -> First[ReferencedTable]:
+        ...
+
+    @t.overload
+    def get_related(self, foreign_key: str) -> First[Table]:
+        ...
+
+    def get_related(
+        self, foreign_key: t.Union[str, ForeignKey[ReferencedTable]]
+    ) -> t.Union[First[Table], First[ReferencedTable]]:
         """
         Used to fetch a ``Table`` instance, for the target of a foreign key.
 
@@ -588,16 +599,12 @@ class Table(metaclass=TableMetaclass):
 
         column_name = foreign_key._meta.name
 
-        references: t.Type[
-            Table
-        ] = foreign_key._foreign_key_meta.resolved_references
+        references = foreign_key._foreign_key_meta.resolved_references
 
         return (
             references.objects()
             .where(
-                references._meta.get_column_by_name(
-                    self._meta.primary_key._meta.name
-                )
+                foreign_key._foreign_key_meta.resolved_target_column
                 == getattr(self, column_name)
             )
             .first()

--- a/tests/columns/foreign_key/test_attribute_access.py
+++ b/tests/columns/foreign_key/test_attribute_access.py
@@ -7,7 +7,7 @@ from piccolo.table import Table
 
 class Manager(Table):
     name = Varchar()
-    manager = ForeignKey("self")
+    manager: ForeignKey["Manager"] = ForeignKey("self")
 
 
 class BandA(Table):
@@ -15,11 +15,11 @@ class BandA(Table):
 
 
 class BandB(Table):
-    manager = ForeignKey(references="Manager")
+    manager: ForeignKey["Manager"] = ForeignKey(references="Manager")
 
 
 class BandC(Table):
-    manager = ForeignKey(
+    manager: ForeignKey["Manager"] = ForeignKey(
         references=LazyTableReference(
             table_class_name="Manager",
             module_path=__name__,
@@ -28,7 +28,9 @@ class BandC(Table):
 
 
 class BandD(Table):
-    manager = ForeignKey(references=f"{__name__}.Manager")
+    manager: ForeignKey["Manager"] = ForeignKey(
+        references=f"{__name__}.Manager"
+    )
 
 
 class TestAttributeAccess(TestCase):

--- a/tests/columns/foreign_key/test_foreign_key_references.py
+++ b/tests/columns/foreign_key/test_foreign_key_references.py
@@ -13,7 +13,7 @@ class BandA(Table):
 
 
 class BandB(Table):
-    manager = ForeignKey(references="Manager")
+    manager: ForeignKey["Manager"] = ForeignKey(references="Manager")
 
 
 class TestReferences(TestCase):

--- a/tests/columns/foreign_key/test_foreign_key_self.py
+++ b/tests/columns/foreign_key/test_foreign_key_self.py
@@ -6,7 +6,7 @@ from piccolo.table import Table
 
 class Manager(Table, tablename="manager"):
     name = Varchar()
-    manager = ForeignKey("self", null=True)
+    manager: ForeignKey["Manager"] = ForeignKey("self", null=True)
 
 
 class TestForeignKeySelf(TestCase):

--- a/tests/columns/foreign_key/test_foreign_key_string.py
+++ b/tests/columns/foreign_key/test_foreign_key_string.py
@@ -9,11 +9,11 @@ class Manager(Table):
 
 
 class BandA(Table):
-    manager = ForeignKey(references="Manager")
+    manager: ForeignKey["Manager"] = ForeignKey(references="Manager")
 
 
 class BandB(Table):
-    manager = ForeignKey(
+    manager: ForeignKey["Manager"] = ForeignKey(
         references=LazyTableReference(
             table_class_name="Manager",
             module_path=__name__,
@@ -22,7 +22,9 @@ class BandB(Table):
 
 
 class BandC(Table, tablename="band"):
-    manager = ForeignKey(references=f"{__name__}.Manager")
+    manager: ForeignKey["Manager"] = ForeignKey(
+        references=f"{__name__}.Manager"
+    )
 
 
 class TestForeignKeyString(TestCase):

--- a/tests/columns/foreign_key/test_value_type.py
+++ b/tests/columns/foreign_key/test_value_type.py
@@ -7,7 +7,7 @@ from piccolo.table import Table
 
 class Manager(Table):
     name = Varchar()
-    manager = ForeignKey("self", null=True)
+    manager: ForeignKey["Manager"] = ForeignKey("self", null=True)
 
 
 class Band(Table):

--- a/tests/table/instance/test_get_related.py
+++ b/tests/table/instance/test_get_related.py
@@ -14,7 +14,7 @@ class TestGetRelated(TestCase):
         for table in reversed(TABLES):
             table.alter().drop_table().run_sync()
 
-    def test_get_related(self):
+    def test_get_related(self) -> None:
         """
         Make sure you can get a related object from another object instance.
         """

--- a/tests/table/instance/test_get_related.py
+++ b/tests/table/instance/test_get_related.py
@@ -1,3 +1,4 @@
+import typing as t
 from unittest import TestCase
 
 from tests.example_apps.music.tables import Band, Manager
@@ -25,15 +26,16 @@ class TestGetRelated(TestCase):
         band.save().run_sync()
 
         _manager = band.get_related(Band.manager).run_sync()
+        assert _manager is not None
         self.assertTrue(_manager.name == "Guido")
 
         # Test non-ForeignKey
         with self.assertRaises(ValueError):
-            band.get_related(Band.name)
+            band.get_related(Band.name)  # type: ignore
 
         # Make sure it also works using a string
-        _manager = band.get_related("manager").run_sync()
-        self.assertTrue(_manager.name == "Guido")
+        _manager_2 = t.cast(Manager, band.get_related("manager").run_sync())
+        self.assertTrue(_manager_2.name == "Guido")
 
         # Test an invalid string
         with self.assertRaises(ValueError):

--- a/tests/table/test_join.py
+++ b/tests/table/test_join.py
@@ -23,7 +23,6 @@ class TestCreateJoin:
 
 
 class TestJoin(TestCase):
-
     tables = [Manager, Band, Venue, Concert, Ticket]
 
     def setUp(self):
@@ -97,6 +96,29 @@ class TestJoin(TestCase):
         select_query = Concert.select(Concert.band_1.manager.name)
         response = select_query.run_sync()
         self.assertEqual(response, [{"band_1.manager.name": "Guido"}])
+
+    def test_underscore_syntax(self):
+        """
+        Make sure that queries work with the ``._.`` syntax for joins.
+        """
+        response = Concert.select(
+            Concert.band_1._.name,
+            Concert.band_1._.manager._.name,
+            Concert.band_2._.name,
+            Concert.band_2._.manager._.name,
+        ).run_sync()
+
+        self.assertListEqual(
+            response,
+            [
+                {
+                    "band_1.name": "Pythonistas",
+                    "band_1.manager.name": "Guido",
+                    "band_2.name": "Rustaceans",
+                    "band_2.manager.name": "Graydon",
+                }
+            ],
+        )
 
     def test_select_all_columns(self):
         """

--- a/tests/testing/test_model_builder.py
+++ b/tests/testing/test_model_builder.py
@@ -42,7 +42,7 @@ class TableWithDecimal(Table):
 
 
 class BandWithLazyReference(Table):
-    manager = ForeignKey(
+    manager: ForeignKey["Manager"] = ForeignKey(
         references=LazyTableReference(
             "Manager", module_path="tests.example_apps.music.tables"
         )

--- a/tests/type_checking.py
+++ b/tests/type_checking.py
@@ -9,9 +9,10 @@ import typing as t
 
 from typing_extensions import assert_type
 
+from piccolo.columns import ForeignKey, Varchar
 from piccolo.testing.model_builder import ModelBuilder
 
-from .example_apps.music.tables import Band, Manager
+from .example_apps.music.tables import Band, Concert, Manager
 
 if t.TYPE_CHECKING:
 
@@ -32,6 +33,21 @@ if t.TYPE_CHECKING:
         assert_type(await query, t.Optional[Band])
         assert_type(await query.run(), t.Optional[Band])
         assert_type(query.run_sync(), t.Optional[Band])
+
+    async def foreign_key_reference() -> None:
+        assert_type(Band.manager, ForeignKey[Manager])
+
+    async def foreign_key_traversal() -> None:
+        # Single level
+        assert_type(Band.manager._.name, Varchar)
+        # Multi level
+        assert_type(Concert.band_1._.manager._.name, Varchar)
+
+    async def get_related() -> None:
+        band = await Band.objects().get(Band.name == "Pythonistas")
+        assert band is not None
+        manager = await band.get_related(Band.manager)
+        assert_type(manager, t.Optional[Manager])
 
     async def get_or_create() -> None:
         query = Band.objects().get_or_create(Band.name == "Pythonistas")


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/680

Related to https://github.com/piccolo-orm/piccolo/issues/436

## `ForeignKey` static typing in joins

The 'holy grail' for Piccolo for a long time has been to get 'perfect' static typing for ``ForeignKey`` columns.

If there was some kind of ``Proxy`` type in the ``typing`` module, it would be easy, but there isn't. Here's a related issue (https://github.com/python/typing/issues/802) for anyone who wants to track the progress.

I've come up with a solution. This query will continue to work:

```python
await Band.select(Band.name, Band.manager.name)
```

But this PR allows you to do this:

```python
await Band.select(Band.name, Band.manager._.name)
```

Note the addition of the ``_`` after the foreign key. It then has perfect static typing.

To remember the syntax, `._.` looks a bit like a connector in a diagram.

When Python adds a ``Proxy`` type to the typing ``module``, we can make ``Band.manager.name`` behave the same as ``Band.manager._.name``, but for now I think it's the best solution.

With perfect static typing of foreign keys, it is really cool, because Mypy and Pylance will detect any column name typos when doing joins.

## `get_related`

This PR also improves the typing for ``get_related``. For example:

```python
band = await Band.objects().first()

# Oops, I need the manager object too:
manager = await band.get_related(Band.manager)
```

In the above example, the type for ``manager`` is ``Manager | None``.

## Remaining tasks

- [x] Fix some minor linter errors
- [x] Add some tests to make sure the new syntax works
- [x] Update the docs
