### PR TITLE
1028 Document how to achieve a `OneToOneField` in Piccolo

### DIFF
--- a/docs/src/piccolo/query_types/django_comparison.rst
+++ b/docs/src/piccolo/query_types/django_comparison.rst
@@ -218,7 +218,7 @@ Or alternatively, using ``get_related``:
 
     fan_club = await band.get_related(Band.id.join_on(FanClub.band))
 
-    # Similarly:
+    # Alternatively, by reversing the foreign key:
     fan_club = await band.get_related(FanClub.band.reverse())
 
 If doing a select query, and you want data from the related table:
@@ -231,7 +231,7 @@ If doing a select query, and you want data from the related table:
     ... )
     [{'name': 'Pythonistas', 'address': '1 Flying Circus, UK'}, ...]
 
-Similarly, in where clauses:
+And filtering by related tables in the ``where`` clause:
 
 .. code-block:: python
 

--- a/docs/src/piccolo/query_types/django_comparison.rst
+++ b/docs/src/piccolo/query_types/django_comparison.rst
@@ -185,7 +185,7 @@ Schema
 OneToOneField
 ~~~~~~~~~~~~~
 
-To do this in Piccolo, use a unique ``ForeignKey`` - see
+To do this in Piccolo, use a ``ForeignKey`` with a unique constraint - see
 :ref:`One to One<OneToOne>`.
 
 -------------------------------------------------------------------------------

--- a/docs/src/piccolo/query_types/django_comparison.rst
+++ b/docs/src/piccolo/query_types/django_comparison.rst
@@ -185,60 +185,8 @@ Schema
 OneToOneField
 ~~~~~~~~~~~~~
 
-Django has a ``OneToOneField``. It's basically just a foreign key with a unique
-constraint. In Piccolo you can achieve it like this:
-
-.. code-block:: python
-
-    from piccolo.table import Table
-    from piccolo.columns import ForeignKey, Varchar, Text
-
-    class Band(Table):
-        name = Varchar()
-
-    class FanClub(Table):
-        band = ForeignKey(Band, unique=True)
-        address = Text()
-
-If we have a ``Band`` object:
-
-.. code-block:: python
-
-    band = await Band.objects().where(Band.name == "Pythonistas")
-
-To get the associated ``FanClub`` object, you could do this:
-
-.. code-block:: python
-
-    fan_club = await FanClub.objects().where(FanClub.band == band).first()
-
-Or alternatively, using ``get_related``:
-
-.. code-block:: python
-
-    fan_club = await band.get_related(Band.id.join_on(FanClub.band))
-
-    # Alternatively, by reversing the foreign key:
-    fan_club = await band.get_related(FanClub.band.reverse())
-
-If doing a select query, and you want data from the related table:
-
-.. code-block:: python
-
-    >>> await Band.select(
-    ...     Band.name,
-    ...     Band.id.join_on(FanClub.band).address.as_alias("address")
-    ... )
-    [{'name': 'Pythonistas', 'address': '1 Flying Circus, UK'}, ...]
-
-And filtering by related tables in the ``where`` clause:
-
-.. code-block:: python
-
-    >>> await Band.select(
-    ...     Band.name,
-    ... ).where(Band.id.join_on(FanClub.band).address.like("%Flying%"))
-    [{'name': 'Pythonistas'}]
+To do this in Piccolo, use a unique ``ForeignKey`` - see
+:ref:`One to One<OneToOne>`.
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/query_types/django_comparison.rst
+++ b/docs/src/piccolo/query_types/django_comparison.rst
@@ -177,6 +177,68 @@ Piccolo has something similar:
     >>> band.manager
     <Manager: 1>
 
