### PR TITLE
1184 Be able to auto register apps

### DIFF
--- a/docs/src/piccolo/projects_and_apps/piccolo_apps.rst
+++ b/docs/src/piccolo/projects_and_apps/piccolo_apps.rst
@@ -46,6 +46,18 @@ automatically. Otherwise, add it manually:
 Anytime you invoke the ``piccolo`` command, you will now be able to perform
 operations on your app, such as :ref:`Migrations`.
 
+root
+~~~~
+
+By default the app is created in the current directory. If you want the app to
+be in a sub folder, you can use the ``--root`` option:
+
+.. code-block:: bash
+
+    piccolo app new my_app --register --root=./apps
+
+The app will then be created in the ``apps`` folder.
+
 -------------------------------------------------------------------------------
 
 AppConfig

--- a/docs/src/piccolo/projects_and_apps/piccolo_apps.rst
+++ b/docs/src/piccolo/projects_and_apps/piccolo_apps.rst
@@ -18,7 +18,7 @@ Run the following command within your project:
 
 .. code-block:: bash
 
-    piccolo app new my_app
+    piccolo app new my_app --register
 
 
 Where ``my_app`` is your new app's name. This will create a folder like this:
@@ -34,7 +34,8 @@ Where ``my_app`` is your new app's name. This will create a folder like this:
 
 
 It's important to register your new app with the ``APP_REGISTRY`` in
-``piccolo_conf.py``.
+``piccolo_conf.py``. If you used the ``--register`` flag, then this is done
+automatically. Otherwise, add it manually:
 
 .. code-block:: python
 

--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -33,7 +33,7 @@ def module_exists(module_name: str) -> bool:
         return True
 
 
-def get_app_identifier(app_name: str, root: str) -> str:
+def get_app_module(app_name: str, root: str) -> str:
     return ".".join([*pathlib.Path(root).parts, app_name, "piccolo_app"])
 
 
@@ -77,8 +77,8 @@ def new_app(app_name: str, root: str = ".", register: bool = False):
         pass
 
     if register:
-        app_identifier = get_app_identifier(app_name=app_name, root=root)
-        PiccoloConfUpdater().register_app(app_identifier=app_identifier)
+        app_module = get_app_module(app_name=app_name, root=root)
+        PiccoloConfUpdater().register_app(app_module=app_module)
 
 
 def new(app_name: str, root: str = ".", register: bool = False):

--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import pathlib
 import sys
 import typing as t
 
@@ -30,6 +31,10 @@ def module_exists(module_name: str) -> bool:
         return False
     else:
         return True
+
+
+def get_app_identifier(app_name: str, root: str) -> str:
+    return ".".join([*pathlib.Path(root).parts, app_name, "piccolo_app"])
 
 
 def new_app(app_name: str, root: str = ".", register: bool = False):
@@ -72,7 +77,8 @@ def new_app(app_name: str, root: str = ".", register: bool = False):
         pass
 
     if register:
-        PiccoloConfUpdater().register_app(app_name=app_name, root=root)
+        app_identifier = get_app_identifier(app_name=app_name, root=root)
+        PiccoloConfUpdater().register_app(app_identifier=app_identifier)
 
 
 def new(app_name: str, root: str = ".", register: bool = False):

--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -8,7 +8,7 @@ import typing as t
 import black
 import jinja2
 
-from piccolo.conf.apps import register_app
+from piccolo.conf.apps import PiccoloConfUpdater
 
 TEMPLATE_DIRECTORY = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "templates"
@@ -72,7 +72,7 @@ def new_app(app_name: str, root: str = ".", register: bool = False):
         pass
 
     if register:
-        register_app(app_name=app_name, root=root)
+        PiccoloConfUpdater().register_app(app_name=app_name, root=root)
 
 
 def new(app_name: str, root: str = ".", register: bool = False):

--- a/piccolo/apps/app/commands/new.py
+++ b/piccolo/apps/app/commands/new.py
@@ -8,6 +8,8 @@ import typing as t
 import black
 import jinja2
 
+from piccolo.conf.apps import register_app
+
 TEMPLATE_DIRECTORY = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "templates"
 )
