### PR TITLE
Datetime Autoconversion for Timestamptz Columns

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -33,6 +33,7 @@ import typing as t
 import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
 from enum import Enum
 
 from piccolo.columns.base import (
@@ -1007,6 +1008,7 @@ class Timestamptz(Column):
     """
 
     value_type = datetime
+    tz_type = ZoneInfo
 
     # Currently just used by ModelBuilder, to know that we want a timezone
     # aware datetime.
@@ -1015,7 +1017,10 @@ class Timestamptz(Column):
     timedelta_delegate = TimedeltaDelegate()
 
     def __init__(
-        self, default: TimestamptzArg = TimestamptzNow(), **kwargs
+        self,
+        tz: ZoneInfo = ZoneInfo('UTC'),
+        default: TimestamptzArg = TimestamptzNow(), 
+        **kwargs
     ) -> None:
         self._validate_default(
             default, TimestamptzArg.__args__  # type: ignore
@@ -1025,10 +1030,11 @@ class Timestamptz(Column):
             default = TimestamptzCustom.from_datetime(default)
 
         if default == datetime.now:
-            default = TimestamptzNow()
+            default = TimestamptzNow(tz)
 
+        self.tz = tz
         self.default = default
-        kwargs.update({"default": default})
+        kwargs.update({"tz": tz, "default": default})
         super().__init__(**kwargs)
 
     ###########################################################################

--- a/piccolo/columns/defaults/timestamptz.py
+++ b/piccolo/columns/defaults/timestamptz.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import typing as t
 from enum import Enum
+from zoneinfo import ZoneInfo
 
 from .timestamp import TimestampCustom, TimestampNow, TimestampOffset
 
@@ -27,12 +28,15 @@ class TimestamptzOffset(TimestampOffset):
 
 
 class TimestamptzNow(TimestampNow):
+    def __init__(self, tz: ZoneInfo = ZoneInfo('UTC')):
+        self._tz = tz
+        
     @property
     def cockroach(self):
         return "current_timestamp"
 
     def python(self):
-        return datetime.datetime.now(tz=datetime.timezone.utc)
+        return datetime.datetime.now(tz=self._tz)
 
 
 class TimestamptzCustom(TimestampCustom):

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -5,6 +5,8 @@ import itertools
 import types
 import typing as t
 import warnings
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from dataclasses import dataclass, field
 
 from piccolo.columns import Column
@@ -17,6 +19,7 @@ from piccolo.columns.column_types import (
     ReferencedTable,
     Secret,
     Serial,
+    Timestamptz,
 )
 from piccolo.columns.defaults.base import Default
 from piccolo.columns.indexes import IndexMethod
@@ -436,6 +439,9 @@ class Table(metaclass=TableMetaclass):
                 ):
                     raise ValueError(f"{column._meta.name} wasn't provided")
 
+            if isinstance(column, Timestamptz) and isinstance(value, datetime):
+                value = value.astimezone(column.tz)
+                
             self[column._meta.name] = value
 
         unrecognized = kwargs.keys()


### PR DESCRIPTION
I made this pull request to rectify the issue where Piccolo does not provide a way to tell Timestamptz columns in which timezones they should identify themselves as.

_Outtake from PG docs:_
> Internally, PostgreSQL stores the timestamptz in UTC value. 
> 
> When you insert a value into a timestamptz column, PostgreSQL converts the timestamptz value into a UTC value and stores the UTC value in the table.
> When you retrieve data from a timestamptz column, PostgreSQL converts the UTC value back to the time value of the timezone set by the database server, the user, or the current database connection.

The solutions provided by Postgres as by which it determines the timezone to convert the value back to was not working properly with Piccolo. Hence I made this pull request. It works, please merge. Kinda need it in my enterprise project. @dantownsend 