+-------------------------------------------------------------------------------
+
+Schema
+------
+
+OneToOneField
+~~~~~~~~~~~~~
+
+Django has a ``OneToOneField``. It's basically just a foreign key with a unique
+constraint. In Piccolo you can achieve it like this:
+
+.. code-block:: python
+
+    from piccolo.table import Table
+    from piccolo.columns import ForeignKey, Varchar, Text
+
+    class Band(Table):
+        name = Varchar()
+
+    class FanClub(Table):
+        band = ForeignKey(Band, unique=True)
+        address = Text()
+
+If we have a ``Band`` object:
+
+.. code-block:: python
+
+    band = await Band.objects().where(Band.name == "Pythonistas")
+
+To get the associated ``FanClub`` object, you could do this:
+
+.. code-block:: python
+
+    fan_club = await FanClub.objects().where(FanClub.band == band).first()
+
+Or alternatively, using ``get_related``:
+
+.. code-block:: python
+
+    fan_club = await band.get_related(Band.id.join_on(FanClub.band))
+
+    # Similarly:
+    fan_club = await band.get_related(FanClub.band.reverse())
+
+If doing a select query, and you want data from the related table:
+
+.. code-block:: python
+
+    >>> await Band.select(
+    ...     Band.name,
+    ...     Band.id.join_on(FanClub.band).address.as_alias("address")
+    ... )
+    [{'name': 'Pythonistas', 'address': '1 Flying Circus, UK'}, ...]
+
+Similarly, in where clauses:
+
+.. code-block:: python
+
+    >>> await Band.select(
+    ...     Band.name,
+    ... ).where(Band.id.join_on(FanClub.band).address.like("%Flying%"))
+    [{'name': 'Pythonistas'}]
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/schema/index.rst
+++ b/docs/src/piccolo/schema/index.rst
@@ -9,4 +9,5 @@ The schema is how you define your database tables, columns and relationships.
     ./defining
     ./column_types
     ./m2m
+    ./one_to_one
     ./advanced

--- a/docs/src/piccolo/schema/one_to_one.rst
+++ b/docs/src/piccolo/schema/one_to_one.rst
@@ -3,6 +3,9 @@
 One to One
 ==========
 
+Schema
+------
+
 A one to one relationship is basically just a foreign key with a unique
 constraint. In Piccolo, you can do it like this:
 
@@ -17,6 +20,12 @@ constraint. In Piccolo, you can do it like this:
     class FanClub(Table):
         band = ForeignKey(Band, unique=True)  # note the unique foreign key
         address = Text()
+
+Queries
+-------
+
+Getting a related object
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 If we have a ``Band`` object:
 
@@ -36,8 +45,15 @@ Or alternatively, using ``get_related``:
 
     fan_club = await band.get_related(Band.id.join_on(FanClub.band))
 
-    # Alternatively, by reversing the foreign key:
+Instead of using ``join_on``, you can use ``reverse`` to traverse the foreign
+key backwards if you prefer:
+
+.. code-block:: python
+
     fan_club = await band.get_related(FanClub.band.reverse())
+
+Select
+~~~~~~
 
 If doing a select query, and you want data from the related table:
 
@@ -49,7 +65,10 @@ If doing a select query, and you want data from the related table:
     ... )
     [{'name': 'Pythonistas', 'address': '1 Flying Circus, UK'}, ...]
 
-And filtering by related tables in the ``where`` clause:
+Where
+~~~~~
+
+If you want to filter by related tables in the ``where`` clause:
 
 .. code-block:: python
 
@@ -57,3 +76,10 @@ And filtering by related tables in the ``where`` clause:
     ...     Band.name,
     ... ).where(Band.id.join_on(FanClub.band).address.like("%Flying%"))
     [{'name': 'Pythonistas'}]
+
+Source
+------
+
+.. currentmodule:: piccolo.columns.column_types
+
+.. automethod:: ForeignKey.reverse

--- a/docs/src/piccolo/schema/one_to_one.rst
+++ b/docs/src/piccolo/schema/one_to_one.rst
@@ -18,7 +18,7 @@ constraint. In Piccolo, you can do it like this:
         name = Varchar()
 
     class FanClub(Table):
-        band = ForeignKey(Band, unique=True)  # note the unique foreign key
+        band = ForeignKey(Band, unique=True)  # <- Note the unique constraint
         address = Text()
 
 Queries

