### PR TITLE
1056 Make `refresh` work when foreign key is set to null, and with `load_json`

### DIFF
--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -303,8 +303,8 @@ It works with ``prefetch`` too:
     # If we have an instance:
     band = await Band.objects().where(Band.name == "Pythonistas").first()
 
-    # Call an API endpoint (e.g. with httpx):
-    await client.post(f"/band/{band.id}/", json={"popularity": 5000})
+    # Call an API endpoint which updates the object (e.g. with httpx):
+    await client.patch(f"/band/{band.id}/", json={"popularity": 5000})
 
     # Make sure the instance was updated:
     await band.refresh()

--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -296,6 +296,20 @@ It works with ``prefetch`` too:
     >>> band.manager.name
     "New value"
 
+``refresh`` is very useful in unit tests:
+
+.. code-block:: python
+
+    # If we have an instance:
+    band = await Band.objects().first()
+
+    # Call an API endpoint (e.g. with httpx):
+    await client.post("/band/", json={"popularity: 5000"})
+
+    # Make sure the instance was updated:
+    await band.refresh()
+    assert band.popularity == 5000
+
 -------------------------------------------------------------------------------
 
 Query clauses

--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -301,10 +301,10 @@ It works with ``prefetch`` too:
 .. code-block:: python
 
     # If we have an instance:
-    band = await Band.objects().first()
+    band = await Band.objects().where(Band.name == "Pythonistas").first()
 
     # Call an API endpoint (e.g. with httpx):
-    await client.post("/band/", json={"popularity: 5000"})
+    await client.post(f"/band/{band.id}/", json={"popularity": 5000})
 
     # Make sure the instance was updated:
     await band.refresh()

--- a/piccolo/query/base.py
+++ b/piccolo/query/base.py
@@ -79,9 +79,7 @@ class Query(t.Generic[TableInstance, QueryResponseType]):
                 if column._alias is not None:
                     json_column_names.append(column._alias)
                 elif len(column._meta.call_chain) > 0:
-                    json_column_names.append(
-                        column._meta.get_default_alias().replace("$", ".")
-                    )
+                    json_column_names.append(column._meta.get_default_alias())
                 else:
                     json_column_names.append(column._meta.name)
 

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -407,6 +407,9 @@ class Select(Query[TableInstance, t.List[t.Dict[str, t.Any]]]):
         ...
 
     @t.overload
+    def output(self: Self, *, load_json: bool, nested: bool) -> Self: ...
+
+    @t.overload
     def output(self: Self, *, nested: bool) -> Self: ...
 
     def output(

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -541,7 +541,9 @@ class Table(metaclass=TableMetaclass):
         )
 
     def refresh(
-        self, columns: t.Optional[t.Sequence[Column]] = None
+        self,
+        columns: t.Optional[t.Sequence[Column]] = None,
+        load_json: bool = False,
     ) -> Refresh:
         """
         Used to fetch the latest data for this instance from the database.
@@ -550,6 +552,10 @@ class Table(metaclass=TableMetaclass):
         :param columns:
             If you only want to refresh certain columns, specify them here.
             Otherwise all columns are refreshed.
+
+        :param load_json:
+            Whether to load ``JSON`` / ``JSONB`` columns as objects, instead of
+            just a string.
 
         Example usage::
 
@@ -564,7 +570,7 @@ class Table(metaclass=TableMetaclass):
             instance.refresh().run_sync()
 
         """
