### PR TITLE
962 Make it clearer how multiple `where` clauses work in the docs

### DIFF
--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -171,6 +171,9 @@ careful to include brackets in the correct place.
 
     ((b.popularity >= 100) & (b.manager.name ==  'Guido')) | (b.popularity > 1000)
 
+Multiple ``where`` clauses
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Using multiple ``where`` clauses is equivalent to an AND.
 
 .. code-block:: python


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/962

Breaking up the `where` clause docs a bit, to make them easier to navigate.