### PR TITLE
Support composite unique constraints in auto migration

### DIFF
--- a/piccolo/apps/migrations/auto/diffable_table.py
+++ b/piccolo/apps/migrations/auto/diffable_table.py
@@ -146,6 +146,7 @@ class DiffableTable:
                 db_column_name=i.column._meta.db_column_name,
                 tablename=value.tablename,
                 schema=self.schema,
+                column_class=i.column.__class__,
             )
             for i in sorted(
                 {ColumnComparison(column=column) for column in value.columns}

--- a/piccolo/apps/migrations/auto/operations.py
+++ b/piccolo/apps/migrations/auto/operations.py
@@ -49,6 +49,7 @@ class AlterColumn:
 class DropColumn:
     table_class_name: str
     column_name: str
+    column_class: t.Type[Column]
     db_column_name: str
     tablename: str
     schema: t.Optional[str] = None

--- a/piccolo/apps/migrations/auto/schema_differ.py
+++ b/piccolo/apps/migrations/auto/schema_differ.py
@@ -268,15 +268,19 @@ class SchemaDiffer:
             # We track which dropped columns have already been identified by
             # the user as renames, so we don't ask them if another column
             # was also renamed from it.
+
+            # When adding or removing a unique constraint,
+            # we don't ask and rename it.
             used_drop_column_names: t.List[str] = []
 
             for add_column in delta.add_columns:
-                if add_column.column_class == UniqueConstraint:
+                if add_column.column_class is UniqueConstraint:
                     continue
                 for drop_column in delta.drop_columns:
-                    if drop_column.column_name in used_drop_column_names:
-                        continue
-                    if drop_column.column_class == UniqueConstraint:
+                    if (
+                        drop_column.column_name in used_drop_column_names
+                        or drop_column.column_class is UniqueConstraint
+                    ):
                         continue
 
                     user_response = self.auto_input or input(
@@ -513,7 +517,7 @@ class SchemaDiffer:
                     )
 
                 if alter_column.old_column_class is not None:
-                    if alter_column.old_column_class == UniqueConstraint:
+                    if alter_column.old_column_class is UniqueConstraint:
                         print(
                             f"You cannot ALTER `{alter_column.column_name}` unique constraint! At first, delete it, then create the new one."  # noqa: E501
                         )

--- a/piccolo/columns/constraints.py
+++ b/piccolo/columns/constraints.py
@@ -1,0 +1,41 @@
+import typing as t
+
+from .base import Column, ColumnMeta
+
+
+class Constraint(Column):
+    def __init__(self) -> None:
+        pass
+
+
+class UniqueConstraint(Constraint):
+    """
+    Used for applying unique constraint to multiple columns in the table.
+
+    **Example**
+
+    .. code-block:: python
+
+        class FooTable(Table):
+            foo_field = Text()
+            bar_field = Text()
+            my_constraint_1 = UniqueConstraint(['foo_field', 'bar_field'])
+    """
+
+    def __init__(self, unique_columns: t.List[str]) -> None:
+        if len(unique_columns) < 2:
+            raise ValueError("unique_columns must contain at least 2 columns")
+        super().__init__()
+        self._meta = ColumnMeta()
+        self.unique_columns = unique_columns
+        self._meta.params.update({"unique_columns": self.unique_columns})
+
+    @property
+    def column_type(self):
+        return "CONSTRAINT"
+
+    @property
+    def ddl(self) -> str:
+        unique_columns_string = ",".join(self.unique_columns)
+        query = f'{self.column_type} "{self._meta.db_column_name}" UNIQUE ({unique_columns_string})'  # noqa: E501
+        return query

--- a/tests/apps/migrations/auto/test_migration_manager.py
+++ b/tests/apps/migrations/auto/test_migration_manager.py
@@ -551,6 +551,7 @@ class TestMigrationManager(DBTestCase):
             table_class_name="Musician",
             tablename="musician",
             column_name="name",
+            column_class=Varchar,
         )
         asyncio.run(manager_2.run())
 

--- a/tests/apps/migrations/auto/test_migration_manager.py
+++ b/tests/apps/migrations/auto/test_migration_manager.py
@@ -338,9 +338,9 @@ class TestMigrationManager(DBTestCase):
             self.assertEqual(response, [{"id": row_id, "name": "Dave"}])
 
     @engines_only("postgres", "cockroach")
-    def test_add_unique_constraint(self):
+    def test_add_table_with_unique_constraint(self):
         """
-        Test adding a unique constraint to a MigrationManager.
+        Test adding a table with a unique constraint to a MigrationManager.
         """
         manager = MigrationManager()
         manager.add_table(class_name="Musician", tablename="musician")
@@ -375,6 +375,62 @@ class TestMigrationManager(DBTestCase):
 
         # Reverse
         asyncio.run(manager.run(backwards=True))