-        return Refresh(instance=self, columns=columns)
+        return Refresh(instance=self, columns=columns, load_json=load_json)
 
     @t.overload
     def get_related(

--- a/piccolo/utils/encoding.py
+++ b/piccolo/utils/encoding.py
@@ -67,5 +67,8 @@ def load_json(data: str) -> t.Any:
     response = (
         orjson.loads(data) if ORJSON else json.loads(data)  # type: ignore
     )
+
     if isinstance(response, dict):
         return JSONDict(**response)
+
+    return response

--- a/piccolo/utils/encoding.py
+++ b/piccolo/utils/encoding.py
@@ -29,5 +29,43 @@ def dump_json(data: t.Any, pretty: bool = False) -> str:
         return json.dumps(data, **params)  # type: ignore
 
 
+class JSONDict(dict):
+    """
+    Once we have parsed a JSON string into a dictionary, we can't distinguish
+    it from other dictionaries.
+
+    Sometimes we might want to - for example::
+
+        >>> await Album.select(
+        ...     Album.all_columns(),
+        ...     Album.recording_studio.all_columns()
+        ... ).output(
+        ...     nested=True,
+        ...     load_json=True
+        ... )
+
+        [{
+            'id': 1,
+            'band': 1,
+            'name': 'Awesome album 1',
+            'recorded_at': {
+                'id': 1,
+                'facilities': {'restaurant': True, 'mixing_desk': True},
+                'name': 'Abbey Road'
+            },
+            'release_date': datetime.date(2021, 1, 1)
+        }]
+
+    Facilities could be mistaken for a table.
+
+    """
+
+    ...
+
+
 def load_json(data: str) -> t.Any:
-    return orjson.loads(data) if ORJSON else json.loads(data)  # type: ignore
+    response = (
+        orjson.loads(data) if ORJSON else json.loads(data)  # type: ignore
+    )
+    if isinstance(response, dict):
+        return JSONDict(**response)

--- a/tests/columns/m2m/test_m2m.py
+++ b/tests/columns/m2m/test_m2m.py
@@ -4,6 +4,7 @@ import decimal
 import uuid
 from unittest import TestCase
 
+from piccolo.utils.encoding import JSONDict
 from tests.base import engines_skip
 
 try:
@@ -376,6 +377,9 @@ class TestM2MComplexSchema(TestCase):
 
             if isinstance(column, UUID):
                 self.assertIn(type(returned_value), (uuid.UUID, asyncpgUUID))
+            elif isinstance(column, (JSON, JSONB)):
+                self.assertEqual(type(returned_value), JSONDict)
+                self.assertEqual(original_value, returned_value)
             else:
                 self.assertEqual(
                     type(original_value),
@@ -401,6 +405,9 @@ class TestM2MComplexSchema(TestCase):
             if isinstance(column, UUID):
                 self.assertIn(type(returned_value), (uuid.UUID, asyncpgUUID))
                 self.assertEqual(str(original_value), str(returned_value))
+            elif isinstance(column, (JSON, JSONB)):
+                self.assertEqual(type(returned_value), JSONDict)
+                self.assertEqual(original_value, returned_value)
             else:
                 self.assertEqual(
                     type(original_value),

--- a/tests/table/test_refresh.py
+++ b/tests/table/test_refresh.py
@@ -282,8 +282,10 @@ class TestRefreshWithLoadJSON(TableTest):
         self.recording_studio.refresh().run_sync()
 
         self.assertEqual(
-            self.recording_studio.facilities,
-            '{"electric piano":true}',
+            # Remove the white space, because some versions of Python add
+            # whitespace around JSON, and some don't.
+            self.recording_studio.facilities.replace(" ", ""),
+            '{"electricpiano":true}',
         )
 
         # Refresh with load_json:

--- a/tests/table/test_refresh.py
+++ b/tests/table/test_refresh.py
@@ -215,6 +215,23 @@ class TestRefreshWithPrefetch(TableTest):
         self.assertEqual(band.manager.id, new_manager.id)
         self.assertEqual(band.manager.name, "New Manager")
 
+    def test_foreign_key_set_to_null(self):
+        band = (
+            Band.objects(Band.manager)
+            .where(Band.name == "Pythonistas")
+            .first()
+            .run_sync()
+        )
+        assert band is not None
+
+        # Remove the manager from band
+        Band.update({Band.manager: None}, force=True).run_sync()
+
+        # Refresh `band`, and make sure the foreign key value is now `None`,
+        # instead of a nested object.
+        band.refresh().run_sync()
+        self.assertIsNone(band.manager)
+
     def test_exception(self) -> None:
         """
         We don't currently let the user refresh specific fields from nested


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/1056

There are a couple of other edge cases I discovered.

## Null objects

```python
>>> band = await Band.objects(Band.manager).where(Band.name == "Pythonistas").first()
>>> band.manager.name
"Guido"

# If the band.manager foreign key gets set to null, when we refresh the object, it should now be null
>>> await band.refresh()
>>> band.manager
None
```

## ``load_json``

When refreshing, it doesn't load any JSON:

```python
>>> studio = await RecordingStudio.objects().output(load_json=True).first()
>>> studio.facilities
{'restaurant': True, 'mixing_desk': True}

>>> await studio.refresh()
>>> studio.facilities
 '{"restaurant":true,"mixing_desk":true}'
```

Now you can do this:

```python
>>> await studio.refresh(load_json=True)
>>> studio.facilities
{"restaurant":true,"mixing_desk":true}
```
