### PR TITLE
Fix `day` and `minute` in `TimestamptzCustom`'s `from_datetime`

### DIFF
--- a/piccolo/columns/defaults/timestamp.py
+++ b/piccolo/columns/defaults/timestamp.py
@@ -116,7 +116,7 @@ class TimestampCustom(Default):
         return cls(
             year=instance.year,
             month=instance.month,
-            day=instance.month,
+            day=instance.day,
             hour=instance.hour,
             minute=instance.minute,
             second=instance.second,

--- a/piccolo/columns/defaults/timestamp.py
+++ b/piccolo/columns/defaults/timestamp.py
@@ -70,6 +70,7 @@ class TimestampCustom(Default):
         month: int = 1,
         day: int = 1,
         hour: int = 0,
+        minute: int = 0,
         second: int = 0,
         microsecond: int = 0,
     ):
@@ -77,6 +78,7 @@ class TimestampCustom(Default):
         self.month = month
         self.day = day
         self.hour = hour
+        self.minute = minute
         self.second = second
         self.microsecond = microsecond
 
@@ -87,6 +89,7 @@ class TimestampCustom(Default):
             month=self.month,
             day=self.day,
             hour=self.hour,
+            minute=self.minute,
             second=self.second,
             microsecond=self.microsecond,
         )
@@ -115,6 +118,7 @@ class TimestampCustom(Default):
             month=instance.month,
             day=instance.month,
             hour=instance.hour,
+            minute=instance.minute,
             second=instance.second,
             microsecond=instance.microsecond,
         )

--- a/piccolo/columns/defaults/timestamptz.py
+++ b/piccolo/columns/defaults/timestamptz.py
@@ -47,6 +47,7 @@ class TimestamptzCustom(TimestampCustom):
             month=self.month,
             day=self.day,
             hour=self.hour,
+            minute=self.minute,
             second=self.second,
             microsecond=self.microsecond,
             tzinfo=datetime.timezone.utc,

--- a/piccolo/columns/defaults/timestamptz.py
+++ b/piccolo/columns/defaults/timestamptz.py
@@ -59,7 +59,7 @@ class TimestamptzCustom(TimestampCustom):
         return cls(
             year=instance.year,
             month=instance.month,
-            day=instance.month,
+            day=instance.day,
             hour=instance.hour,
             second=instance.second,
             microsecond=instance.microsecond,

--- a/piccolo/columns/defaults/timestamptz.py
+++ b/piccolo/columns/defaults/timestamptz.py
@@ -62,6 +62,7 @@ class TimestamptzCustom(TimestampCustom):
             month=instance.month,
             day=instance.day,
             hour=instance.hour,
+            minute=instance.minute,
             second=instance.second,
             microsecond=instance.microsecond,
         )

--- a/tests/columns/test_defaults.py
+++ b/tests/columns/test_defaults.py
@@ -22,6 +22,8 @@ from piccolo.columns.column_types import (
     TimestampNow,
     Varchar,
 )
+from piccolo.columns.defaults.timestamp import TimestampCustom
+from piccolo.columns.defaults.timestamptz import TimestamptzCustom
 from piccolo.table import Table
 
 
@@ -98,3 +100,35 @@ class TestDefaults(TestCase):
         ForeignKey(references=MyTable, default=1)
         with self.assertRaises(ValueError):
             ForeignKey(references=MyTable, default="hello world")
+
+
+class TestDatetime(TestCase):
+
+    def test_datetime(self):
+        """
+        Make sure we can create a `TimestampCustom` / `TimestamptzCustom` from
+        a datetime, and then convert it back into the same datetime again.
+
+        https://github.com/piccolo-orm/piccolo/issues/1169
+
+        """
+        datetime_obj = datetime.datetime(
+            year=2025,
+            month=1,
+            day=30,
+            hour=12,
+            minute=10,
+            second=15,
+            microsecond=100,
+        )
+
+        self.assertEqual(
+            TimestampCustom.from_datetime(datetime_obj).datetime,
+            datetime_obj,
+        )
+
+        datetime_obj = datetime_obj.astimezone(tz=datetime.timezone.utc)
+        self.assertEqual(
+            TimestamptzCustom.from_datetime(datetime_obj).datetime,
+            datetime_obj,
+        )


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1169

When setting a field like 

```python
class ABC(Table, db=DB):
    date = Timestamptz(
        null=False,
        default=datetime.datetime(
            9999, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc
        ),
    )
```

the field in the database is set as `9999-12-12 23:00:59+00` instead of `9999-12-31 23:59:59+00`. This PR fixes the `TimestamptzCustom`'s `from_datetime` method.