### PR TITLE
1113 Use Python 3.13 for integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
             matrix:
                 # These tests are slow, so we only run on the latest Python
                 # version.
-                python-version: ["3.12"]
+                python-version: ["3.13"]
                 postgres-version: [17]
         services:
             postgres:


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1113