### PR TITLE
1090 fix(m2m): Return empty list if there are no m2m entries

### DIFF
--- a/piccolo/columns/m2m.py
+++ b/piccolo/columns/m2m.py
@@ -386,7 +386,7 @@ class M2MGetRelated:
 
         results = await secondary_table.objects().where(
             secondary_table._meta.primary_key.is_in(ids)
-        )
+        ) if len(ids) > 0 else []
 
         return results
 

--- a/piccolo/columns/m2m.py
+++ b/piccolo/columns/m2m.py
@@ -384,9 +384,13 @@ class M2MGetRelated:
             .output(as_list=True)
         )
 
-        results = await secondary_table.objects().where(
-            secondary_table._meta.primary_key.is_in(ids)
-        ) if len(ids) > 0 else []
+        results = (
+            await secondary_table.objects().where(
+                secondary_table._meta.primary_key.is_in(ids)
+            )
+            if len(ids) > 0
+            else []
+        )
 
         return results
 

--- a/tests/columns/m2m/base.py
+++ b/tests/columns/m2m/base.py
@@ -434,6 +434,22 @@ class M2MBase:
 
         self.assertEqual([i.name for i in genres], ["Rock", "Folk"])
 
+    def test_get_m2m_no_rows(self):
+        """
+        If there are no matching objects, then an empty list should be
+        returned.
+
+        https://github.com/piccolo-orm/piccolo/issues/1090
+
+        """
+        band = Band.objects().get(Band.name == "Pythonistas").run_sync()
+        assert band is not None
+
+        Genre.delete(force=True).run_sync()
+
+        genres = band.get_m2m(Band.genres).run_sync()
+        self.assertEqual(genres, [])
+
     def test_remove_m2m(self):
         """
         Make sure we can remove related items via the joining table.


### PR DESCRIPTION
I ran into an issue where running `getm2m` without any existing m2m entries will throw an error that I believe is unintended.
![image](https://github.com/user-attachments/assets/733906d0-0024-4865-b615-0b6ecef75596)