### PR TITLE
update BlackSheep template

### DIFF
--- a/piccolo/apps/asgi/commands/templates/app/_blacksheep_app.py.jinja
+++ b/piccolo/apps/asgi/commands/templates/app/_blacksheep_app.py.jinja
@@ -115,3 +115,5 @@ async def close_database_connection_pool(application):
 
 app.on_start += open_database_connection_pool
 app.on_stop += close_database_connection_pool
+
+app.router.apply_routes()


### PR DESCRIPTION
Related to #1192. In version 2.3.0 BlackSheep introduces the `apply_routes()` method to make the routes effective after the application is launched, so we need to update the BlackSheep template with that method for the integration test to work. More info [here](https://github.com/Neoteroi/BlackSheep/releases/tag/v2.3.0)