### PR TITLE
1178 Improve imports when app is created in a custom root

### DIFF
--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import shutil
 import sys
 import typing as t
 
@@ -44,7 +45,7 @@ def new_app(app_name: str, root: str = "."):
             "Python module. Please choose a different name for your app."
         )
 
-    os.mkdir(app_root)
+    os.makedirs(app_root)
 
     with open(os.path.join(app_root, "__init__.py"), "w"):
         pass

--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import os
-import shutil
 import sys
 import typing as t
 

--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -77,7 +77,7 @@ def new(app_name: str, root: str = "."):
     :param app_name:
         The name of the new app.
     :param root:
-        Where to create the app e.g. /my/folder. By default it creates the
+        Where to create the app e.g. ./my/folder. By default it creates the
         app in the current directory.
 
     """

--- a/piccolo/apps/app/commands/templates/piccolo_app.py.jinja
+++ b/piccolo/apps/app/commands/templates/piccolo_app.py.jinja
@@ -5,7 +5,7 @@ the APP_CONFIG.
 
 import os
 
-from piccolo.conf.apps import AppConfig, table_finder
+from piccolo.conf.apps import AppConfig, table_finder, get_package
 
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
@@ -18,7 +18,8 @@ APP_CONFIG = AppConfig(
         'piccolo_migrations'
     ),
     table_classes=table_finder(
-        modules=["{{ app_name }}.tables"],
+        modules=[".tables"],
+        package=get_package(__name__),
         exclude_imported=True
     ),
     migration_dependencies=[],

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -95,13 +95,19 @@ def table_finder(
     table_subclasses: t.List[t.Type[Table]] = []
 
     for module_path in modules:
+        full_module_path = (
+            ".".join([package, module_path.lstrip(".")])
+            if package
+            else module_path
+        )
+
         try:
             module = import_module(
                 module_path,
                 package=package,
             )
         except ImportError as exception:
-            print(f"Unable to import {module_path}")
+            print(f"Unable to import {full_module_path}")
             raise exception from exception
 
         object_names = [i for i in dir(module) if not i.startswith("_")]
@@ -115,7 +121,7 @@ def table_finder(
             ):
                 table: Table = _object  # type: ignore
 
-                if exclude_imported and table.__module__ != module_path:
+                if exclude_imported and table.__module__ != full_module_path:
                     continue
 
                 if exclude_tags and set(table._meta.tags).intersection(

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -32,8 +32,18 @@ class PiccoloAppModule(ModuleType):
     APP_CONFIG: AppConfig
 
 
+def get_package(name: str) -> str:
+    """
+    :param name:
+        The __name__ variable from a Python file.
+
+    """
+    return ".".join(name.split(".")[:-1])
+
+
 def table_finder(
     modules: t.Sequence[str],
+    package: t.Optional[str] = None,
     include_tags: t.Optional[t.Sequence[str]] = None,
     exclude_tags: t.Optional[t.Sequence[str]] = None,
     exclude_imported: bool = False,
@@ -46,8 +56,10 @@ def table_finder(
 
     :param modules:
         The module paths to check for ``Table`` subclasses. For example,
-        ``['blog.tables']``. The path should be from the root of your project,
-        not a relative path.
+        ``['blog.tables']``.
+    :param package:
+        This must be passed in if the modules are relative paths (e.g.
+        ``['.foo']``).
     :param include_tags:
         If the ``Table`` subclass has one of these tags, it will be
         imported. The special tag ``'__all__'`` will import all ``Table``
@@ -84,7 +96,10 @@ def table_finder(
 
     for module_path in modules:
         try:
-            module = import_module(module_path)
+            module = import_module(
+                module_path,
+                package=package,
+            )
         except ImportError as exception:
             print(f"Unable to import {module_path}")
             raise exception from exception


### PR DESCRIPTION
Related to https://github.com/piccolo-orm/piccolo/issues/1178

Rather than using absolute paths for `table_finder` in `piccolo_app.py`, we can use relative imports.

This is better when someone creates a Piccolo app under a sub directory using the `root` argument.

```
piccolo app new my_app --root=./src
```