### PR TITLE
991 Pressing Enter in Reverse 1 migration? [y/N] still leads to reversing.

### DIFF
--- a/piccolo/apps/migrations/commands/backwards.py
+++ b/piccolo/apps/migrations/commands/backwards.py
@@ -78,9 +78,11 @@ class BackwardsMigrationManager(BaseMigrationManager):
         _continue = (
             "y"
             if self.auto_agree
-            else input(f"Reverse {n} migration{'s' if n != 1 else ''}? [y/N] ")
+            else input(
+                f"Reverse {n} migration{'s' if n != 1 else ''}? [y/N] "
+            ).lower()
         )
-        if _continue in "yY":
+        if _continue == "y":
             for migration_id in reversed_migration_ids:
                 migration_module = migration_modules[migration_id]
                 response = await migration_module.forwards()
@@ -131,10 +133,10 @@ async def run_backwards(
                 "apps:\n"
                 f"{', '.join(names)}\n"
                 "Are you sure you want to continue? [y/N] "
-            )
+            ).lower()
         )
 
-        if _continue not in "yY":
+        if _continue != "y":
             return MigrationResult(success=False, message="user cancelled")
         for _app_name in sorted_app_names:
             print_heading(_app_name)


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/991