### PR TITLE
granian support in asgi templates

### DIFF
--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -9,10 +9,10 @@ import colorama
 from jinja2 import Environment, FileSystemLoader
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates/app/")
-SERVERS = ["uvicorn", "Hypercorn"]
+SERVERS = ["uvicorn", "Hypercorn", "granian"]
 ROUTER_DEPENDENCIES = {
     "starlette": ["starlette"],
-    "fastapi": ["fastapi>=0.100.0"],
+    "fastapi": ["fastapi>=0.112.1"],
     "blacksheep": ["blacksheep"],
     "litestar": ["litestar"],
     "esmerald": ["esmerald"],

--- a/piccolo/apps/asgi/commands/templates/app/main.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/main.py.jinja
@@ -18,4 +18,8 @@ if __name__ == "__main__":
     asyncio.run(serve(app, CustomConfig()))
 
     serve(app)
+    {% elif server == 'granian' %}
+    import granian
+
+    granian.Granian("app:app", interface="asgi").serve()
     {% endif %}


### PR DESCRIPTION
FastAPI updated the Starlette version in the latest release, and I added support for Granian in asgi templates.
Related to [this Piccolo Admin issue](https://github.com/piccolo-orm/piccolo_admin/issues/399).