### PR TITLE
1056 Fix `refresh` if foreign key value has changed

### DIFF
--- a/piccolo/query/methods/refresh.py
+++ b/piccolo/query/methods/refresh.py
@@ -84,11 +84,9 @@ class Refresh:
                 select_columns.extend(
                     self._get_columns(
                         child_instance,
-                        column.all_columns(
-                            exclude=[
-                                child_instance.__class__._meta.primary_key
-                            ]
-                        ),
+                        # Fetch all columns (even the primary key, just in
+                        # case the foreign key now references a different row).
+                        column.all_columns(),
                     )
                 )
             else:


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/1056

I realised there's a small bug in https://github.com/piccolo-orm/piccolo/pull/1058

https://github.com/piccolo-orm/piccolo/blob/31a76ebb6b2228e79f85a9a3fc2bfe76d917d6f9/piccolo/query/methods/refresh.py#L87-L91

When fetching the values for the child objects, it was excluding the primary key. This is wrong though, as the foreign key value might have been updated to reference a different row.