+
+    @engines_only("postgres")
+    @patch.object(
+        BaseMigrationManager, "get_migration_managers", new_callable=AsyncMock
+    )
+    @patch.object(BaseMigrationManager, "get_app_config")
+    def test_add_unique_constraint(
+        self, get_app_config: MagicMock, get_migration_managers: MagicMock
+    ):
+        """
+        Test adding a unique constraint to a MigrationManager.
+        Cockroach DB doesn't support dropping unique constraints with ALTER TABLE DROP CONSTRAINT.
+        https://github.com/cockroachdb/cockroach/issues/42840
+        """  # noqa: E501
+        manager_1 = MigrationManager()
+        manager_1.add_table(class_name="Musician", tablename="musician")
+        manager_1.add_column(
+            table_class_name="Musician",
+            tablename="musician",
+            column_name="name",
+            column_class_name="Varchar",
+        )
+        manager_1.add_column(
+            table_class_name="Musician",
+            tablename="musician",
+            column_name="label",
+            column_class_name="Varchar",
+        )
+        asyncio.run(manager_1.run())
+
+        manager_2 = MigrationManager()
+        manager_2.add_column(
+            table_class_name="Musician",
+            tablename="musician",
+            column_name="musician_unique",
+            column_class=UniqueConstraint,
+            column_class_name="UniqueConstraint",
+            params={
+                "unique_columns": ["name", "label"],
+            },
+            schema=None,
+        )
+        asyncio.run(manager_2.run())
+
+        self.run_sync("INSERT INTO musician VALUES (default, 'a', 'a');")
+        with self.assertRaises(asyncpg.exceptions.UniqueViolationError):
+            self.run_sync("INSERT INTO musician VALUES (default, 'a', 'a');")
+
+        get_migration_managers.return_value = [manager_1]
+        app_config = AppConfig(app_name="music", migrations_folder_path="")
+        get_app_config.return_value = app_config
+        asyncio.run(manager_2.run(backwards=True))
+
+        self.run_sync("INSERT INTO musician VALUES (default, 'a', 'a');")
+
+        asyncio.run(manager_1.run(backwards=True))
 
     @engines_only("postgres")
     @patch.object(

--- a/tests/apps/migrations/auto/test_schema_differ.py
+++ b/tests/apps/migrations/auto/test_schema_differ.py
@@ -199,7 +199,7 @@ class TestSchemaDiffer(TestCase):
         self.assertTrue(len(schema_differ.drop_columns.statements) == 1)
         self.assertEqual(
             schema_differ.drop_columns.statements[0],
-            "manager.drop_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre', schema=None)",  # noqa: E501
+            "manager.drop_column(table_class_name='Band', tablename='band', column_name='genre', db_column_name='genre', schema=None, column_class=Varchar)",  # noqa: E501
         )
 
     def test_rename_column(self) -> None:
@@ -254,7 +254,7 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.drop_columns.statements,
             [
-                "manager.drop_column(table_class_name='Band', tablename='band', column_name='title', db_column_name='title', schema=None)"  # noqa: E501
+                "manager.drop_column(table_class_name='Band', tablename='band', column_name='title', db_column_name='title', schema=None, column_class=Varchar)"  # noqa: E501
             ],
         )
         self.assertTrue(schema_differ.rename_columns.statements == [])
@@ -396,7 +396,7 @@ class TestSchemaDiffer(TestCase):
         self.assertEqual(
             schema_differ.drop_columns.statements,
             [
-                "manager.drop_column(table_class_name='Band', tablename='band', column_name='b1', db_column_name='b1', schema=None)"  # noqa: E501
+                "manager.drop_column(table_class_name='Band', tablename='band', column_name='b1', db_column_name='b1', schema=None, column_class=Varchar)"  # noqa: E501
             ],
         )
         self.assertEqual(

--- a/tests/apps/migrations/auto/test_schema_snapshot.py
+++ b/tests/apps/migrations/auto/test_schema_snapshot.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from piccolo.apps.migrations.auto import MigrationManager, SchemaSnapshot
+from piccolo.columns import Varchar
 
 
 class TestSchemaSnaphot(TestCase):
@@ -140,7 +141,10 @@ class TestSchemaSnaphot(TestCase):
 
         manager_2 = MigrationManager()
         manager_2.drop_column(
-            table_class_name="Manager", tablename="manager", column_name="name"
+            table_class_name="Manager",
+            tablename="manager",
+            column_name="name",
+            column_class=Varchar,
         )
 
         schema_snapshot = SchemaSnapshot(managers=[manager_1, manager_2])


### PR DESCRIPTION
Related to #172 , #175 and based on #582, #583.

- Add `UniqueConstraint` class with the same behavior as a `Column` to support auto migration with composite unique constraint
- Update existing tests for internal changes and add tests for auto maigration with adding/dropping unique constraint