@@ -30,7 +32,7 @@ def module_exists(module_name: str) -> bool:
         return True
 
 
-def new_app(app_name: str, root: str = "."):
+def new_app(app_name: str, root: str = ".", register: bool = False):
     print(f"Creating {app_name} app ...")
 
     app_root = os.path.join(root, app_name)
@@ -69,8 +71,11 @@ def new_app(app_name: str, root: str = "."):
     with open(os.path.join(migrations_folder_path, "__init__.py"), "w"):
         pass
 
+    if register:
+        register_app(app_name=app_name, root=root)
 
-def new(app_name: str, root: str = "."):
+
+def new(app_name: str, root: str = ".", register: bool = False):
     """
     Creates a new Piccolo app.
 
@@ -79,6 +84,8 @@ def new(app_name: str, root: str = "."):
     :param root:
         Where to create the app e.g. ./my/folder. By default it creates the
         app in the current directory.
+    :param register:
+        If True, the app is registered automatically in piccolo_conf.py.
 
     """
-    new_app(app_name=app_name, root=root)
+    new_app(app_name=app_name, root=root, register=register)

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -647,8 +647,8 @@ class PiccoloConfUpdater:
 
         if not parsing_successful:
             raise SyntaxError(
-                "Unable to parse piccolo_conf.py - `AppRegistry(apps=...)` not "
-                "found)."
+                "Unable to parse piccolo_conf.py - `AppRegistry(apps=...)` "
+                "not found)."
             )
 
         new_contents = ast.unparse(ast_root)
@@ -659,10 +659,7 @@ class PiccoloConfUpdater:
 
         return formatted_contents
 
-    def _get_app_identifier(self, app_name: str, root: str) -> str:
-        return ".".join([*pathlib.Path(root).parts, app_name, "piccolo_app"])
-
-    def register_app(self, app_name: str, root: str = "."):
+    def register_app(self, app_identifier: str):
         """
         Adds the given app to the ``AppRegistry`` in ``piccolo_conf.py``.
 
@@ -672,17 +669,12 @@ class PiccoloConfUpdater:
 
             piccolo app new my_app --register
 
-        :param app_name:
-            The name of the app, e.g. ``'music'``.
-        :param root:
-            Typically the app is created at the root of the project, if not
-            then include the path here. For example ``'./apps'``.
+        :param app_identifier:
+            The name of the app, e.g. ``'music.piccolo_app'``.
 
         """
         with open(self.piccolo_conf_path) as f:
             piccolo_conf_src = f.read()
-
-        app_identifier = self._get_app_identifier(app_name=app_name, root=root)
 
         new_contents = self._modify_app_registry_src(
             src=piccolo_conf_src, app_identifier=app_identifier

--- a/piccolo/conf/apps.py
+++ b/piccolo/conf/apps.py
@@ -614,11 +614,11 @@ class PiccoloConfUpdater:
             piccolo_conf_path or Finder().get_piccolo_conf_path()
         )
 
-    def _modify_app_registry_src(self, src: str, app_identifier: str) -> str:
+    def _modify_app_registry_src(self, src: str, app_module: str) -> str:
         """
         :param src:
             The contents of the ``piccolo_conf.py`` file.
-        :param app_identifier:
+        :param app_module:
             The app to add to the registry e.g. ``'music.piccolo_app'``.
         :returns:
             Updated Python source code string.
@@ -640,7 +640,7 @@ class PiccoloConfUpdater:
                             apps = keyword.value
                             if isinstance(apps, ast.List):
                                 apps.elts.append(
-                                    ast.Constant(app_identifier, kind="str")
+                                    ast.Constant(app_module, kind="str")
                                 )
                                 parsing_successful = True
                                 break
@@ -659,7 +659,7 @@ class PiccoloConfUpdater:
 
         return formatted_contents
 
-    def register_app(self, app_identifier: str):
+    def register_app(self, app_module: str):
         """
         Adds the given app to the ``AppRegistry`` in ``piccolo_conf.py``.
 
@@ -669,15 +669,15 @@ class PiccoloConfUpdater:
 
             piccolo app new my_app --register
 
