### PR TITLE
Better password error messages

### DIFF
--- a/docs/src/piccolo/authentication/baseuser.rst
+++ b/docs/src/piccolo/authentication/baseuser.rst
@@ -143,7 +143,9 @@ Limits
 ------
 
 The maximum password length allowed is 128 characters. This should be
-sufficiently long for most use cases.
+sufficiently long for most use cases.  
+
+The minimum password length allowed is 6 characters.
 
 -------------------------------------------------------------------------------
 

--- a/piccolo/apps/user/tables.py
+++ b/piccolo/apps/user/tables.py
@@ -91,15 +91,17 @@ class BaseUser(Table, tablename="piccolo_user"):
             raise ValueError("A password must be provided.")
 
         if len(password) < cls._min_password_length:
-            raise ValueError("The password is too short.")
+            raise ValueError(
+                f"The password is too short. (min {cls._min_password_length})"
+            )
 
         if len(password) > cls._max_password_length:
-            raise ValueError("The password is too long.")
+            raise ValueError(
+                f"The password is too long. (max {cls._max_password_length})"
+            )
 
         if password.startswith("pbkdf2_sha256"):
-            logger.warning(
-                "Tried to create a user with an already hashed password."
-            )
+            logger.warning("Tried to create a user with an already hashed password.")
             raise ValueError("Do not pass a hashed password.")
 
     ###########################################################################
@@ -122,9 +124,7 @@ class BaseUser(Table, tablename="piccolo_user"):
         elif isinstance(user, int):
             clause = cls.id == user
         else:
-            raise ValueError(
-                "The `user` arg must be a user id, or a username."
-            )
+            raise ValueError("The `user` arg must be a user id, or a username.")
 
         cls._validate_password(password=password)
 
@@ -243,16 +243,12 @@ class BaseUser(Table, tablename="piccolo_user"):
     ###########################################################################
 
     @classmethod
-    def create_user_sync(
-        cls, username: str, password: str, **extra_params
-    ) -> BaseUser:
+    def create_user_sync(cls, username: str, password: str, **extra_params) -> BaseUser:
         """
         A sync equivalent of :meth:`create_user`.
         """
         return run_sync(
-            cls.create_user(
-                username=username, password=password, **extra_params
-            )
+            cls.create_user(username=username, password=password, **extra_params)
         )
 
     @classmethod

--- a/piccolo/apps/user/tables.py
+++ b/piccolo/apps/user/tables.py
@@ -101,7 +101,9 @@ class BaseUser(Table, tablename="piccolo_user"):
             )
 
         if password.startswith("pbkdf2_sha256"):
-            logger.warning("Tried to create a user with an already hashed password.")
+            logger.warning(
+                "Tried to create a user with an already hashed password."
+            )
             raise ValueError("Do not pass a hashed password.")
 
     ###########################################################################
@@ -124,7 +126,9 @@ class BaseUser(Table, tablename="piccolo_user"):
         elif isinstance(user, int):
             clause = cls.id == user
         else:
-            raise ValueError("The `user` arg must be a user id, or a username.")
+            raise ValueError(
+                "The `user` arg must be a user id, or a username."
+            )
 
         cls._validate_password(password=password)
 
@@ -243,12 +247,16 @@ class BaseUser(Table, tablename="piccolo_user"):
     ###########################################################################
 
     @classmethod
-    def create_user_sync(cls, username: str, password: str, **extra_params) -> BaseUser:
+    def create_user_sync(
+        cls, username: str, password: str, **extra_params
+    ) -> BaseUser:
         """
         A sync equivalent of :meth:`create_user`.
         """
         return run_sync(
-            cls.create_user(username=username, password=password, **extra_params)
+            cls.create_user(
+                username=username, password=password, **extra_params
+            )
         )
 
     @classmethod