--- a/docs/src/piccolo/schema/one_to_one.rst
+++ b/docs/src/piccolo/schema/one_to_one.rst
@@ -1,0 +1,59 @@
+.. _OneToOne:
+
+One to One
+==========
+
+A one to one relationship is basically just a foreign key with a unique
+constraint. In Piccolo, you can do it like this:
+
+.. code-block:: python
+
+    from piccolo.table import Table
+    from piccolo.columns import ForeignKey, Varchar, Text
+
+    class Band(Table):
+        name = Varchar()
+
+    class FanClub(Table):
+        band = ForeignKey(Band, unique=True)  # note the unique foreign key
+        address = Text()
+
+If we have a ``Band`` object:
+
+.. code-block:: python
+
+    band = await Band.objects().where(Band.name == "Pythonistas").first()
+
+To get the associated ``FanClub`` object, you could do this:
+
+.. code-block:: python
+
+    fan_club = await FanClub.objects().where(FanClub.band == band).first()
+
+Or alternatively, using ``get_related``:
+
+.. code-block:: python
+
+    fan_club = await band.get_related(Band.id.join_on(FanClub.band))
+
+    # Alternatively, by reversing the foreign key:
+    fan_club = await band.get_related(FanClub.band.reverse())
+
+If doing a select query, and you want data from the related table:
+
+.. code-block:: python
+
+    >>> await Band.select(
+    ...     Band.name,
+    ...     Band.id.join_on(FanClub.band).address.as_alias("address")
+    ... )
+    [{'name': 'Pythonistas', 'address': '1 Flying Circus, UK'}, ...]
+
+And filtering by related tables in the ``where`` clause:
+
+.. code-block:: python
+
+    >>> await Band.select(
+    ...     Band.name,
+    ... ).where(Band.id.join_on(FanClub.band).address.like("%Flying%"))
+    [{'name': 'Pythonistas'}]

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -19,6 +19,7 @@ from piccolo.columns import (
     Interval,
     Numeric,
     Serial,
+    Text,
     Timestamp,
     Varchar,
 )
@@ -53,6 +54,12 @@ class Band(Table):
             template="%s",
             columns=[cls.name],
         )
+
+
+class FanClub(Table):
+    id: Serial
+    address = Text()
+    band = ForeignKey(Band, unique=True)
 
 
 class Venue(Table):