-        :param app_identifier:
-            The name of the app, e.g. ``'music.piccolo_app'``.
+        :param app_module:
+            The module of the app, e.g. ``'music.piccolo_app'``.
 
         """
         with open(self.piccolo_conf_path) as f:
             piccolo_conf_src = f.read()
 
         new_contents = self._modify_app_registry_src(
-            src=piccolo_conf_src, app_identifier=app_identifier
+            src=piccolo_conf_src, app_module=app_module
         )
 
         with open(self.piccolo_conf_path, "wt") as f:

--- a/tests/apps/app/commands/test_new.py
+++ b/tests/apps/app/commands/test_new.py
@@ -3,7 +3,11 @@ import shutil
 import tempfile
 from unittest import TestCase
 
-from piccolo.apps.app.commands.new import module_exists, new
+from piccolo.apps.app.commands.new import (
+    get_app_identifier,
+    module_exists,
+    new,
+)
 
 
 class TestModuleExists(TestCase):
@@ -43,3 +47,21 @@ class TestNewApp(TestCase):
                 "A module called sys already exists"
             )
         )
+
+
+class TestGetAppIdentifier(TestCase):
+
+    def test_get_app_identifier(self):
+        """
+        Make sure the the ``root`` argument is handled correctly.
+        """
+        self.assertEqual(
+            get_app_identifier(app_name="music", root="."),
+            "music.piccolo_app",
+        )
+
+        for root in ("apps", "./apps", "./apps/"):
+            self.assertEqual(
+                get_app_identifier(app_name="music", root=root),
+                "apps.music.piccolo_app",
+            )

--- a/tests/apps/app/commands/test_new.py
+++ b/tests/apps/app/commands/test_new.py
@@ -3,11 +3,7 @@ import shutil
 import tempfile
 from unittest import TestCase
 
-from piccolo.apps.app.commands.new import (
-    get_app_identifier,
-    module_exists,
-    new,
-)
+from piccolo.apps.app.commands.new import get_app_module, module_exists, new
 
 
 class TestModuleExists(TestCase):
@@ -51,17 +47,17 @@ class TestNewApp(TestCase):
 
 class TestGetAppIdentifier(TestCase):
 
-    def test_get_app_identifier(self):
+    def test_get_app_module(self):
         """
         Make sure the the ``root`` argument is handled correctly.
         """
         self.assertEqual(
-            get_app_identifier(app_name="music", root="."),
+            get_app_module(app_name="music", root="."),
             "music.piccolo_app",
         )
 
         for root in ("apps", "./apps", "./apps/"):
             self.assertEqual(
-                get_app_identifier(app_name="music", root=root),
+                get_app_module(app_name="music", root=root),
                 "apps.music.piccolo_app",
             )

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import pathlib
+import tempfile
 from unittest import TestCase
 
 from piccolo.apps.user.tables import BaseUser
-from piccolo.conf.apps import AppConfig, AppRegistry, Finder, table_finder
+from piccolo.conf.apps import (
+    AppConfig,
+    AppRegistry,
+    Finder,
+    PiccoloConfUpdater,
+    table_finder,
+)
 from tests.example_apps.mega.tables import MegaTable, SmallTable
 from tests.example_apps.music.tables import (
     Band,
@@ -309,4 +316,62 @@ class TestFinder(TestCase):
 
         self.assertListEqual(
             [i.app_name for i in sorted_app_configs], ["app_2", "app_1"]
+        )
+
+
+class TestPiccoloConfUpdater(TestCase):
+
+    def test_get_app_identifier(self):
+        """
+        Make sure the the ``root`` argument is handled correctly.
+        """
+        updater = PiccoloConfUpdater()
+
+        self.assertEqual(
+            updater._get_app_identifier(app_name="music", root="."),
+            "music.piccolo_app",
+        )
+
+        for root in ("apps", "./apps", "./apps/"):
+            self.assertEqual(
+                updater._get_app_identifier(app_name="music", root=root),
+                "apps.music.piccolo_app",
+            )
+
+    def test_modify_app_registry_src(self):
+        """
+        Make sure the `piccolo_conf.py` source code can be modified
+        successfully.
+        """
+        updater = PiccoloConfUpdater()
+
+        new_src = updater._modify_app_registry_src(
+            src="APP_REGISTRY = AppRegistry(apps=[])",
+            app_identifier="music.piccolo_app",
+        )
+        self.assertEqual(
+            new_src.strip(),
+            'APP_REGISTRY = AppRegistry(apps=["music.piccolo_app"])',
+        )
+
+    def test_register_app(self):
+        """
+        Make sure the new contents get written to disk.
+        """
+        temp_dir = tempfile.gettempdir()
+        piccolo_conf_path = pathlib.Path(temp_dir) / "piccolo_conf.py"
+
+        src = "APP_REGISTRY = AppRegistry(apps=[])"
+
+        with open(piccolo_conf_path, "wt") as f:
+            f.write(src)
+
+        updater = PiccoloConfUpdater()
+        updater.register_app(app_name="music")
+
+        with open(piccolo_conf_path) as f:
+            contents = f.read().strip()
+
+        self.assertEqual(
+            contents, 'APP_REGISTRY = AppRegistry(apps=["music.piccolo_app])'
         )

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -321,23 +321,6 @@ class TestFinder(TestCase):
 
 class TestPiccoloConfUpdater(TestCase):
 
-    def test_get_app_identifier(self):
-        """
-        Make sure the the ``root`` argument is handled correctly.
-        """
-        updater = PiccoloConfUpdater()
-
-        self.assertEqual(
-            updater._get_app_identifier(app_name="music", root="."),
-            "music.piccolo_app",
-        )
-
-        for root in ("apps", "./apps", "./apps/"):
-            self.assertEqual(
-                updater._get_app_identifier(app_name="music", root=root),
-                "apps.music.piccolo_app",
-            )
-
     def test_modify_app_registry_src(self):
         """
         Make sure the `piccolo_conf.py` source code can be modified
