### PR TITLE
1030 Use `TableTest` to cut down boiler plate in tests

### DIFF
--- a/tests/columns/test_array.py
+++ b/tests/columns/test_array.py
@@ -14,7 +14,7 @@ from piccolo.columns.column_types import (
 )
 from piccolo.querystring import QueryString
 from piccolo.table import Table
-from tests.base import engines_only, engines_skip, sqlite_only
+from tests.base import TableTest, engines_only, engines_skip, sqlite_only
 
 
 class MyTable(Table):
@@ -32,16 +32,12 @@ class TestArrayDefault(TestCase):
         self.assertTrue(column.default is list)
 
 
-class TestArray(TestCase):
+class TestArray(TableTest):
     """
     Make sure an Array column can be created, and works correctly.
     """
 
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+    tables = [MyTable]
 
     @pytest.mark.cockroach_array_slow
     def test_storage(self):

--- a/tests/columns/test_bigint.py
+++ b/tests/columns/test_bigint.py
@@ -1,10 +1,8 @@
 import os
-from unittest import TestCase
 
 from piccolo.columns.column_types import BigInt
 from piccolo.table import Table
-
-from ..base import engines_only
+from tests.base import TableTest, engines_only
 
 
 class MyTable(Table):
@@ -12,16 +10,12 @@ class MyTable(Table):
 
 
 @engines_only("postgres", "cockroach")
-class TestBigIntPostgres(TestCase):
+class TestBigIntPostgres(TableTest):
     """
     Make sure a BigInt column in Postgres can store a large number.
     """
 
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+    tables = [MyTable]
 
     def _test_length(self):
         # Can store 8 bytes, but split between positive and negative values.

--- a/tests/columns/test_boolean.py
+++ b/tests/columns/test_boolean.py
@@ -1,20 +1,16 @@
 import typing as t
-from unittest import TestCase
 
 from piccolo.columns.column_types import Boolean
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
     boolean = Boolean(boolean=False, null=True)
 
 