@@ -154,6 +161,7 @@ class Album(Table):
 TABLES = (
     Manager,
     Band,
+    FanClub,
     Venue,
     Concert,
     Ticket,
@@ -184,6 +192,9 @@ def populate():
 
     pythonistas = Band(name="Pythonistas", manager=guido.id, popularity=1000)
     pythonistas.save().run_sync()
+
+    fan_club = FanClub(address="1 Flying Circus, UK", band=pythonistas)
+    fan_club.save().run_sync()
 
     graydon = Manager(name="Graydon")
     graydon.save().run_sync()

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -35,8 +35,6 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 
-from typing_extensions import Self
-
 from piccolo.columns.base import (
     Column,
     ForeignKeyMeta,

--- a/tests/base.py
+++ b/tests/base.py
@@ -13,7 +13,12 @@ from piccolo.engine.cockroach import CockroachEngine
 from piccolo.engine.finder import engine_finder
 from piccolo.engine.postgres import PostgresEngine
 from piccolo.engine.sqlite import SQLiteEngine
-from piccolo.table import Table, create_table_class
+from piccolo.table import (
+    Table,
+    create_db_tables_sync,
+    create_table_class,
+    drop_db_tables_sync,
+)
 from piccolo.utils.sync import run_sync
 
 ENGINE = engine_finder()
@@ -454,3 +459,17 @@ class DBTestCase(TestCase):
 
     def tearDown(self):
         self.drop_tables()
+
+
+class TableTest(TestCase):
+    """
+    Used for tests where we need to create Piccolo tables.
+    """
+
+    tables: t.List[t.Type[Table]]
+
+    def setUp(self) -> None:
+        create_db_tables_sync(*self.tables)
+
+    def tearDown(self) -> None:
+        drop_db_tables_sync(*self.tables)

--- a/tests/columns/foreign_key/test_reverse.py
+++ b/tests/columns/foreign_key/test_reverse.py
@@ -1,0 +1,56 @@
+from piccolo.columns import ForeignKey, Text, Varchar
+from piccolo.table import Table
+from tests.base import TableTest
+
+
+class Band(Table):
+    name = Varchar()
+
+
+class FanClub(Table):
+    address = Text()
+    band = ForeignKey(Band, unique=True)
+
+
+class Treasurer(Table):
+    name = Varchar()
+    fan_club = ForeignKey(FanClub, unique=True)
+
+
+class TestReverse(TableTest):
+    tables = [Band, FanClub, Treasurer]
+
+    def setUp(self):
+        super().setUp()
+
+        band = Band({Band.name: "Pythonistas"})
+        band.save().run_sync()
+
+        fan_club = FanClub(
+            {FanClub.band: band, FanClub.address: "1 Flying Circus, UK"}
+        )
+        fan_club.save().run_sync()
+
+        treasurer = Treasurer(
+            {Treasurer.fan_club: fan_club, Treasurer.name: "Bob"}
+        )
+        treasurer.save().run_sync()
+
+    def test_reverse(self):
+        response = Band.select(
+            Band.name,
+            FanClub.band.reverse().address.as_alias("address"),
+            Treasurer.fan_club._.band.reverse().name.as_alias(
+                "treasurer_name"
+            ),
+        ).run_sync()
+        self.assertListEqual(
+            response,
+            [
+                {
+                    "name": "Pythonistas",
+                    "address": "1 Flying Circus, UK",
+                    "treasurer_name": "Bob",
+                }
+            ],
+        )

--- a/tests/query/functions/base.py
+++ b/tests/query/functions/base.py
@@ -1,21 +1,8 @@
-import typing as t
-from unittest import TestCase
-
-from piccolo.table import Table, create_db_tables_sync, drop_db_tables_sync
+from tests.base import TableTest
 from tests.example_apps.music.tables import Band, Manager
 
 
-class FunctionTest(TestCase):
-    tables: t.List[t.Type[Table]]
-
-    def setUp(self) -> None:
-        create_db_tables_sync(*self.tables)
-
-    def tearDown(self) -> None:
-        drop_db_tables_sync(*self.tables)
-
-
-class BandTest(FunctionTest):
+class BandTest(TableTest):
     tables = [Band, Manager]
 
     def setUp(self) -> None:

--- a/tests/query/functions/test_datetime.py
+++ b/tests/query/functions/test_datetime.py
@@ -12,16 +12,14 @@ from piccolo.query.functions.datetime import (
     Year,
 )
 from piccolo.table import Table
-from tests.base import engines_only, sqlite_only
-
-from .base import FunctionTest
+from tests.base import TableTest, engines_only, sqlite_only
 
 
 class Concert(Table):
     starts = Timestamp()
 
 
-class DatetimeTest(FunctionTest):
+class DatetimeTest(TableTest):
     tables = [Concert]
 
     def setUp(self) -> None:

--- a/tests/query/functions/test_math.py
+++ b/tests/query/functions/test_math.py
@@ -3,15 +3,14 @@ import decimal
 from piccolo.columns import Numeric
 from piccolo.query.functions.math import Abs, Ceil, Floor, Round
 from piccolo.table import Table
-
-from .base import FunctionTest
+from tests.base import TableTest
 
 
 class Ticket(Table):
     price = Numeric(digits=(5, 2))
 
 
-class TestMath(FunctionTest):
+class TestMath(TableTest):
 
     tables = [Ticket]
 


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1028

As well as adding documentation, this PR adds a new table to the playground called `FanClub`, for testing unique foreign keys.

It also adds a new method to `ForeignKey` called `reverse`, which is an alternative to `join_on` for traversing foreign keys in reverse.