--- a/tests/apps/user/test_tables.py
+++ b/tests/apps/user/test_tables.py
@@ -38,7 +38,9 @@ class TestInstantiateUser(TestCase):
         malicious_password = secrets.token_urlsafe(1000)
         with self.assertRaises(ValueError) as manager:
             BaseUser(username="bob", password=malicious_password)
-        self.assertEqual(manager.exception.__str__(), "The password is too long.")
+        self.assertEqual(
+            manager.exception.__str__(), "The password is too long."
+        )
 
 
 class TestLogin(TestCase):
@@ -182,12 +184,20 @@ class TestCreateUser(TestCase):
     @patch("piccolo.apps.user.tables.logger")
     def test_hashed_password_error(self, logger: MagicMock):
         with self.assertRaises(ValueError) as manager:
-            BaseUser.create_user_sync(username="bob", password="pbkdf2_sha256$10000")
+            BaseUser.create_user_sync(
+                username="bob", password="pbkdf2_sha256$10000"
+            )
 
-        self.assertEqual(manager.exception.__str__(), "Do not pass a hashed password.")
+        self.assertEqual(
+            manager.exception.__str__(), "Do not pass a hashed password."
+        )
         self.assertEqual(
             logger.method_calls,
-            [call.warning("Tried to create a user with an already hashed password.")],
+            [
+                call.warning(
+                    "Tried to create a user with an already hashed password."
+                )
+            ],
         )
 
     def test_short_password_error(self):
@@ -218,7 +228,9 @@ class TestCreateUser(TestCase):
                 password="abc123",
             )
 
-        self.assertEqual(manager.exception.__str__(), "A username must be provided.")
+        self.assertEqual(
+            manager.exception.__str__(), "A username must be provided."
+        )
 
     def test_no_password_error(self):
         with self.assertRaises(ValueError) as manager:
@@ -227,7 +239,9 @@ class TestCreateUser(TestCase):
                 password=None,  # type: ignore
             )
 
-        self.assertEqual(manager.exception.__str__(), "A password must be provided.")
+        self.assertEqual(
+            manager.exception.__str__(), "A password must be provided."
+        )
 
 
 class TestAutoHashingUpdate(TestCase):
@@ -262,7 +276,9 @@ class TestAutoHashingUpdate(TestCase):
 
         # Login the user - Piccolo should detect their password needs rehashing
         # and update it.
-        self.assertIsNotNone(BaseUser.login_sync(username=username, password=password))
+        self.assertIsNotNone(
+            BaseUser.login_sync(username=username, password=password)
+        )
 
         user_data = (
             BaseUser.select(BaseUser.password)
@@ -280,4 +296,6 @@ class TestAutoHashingUpdate(TestCase):
         self.assertEqual(int(iterations_), BaseUser._pbkdf2_iteration_count)
 
         # Make sure subsequent logins work as expected
-        self.assertIsNotNone(BaseUser.login_sync(username=username, password=password))
+        self.assertIsNotNone(
+            BaseUser.login_sync(username=username, password=password)
+        )

--- a/tests/apps/user/test_tables.py
+++ b/tests/apps/user/test_tables.py
@@ -118,7 +118,10 @@ class TestLogin(TestCase):
             BaseUser.update_password_sync(username, short_password)
         self.assertEqual(
             manager.exception.__str__(),
-            f"The password is too short. (min {BaseUser._min_password_length})",
+            (
+                "The password is too short. (min "
+                f"{BaseUser._min_password_length})"
+            ),
         )
 
         # Test no password
@@ -206,7 +209,10 @@ class TestCreateUser(TestCase):
 
         self.assertEqual(
             manager.exception.__str__(),
-            f"The password is too short. (min {BaseUser._min_password_length})",
+            (
+                "The password is too short. (min "
+                f"{BaseUser._min_password_length})"
+            ),
         )
 
     def test_long_password_error(self):


### PR DESCRIPTION
Show minimum and maximum password length in error message.
Add minimum password length limit to documentation. 

Closes #1049