-class TestBoolean(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestBoolean(TableTest):
+    tables = [MyTable]
 
     def test_return_type(self) -> None:
         for value in (True, False, None, ...):

--- a/tests/columns/test_bytea.py
+++ b/tests/columns/test_bytea.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
-
 from piccolo.columns.column_types import Bytea
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -19,12 +18,8 @@ class MyTableDefault(Table):
     token_none = Bytea(default=None, null=True)
 
 
-class TestBytea(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestBytea(TableTest):
+    tables = [MyTable]
 
     def test_bytea(self):
         """
@@ -40,12 +35,8 @@ class TestBytea(TestCase):
         )
 
 
-class TestByteaDefault(TestCase):
-    def setUp(self):
-        MyTableDefault.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefault.alter().drop_table().run_sync()
+class TestByteaDefault(TableTest):
+    tables = [MyTableDefault]
 
     def test_json_default(self):
         row = MyTableDefault()

--- a/tests/columns/test_choices.py
+++ b/tests/columns/test_choices.py
@@ -1,18 +1,13 @@
 import enum
-from unittest import TestCase
 
 from piccolo.columns.column_types import Array, Varchar
 from piccolo.table import Table
-from tests.base import engines_only
+from tests.base import TableTest, engines_only
 from tests.example_apps.music.tables import Shirt
 
 
-class TestChoices(TestCase):
-    def setUp(self):
-        Shirt.create_table().run_sync()
-
-    def tearDown(self):
-        Shirt.alter().drop_table().run_sync()
+class TestChoices(TableTest):
+    tables = [Shirt]
 
     def _insert_shirts(self):
         Shirt.insert(
@@ -87,16 +82,12 @@ class Ticket(Table):
 
 
 @engines_only("postgres", "sqlite")
-class TestArrayChoices(TestCase):
+class TestArrayChoices(TableTest):
     """
     🐛 Cockroach bug: https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
     """  # noqa: E501
 
-    def setUp(self):
-        Ticket.create_table().run_sync()
-
-    def tearDown(self):
-        Ticket.alter().drop_table().run_sync()
+    tables = [Ticket]
 
     def test_string(self):
         """

--- a/tests/columns/test_date.py
+++ b/tests/columns/test_date.py
@@ -1,9 +1,9 @@
 import datetime
-from unittest import TestCase
 
 from piccolo.columns.column_types import Date
 from piccolo.columns.defaults.date import DateNow
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -14,12 +14,8 @@ class MyTableDefault(Table):
     created_on = Date(default=DateNow())
 
 
-class TestDate(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestDate(TableTest):
+    tables = [MyTable]
 
     def test_timestamp(self):
         created_on = datetime.datetime.now().date()
@@ -31,12 +27,8 @@ class TestDate(TestCase):
         self.assertEqual(result.created_on, created_on)
 
 
-class TestDateDefault(TestCase):
-    def setUp(self):
-        MyTableDefault.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefault.alter().drop_table().run_sync()
+class TestDateDefault(TableTest):
+    tables = [MyTableDefault]
 
     def test_timestamp(self):
         created_on = datetime.datetime.now().date()

--- a/tests/columns/test_double_precision.py
+++ b/tests/columns/test_double_precision.py
@@ -1,19 +1,14 @@
-from unittest import TestCase
-
 from piccolo.columns.column_types import DoublePrecision
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
     column_a = DoublePrecision()
 
 
-class TestDoublePrecision(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestDoublePrecision(TableTest):
+    tables = [MyTable]
 
     def test_creation(self):
         row = MyTable(column_a=1.23)

--- a/tests/columns/test_interval.py
+++ b/tests/columns/test_interval.py
@@ -1,9 +1,9 @@
 import datetime
-from unittest import TestCase
 
 from piccolo.columns.column_types import Interval
 from piccolo.columns.defaults.interval import IntervalCustom
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -14,12 +14,8 @@ class MyTableDefault(Table):
     interval = Interval(default=IntervalCustom(days=1))
 
 
-class TestInterval(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestInterval(TableTest):
+    tables = [MyTable]
 
     def test_interval(self):
         # Test a range of different timedeltas
@@ -91,12 +87,8 @@ class TestInterval(TestCase):
         self.assertTrue(result)
 
 
-class TestIntervalDefault(TestCase):
-    def setUp(self):
-        MyTableDefault.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefault.alter().drop_table().run_sync()
+class TestIntervalDefault(TableTest):
+    tables = [MyTableDefault]
 
     def test_interval(self):
         row = MyTableDefault()

--- a/tests/columns/test_json.py
+++ b/tests/columns/test_json.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
-
 from piccolo.columns.column_types import JSON
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -20,12 +19,8 @@ class MyTableDefault(Table):
     json_none = JSON(default=None, null=True)
 
 
-class TestJSONSave(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestJSONSave(TableTest):
+    tables = [MyTable]
 
     def test_json_string(self):
         """
@@ -58,12 +53,8 @@ class TestJSONSave(TestCase):
         )
 
 
-class TestJSONDefault(TestCase):
-    def setUp(self):
-        MyTableDefault.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefault.alter().drop_table().run_sync()
+class TestJSONDefault(TableTest):
+    tables = [MyTableDefault]
 
     def test_json_default(self):
         row = MyTableDefault()
@@ -81,12 +72,8 @@ class TestJSONDefault(TestCase):
                 JSON(default=value)  # type: ignore
 
 
-class TestJSONInsert(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestJSONInsert(TableTest):
+    tables = [MyTable]
 
     def check_response(self):
         row = MyTable.select(MyTable.json).first().run_sync()
@@ -112,12 +99,8 @@ class TestJSONInsert(TestCase):
         MyTable.insert(row).run_sync()
 
 
-class TestJSONUpdate(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestJSONUpdate(TableTest):
+    tables = [MyTable]
 
     def add_row(self):
         row = MyTable(json={"message": "original"})

--- a/tests/columns/test_jsonb.py
+++ b/tests/columns/test_jsonb.py
@@ -1,8 +1,6 @@
-from unittest import TestCase
-
 from piccolo.columns.column_types import JSONB, ForeignKey, Varchar
 from piccolo.table import Table
-from tests.base import engines_only, engines_skip
+from tests.base import TableTest, engines_only, engines_skip
 
 
 class RecordingStudio(Table):
@@ -16,14 +14,8 @@ class Instrument(Table):
 
 
 @engines_only("postgres", "cockroach")
-class TestJSONB(TestCase):
-    def setUp(self):
-        RecordingStudio.create_table().run_sync()
-        Instrument.create_table().run_sync()
-
-    def tearDown(self):
-        Instrument.alter().drop_table().run_sync()
-        RecordingStudio.alter().drop_table().run_sync()
+class TestJSONB(TableTest):
+    tables = [RecordingStudio, Instrument]
 
     def test_json(self):
         """

--- a/tests/columns/test_numeric.py
+++ b/tests/columns/test_numeric.py
@@ -1,8 +1,8 @@
 from decimal import Decimal
-from unittest import TestCase
 
 from piccolo.columns.column_types import Numeric
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -10,12 +10,8 @@ class MyTable(Table):
     column_b = Numeric(digits=(3, 2))
 
 
-class TestNumeric(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestNumeric(TableTest):
+    tables = [MyTable]
 
     def test_creation(self):
         row = MyTable(column_a=Decimal(1.23), column_b=Decimal(1.23))

--- a/tests/columns/test_primary_key.py
+++ b/tests/columns/test_primary_key.py
@@ -1,5 +1,4 @@
 import uuid
-from unittest import TestCase
 
 from piccolo.columns.column_types import (
     UUID,
@@ -9,6 +8,7 @@ from piccolo.columns.column_types import (
     Varchar,
 )
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTableDefaultPrimaryKey(Table):
@@ -30,12 +30,8 @@ class MyTablePrimaryKeyUUID(Table):
     name = Varchar()
 
 
-class TestPrimaryKeyDefault(TestCase):
-    def setUp(self):
-        MyTableDefaultPrimaryKey.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefaultPrimaryKey.alter().drop_table().run_sync()
+class TestPrimaryKeyDefault(TableTest):
+    tables = [MyTableDefaultPrimaryKey]
 
     def test_return_type(self):
         row = MyTableDefaultPrimaryKey()
@@ -45,12 +41,8 @@ class TestPrimaryKeyDefault(TestCase):
         self.assertIsInstance(row["id"], int)
 
 
-class TestPrimaryKeyInteger(TestCase):
-    def setUp(self):
-        MyTablePrimaryKeySerial.create_table().run_sync()
-
-    def tearDown(self):
-        MyTablePrimaryKeySerial.alter().drop_table().run_sync()
+class TestPrimaryKeyInteger(TableTest):
+    tables = [MyTablePrimaryKeySerial]
 
     def test_return_type(self):
         row = MyTablePrimaryKeySerial()
@@ -60,12 +52,8 @@ class TestPrimaryKeyInteger(TestCase):
         self.assertIsInstance(row["pk"], int)
 
 
-class TestPrimaryKeyBigSerial(TestCase):
-    def setUp(self):
-        MyTablePrimaryKeyBigSerial.create_table().run_sync()
-
-    def tearDown(self):
-        MyTablePrimaryKeyBigSerial.alter().drop_table().run_sync()
+class TestPrimaryKeyBigSerial(TableTest):
+    tables = [MyTablePrimaryKeyBigSerial]
 
     def test_return_type(self):
         row = MyTablePrimaryKeyBigSerial()
@@ -75,12 +63,8 @@ class TestPrimaryKeyBigSerial(TestCase):
         self.assertIsInstance(row["pk"], int)
 
 
-class TestPrimaryKeyUUID(TestCase):
-    def setUp(self):
-        MyTablePrimaryKeyUUID.create_table().run_sync()
-
-    def tearDown(self):
-        MyTablePrimaryKeyUUID.alter().drop_table().run_sync()
+class TestPrimaryKeyUUID(TableTest):
+    tables = [MyTablePrimaryKeyUUID]
 
     def test_return_type(self):
         row = MyTablePrimaryKeyUUID()
@@ -101,14 +85,8 @@ class Band(Table):
     manager = ForeignKey(Manager)
 
 
-class TestPrimaryKeyQueries(TestCase):
-    def setUp(self):
-        Manager.create_table().run_sync()
-        Band.create_table().run_sync()
-
-    def tearDown(self):
-        Band.alter().drop_table().run_sync()
-        Manager.alter().drop_table().run_sync()
+class TestPrimaryKeyQueries(TableTest):
+    tables = [Manager, Band]
 
     def test_primary_key_queries(self):
         """

--- a/tests/columns/test_readable.py
+++ b/tests/columns/test_readable.py
@@ -1,8 +1,7 @@
-import unittest
-
 from piccolo import columns
 from piccolo.columns.readable import Readable
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -16,14 +15,13 @@ class MyTable(Table):
         )
 
 
-class TestReadable(unittest.TestCase):
+class TestReadable(TableTest):
+    tables = [MyTable]
+
     def setUp(self):
-        MyTable.create_table().run_sync()
+        super().setUp()
         MyTable(first_name="Guido", last_name="van Rossum").save().run_sync()
 
     def test_readable(self):
         response = MyTable.select(MyTable.get_readable()).run_sync()
         self.assertEqual(response[0]["readable"], "Guido van Rossum")
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()

--- a/tests/columns/test_real.py
+++ b/tests/columns/test_real.py
@@ -1,19 +1,14 @@
-from unittest import TestCase
-
 from piccolo.columns.column_types import Real
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
     column_a = Real()
 
 
-class TestReal(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestReal(TableTest):
+    tables = [MyTable]
 
     def test_creation(self):
         row = MyTable(column_a=1.23)

--- a/tests/columns/test_reserved_column_names.py
+++ b/tests/columns/test_reserved_column_names.py
@@ -1,7 +1,6 @@
-from unittest import TestCase
-
 from piccolo.columns.column_types import Integer, Varchar
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class Concert(Table):
@@ -16,17 +15,13 @@ class Concert(Table):
     order = Integer()
 
 
-class TestReservedColumnNames(TestCase):
+class TestReservedColumnNames(TableTest):
     """
     Make sure the table works as expected, even though it has a problematic
     column name.
     """
 
-    def setUp(self):
-        Concert.create_table().run_sync()
-
-    def tearDown(self):
-        Concert.alter().drop_table().run_sync()
+    tables = [Concert]
 
     def test_common_operations(self):
         # Save / Insert

--- a/tests/columns/test_smallint.py
+++ b/tests/columns/test_smallint.py
@@ -1,10 +1,9 @@
 import os
-from unittest import TestCase
 
 from piccolo.columns.column_types import SmallInt
 from piccolo.table import Table
 
-from ..base import engines_only
+from ..base import TableTest, engines_only
 
 
 class MyTable(Table):
@@ -12,16 +11,12 @@ class MyTable(Table):
 
 
 @engines_only("postgres", "cockroach")
-class TestSmallIntPostgres(TestCase):
+class TestSmallIntPostgres(TableTest):
     """
     Make sure a SmallInt column in Postgres can only store small numbers.
     """
 
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+    tables = [MyTable]
 
     def _test_length(self):
         # Can store 2 bytes, but split between positive and negative values.

--- a/tests/columns/test_time.py
+++ b/tests/columns/test_time.py
@@ -1,11 +1,10 @@
 import datetime
 from functools import partial
-from unittest import TestCase
 
 from piccolo.columns.column_types import Time
 from piccolo.columns.defaults.time import TimeNow
 from piccolo.table import Table
-from tests.base import engines_skip
+from tests.base import TableTest, engines_skip
 
 
 class MyTable(Table):
@@ -16,12 +15,8 @@ class MyTableDefault(Table):
     created_on = Time(default=TimeNow())
 
 
-class TestTime(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestTime(TableTest):
+    tables = [MyTable]
 
     @engines_skip("cockroach")
     def test_timestamp(self):
@@ -34,12 +29,8 @@ class TestTime(TestCase):
         self.assertEqual(result.created_on, created_on)
 
 
-class TestTimeDefault(TestCase):
-    def setUp(self):
-        MyTableDefault.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefault.alter().drop_table().run_sync()
+class TestTimeDefault(TableTest):
+    tables = [MyTableDefault]
 
     @engines_skip("cockroach")
     def test_timestamp(self):

--- a/tests/columns/test_timestamp.py
+++ b/tests/columns/test_timestamp.py
@@ -1,9 +1,9 @@
 import datetime
-from unittest import TestCase
 
 from piccolo.columns.column_types import Timestamp
 from piccolo.columns.defaults.timestamp import TimestampNow
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -19,12 +19,8 @@ class MyTableDefault(Table):
     created_on = Timestamp(default=TimestampNow())
 
 
-class TestTimestamp(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestTimestamp(TableTest):
+    tables = [MyTable]
 
     def test_timestamp(self):
         """
@@ -46,12 +42,8 @@ class TestTimestamp(TestCase):
             Timestamp(default=datetime.datetime.now(tz=datetime.timezone.utc))
 
 
-class TestTimestampDefault(TestCase):
-    def setUp(self):
-        MyTableDefault.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefault.alter().drop_table().run_sync()
+class TestTimestampDefault(TableTest):
+    tables = [MyTableDefault]
 
     def test_timestamp(self):
         """

--- a/tests/columns/test_timestamptz.py
+++ b/tests/columns/test_timestamptz.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest import TestCase
 
 from dateutil import tz
 
@@ -10,6 +9,7 @@ from piccolo.columns.defaults.timestamptz import (
     TimestamptzOffset,
 )
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
@@ -34,12 +34,8 @@ class CustomTimezone(datetime.tzinfo):
     pass
 
 
-class TestTimestamptz(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestTimestamptz(TableTest):
+    tables = [MyTable]
 
     def test_timestamptz_timezone_aware(self):
         """
@@ -78,12 +74,8 @@ class TestTimestamptz(TestCase):
             self.assertEqual(result.created_on.tzinfo, datetime.timezone.utc)
 
 
-class TestTimestamptzDefault(TestCase):
-    def setUp(self):
-        MyTableDefault.create_table().run_sync()
-
-    def tearDown(self):
-        MyTableDefault.alter().drop_table().run_sync()
+class TestTimestamptzDefault(TableTest):
+    tables = [MyTableDefault]
 
     def test_timestamptz_default(self):
         """

--- a/tests/columns/test_uuid.py
+++ b/tests/columns/test_uuid.py
@@ -1,20 +1,16 @@
 import uuid
-from unittest import TestCase
 
 from piccolo.columns.column_types import UUID
 from piccolo.table import Table
+from tests.base import TableTest
 
 
 class MyTable(Table):
     uuid = UUID()
 
 
-class TestUUID(TestCase):
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+class TestUUID(TableTest):
+    tables = [MyTable]
 
     def test_return_type(self):
         row = MyTable()

--- a/tests/columns/test_varchar.py
+++ b/tests/columns/test_varchar.py
@@ -1,9 +1,7 @@
-from unittest import TestCase
-
 from piccolo.columns.column_types import Varchar
 from piccolo.table import Table
 
-from ..base import engines_only
+from ..base import TableTest, engines_only
 
 
 class MyTable(Table):
@@ -11,7 +9,7 @@ class MyTable(Table):
 
 
 @engines_only("postgres", "cockroach")
-class TestVarchar(TestCase):
+class TestVarchar(TableTest):
     """
     SQLite doesn't enforce any constraints on max character length.
 
@@ -20,11 +18,7 @@ class TestVarchar(TestCase):
     Might consider enforcing this at the ORM level instead in the future.
     """
 
-    def setUp(self):
-        MyTable.create_table().run_sync()
-
-    def tearDown(self):
-        MyTable.alter().drop_table().run_sync()
+    tables = [MyTable]
 
     def test_length(self):
         row = MyTable(name="bob")


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1030