### PR TITLE
945 Using `db_column_name` when adding columns to existing tables using auto migrations

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -815,7 +815,7 @@ class MigrationManager:
                     )
                     await self._run_query(
                         _Table.alter().add_column(
-                            name=column._meta.name, column=column
+                            name=column._meta.db_column_name, column=column
                         )
                     )
                     if add_column.column._meta.index:


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/945