### PR TITLE
add a `page` arg to `piccolo user list` command

### DIFF
--- a/piccolo/apps/user/commands/list.py
+++ b/piccolo/apps/user/commands/list.py
@@ -2,18 +2,27 @@ from piccolo.apps.user.tables import BaseUser
 from piccolo.utils.printing import print_dict_table
 
 
-def list_users(limit: int = 20):
+def list_users(limit: int = 20, page: int = 1):
     """
     List existing users.
 
     :param limit:
         The maximum number of users to list.
+    :param page:
+        Lets you paginate through the list of users.
 
     """
+    if page < 1:
+        raise ValueError("The page number must > 0.")
+
+    if limit < 1:
+        raise ValueError("The limit number must be > 0.")
+
     users = (
         BaseUser.select(*BaseUser.all_columns(exclude=[BaseUser.password]))
         .order_by(BaseUser.username)
         .limit(limit)
+        .offset(limit * (page - 1))
         .run_sync()
     )
 

--- a/tests/apps/user/commands/test_list.py
+++ b/tests/apps/user/commands/test_list.py
@@ -29,3 +29,21 @@ class TestList(TestCase):
         assert self.username in output
         assert self.password not in output
         assert self.user.password not in output
+
+
+class TestListArgs(TestCase):
+    def test_limit(self):
+        """
+        Make sure non-positive `limit` values are rejected.
+        """
+        for value in (0, -1):
+            with self.assertRaises(ValueError):
+                list_users(page=value)
+
+    def test_page(self):
+        """
+        Make sure non-positive `page` values are rejected.
+        """
+        for value in (0, -1):
+            with self.assertRaises(ValueError):
+                list_users(limit=value)


### PR DESCRIPTION
We recently added the `piccolo user list` command.

When trying this out, I realised we needed some kind of pagination if the database contains a lot of users.

You can now do:

```
piccolo user list --page=10
```