### PR TITLE
docs: Update code example of prefetching related objects

### DIFF
--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -191,7 +191,7 @@ prefer.
 
     ticket = await Ticket.objects().prefetch(
         Ticket.concert.all_related()
-    )
+    ).first()
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
To ensure equivalence between the two code snippets, I believe we may be missing the `.first()` method call in the last one.
```python
# These are equivalent:
ticket = await Ticket.objects(
    Ticket.concert.all_related()
).first()

ticket = await Ticket.objects().prefetch(
    Ticket.concert.all_related()
) # <= missing `.first()` here
```