### PR TITLE
Fix adding and dropping column with db_column_name in auto migration

### DIFF
--- a/piccolo/apps/migrations/auto/migration_manager.py
+++ b/piccolo/apps/migrations/auto/migration_manager.py
@@ -665,7 +665,9 @@ class MigrationManager:
 
                 for column in columns:
                     await self._run_query(
-                        _Table.alter().drop_column(column=column.column_name)
+                        _Table.alter().drop_column(
+                            column=column.db_column_name
+                        )
                     )
 
     async def _run_rename_tables(self, backwards: bool = False):

--- a/piccolo/query/methods/alter.py
+++ b/piccolo/query/methods/alter.py
@@ -317,7 +317,6 @@ class Alter(DDL):
         """
         column._meta._table = self.table
         column._meta._name = name
-        column._meta.db_column_name = name
 
         if isinstance(column, ForeignKey):
             column._setup(table_class=self.table)


### PR DESCRIPTION
Related to #945.