### PR TITLE
fix constraint typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3737,7 +3737,7 @@ metaclass not being explicit enough when checking falsy values.
   which prevents circular import issues.
 * Faster column copying, which is important when specifying joins, e.g.
   ``await Band.select(Band.manager.name).run()``.
-* Fixed a bug with migrations and foreign key contraints.
+* Fixed a bug with migrations and foreign key constraints.
 
 -------------------------------------------------------------------------------
 

--- a/tests/table/test_insert.py
+++ b/tests/table/test_insert.py
@@ -201,7 +201,7 @@ class TestOnConflict(TestCase):
         Make sure that a composite unique constraint can be used as a target.
 
         We only run it on Postgres and Cockroach because we use ALTER TABLE
-        to add a contraint, which SQLite doesn't support.
+        to add a constraint, which SQLite doesn't support.
         """
         Band = self.Band
 


### PR DESCRIPTION
I can't seem to spell `constraint`.