@@ -367,7 +350,7 @@ class TestPiccoloConfUpdater(TestCase):
             f.write(src)
 
         updater = PiccoloConfUpdater()
-        updater.register_app(app_name="music")
+        updater.register_app(app_identifier="music.piccolo_app")
 
         with open(piccolo_conf_path) as f:
             contents = f.read().strip()

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -330,7 +330,7 @@ class TestPiccoloConfUpdater(TestCase):
 
         new_src = updater._modify_app_registry_src(
             src="APP_REGISTRY = AppRegistry(apps=[])",
-            app_identifier="music.piccolo_app",
+            app_module="music.piccolo_app",
         )
         self.assertEqual(
             new_src.strip(),
@@ -350,7 +350,7 @@ class TestPiccoloConfUpdater(TestCase):
             f.write(src)
 
         updater = PiccoloConfUpdater()
-        updater.register_app(app_identifier="music.piccolo_app")
+        updater.register_app(app_module="music.piccolo_app")
 
         with open(piccolo_conf_path) as f:
             contents = f.read().strip()

--- a/tests/conf/test_apps.py
+++ b/tests/conf/test_apps.py
@@ -349,12 +349,12 @@ class TestPiccoloConfUpdater(TestCase):
         with open(piccolo_conf_path, "wt") as f:
             f.write(src)
 
-        updater = PiccoloConfUpdater()
+        updater = PiccoloConfUpdater(piccolo_conf_path=str(piccolo_conf_path))
         updater.register_app(app_module="music.piccolo_app")
 
         with open(piccolo_conf_path) as f:
             contents = f.read().strip()
 
         self.assertEqual(
-            contents, 'APP_REGISTRY = AppRegistry(apps=["music.piccolo_app])'
+            contents, 'APP_REGISTRY = AppRegistry(apps=["music.piccolo_app"])'
         )


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1184

This PR add a ``--register`` flag to ``piccolo app new``, which auto registers the new app with the ``AppRegistry`` in ``piccolo_conf.py``.

For example:

```bash
piccolo app new my_app --register
```

Remaining tasks:

- [x] Add auto register logic
- [x] Add docs
- [x] Add tests