### PR TITLE
1152 `get_or_create` raises `ValueError`

### DIFF
--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -65,7 +65,7 @@ class GetOrCreate(
             instance._was_created = False
             return instance
 
-        instance = self.table_class(_data=self.defaults)
+        instance = self.table_class(_data=self.defaults, _ignore_missing=True)
 
         # If it's a complex `where`, there can be several column values to
         # extract e.g. (Band.name == 'Pythonistas') & (Band.popularity == 1000)

--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -65,22 +65,20 @@ class GetOrCreate(
             instance._was_created = False
             return instance
 
-        instance = self.table_class(_data=self.defaults, _ignore_missing=True)
+        data = {**self.defaults}
 
         # If it's a complex `where`, there can be several column values to
         # extract e.g. (Band.name == 'Pythonistas') & (Band.popularity == 1000)
         if isinstance(self.where, Where):
-            setattr(
-                instance,
-                self.where.column._meta.name,  # type: ignore
-                self.where.value,  # type: ignore
-            )
+            data[self.where.column] = self.where.value
         elif isinstance(self.where, And):
             for column, value in self.where.get_column_values().items():
                 if len(column._meta.call_chain) == 0:
                     # Make sure we only set the value if the column belongs
                     # to this table.
-                    setattr(instance, column._meta.name, value)
+                    data[column] = value
+
+        instance = self.table_class(_data=data)
 
         await instance.save().run(node=node, in_pool=in_pool)
 

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -272,7 +272,7 @@ class TestGetOrCreate(DBTestCase):
         self.assertEqual(band.manager.name, "Guido")
 
 
-class BandNotNull(Band):
+class BandNotNull(Band, tablename="band"):
     manager = ForeignKey(Manager, null=False)
 
 

--- a/tests/table/test_objects.py
+++ b/tests/table/test_objects.py
@@ -1,3 +1,5 @@
+from piccolo.columns.column_types import ForeignKey
+from piccolo.testing.test_case import AsyncTableTest
 from tests.base import DBTestCase, engines_only, sqlite_only
 from tests.example_apps.music.tables import Band, Manager
 
@@ -268,3 +270,32 @@ class TestGetOrCreate(DBTestCase):
         self.assertIsInstance(band.manager, Manager)
         self.assertEqual(band.name, "New Band 2")
         self.assertEqual(band.manager.name, "Guido")
+
+
+class BandNotNull(Band):
+    manager = ForeignKey(Manager, null=False)
+
+
+class TestGetOrCreateNotNull(AsyncTableTest):
+
+    tables = [BandNotNull, Manager]
+
+    async def test_not_null(self):
+        """
+        There was a bug where `get_or_create` would fail for columns with
+        `default=None` and `null=False`, even if the value for those columns
+        was specified in the where clause.
+
+        https://github.com/piccolo-orm/piccolo/issues/1152
+
+        """
+
+        manager = Manager({Manager.name: "Test"})
+        await manager.save()
+
+        self.assertIsInstance(
+            await BandNotNull.objects().get_or_create(
+                BandNotNull.manager == manager
+            ),
+            BandNotNull,
+        )


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1152

We can set `_ignore_missing=True`, but a better solution is outlined here:

https://github.com/piccolo-orm/piccolo/issues/1152#issuecomment-2661688912

Remaining tasks:

- [x] Merge values from `self.where` and `self.defaults`, and then instantiate the `Table`
- [x] Add tests