### PR TITLE
Allow a subquery to be passed into `is_in` and `not_in`

### DIFF
--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -112,6 +112,23 @@ And all rows with a value not contained in the list:
         Band.name.not_in(['Terrible Band', 'Awful Band'])
     )
 
+For tables with a foreign key relationships, you can use a subquery 
+in the ``is_in`` clause to get the result in a single database query like this:
+
+.. code-block:: python
+
+    await Band.select().where(
+        Band.id.is_in(Concert.select(Concert.band_1).where(Concert.band_1 == 1))
+    )
+
+The same can be used in the ``not_in`` clause like this:
+
+.. code-block:: python
+
+    await Band.select().where(
+        Band.id.not_in(Concert.select(Concert.band_1).where(Concert.band_1 == 1))
+    )
+
 -------------------------------------------------------------------------------
 
 ``is_null`` / ``is_not_null``

--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -112,22 +112,44 @@ And all rows with a value not contained in the list:
         Band.name.not_in(['Terrible Band', 'Awful Band'])
     )
 
-For tables with a foreign key relationships, you can use a subquery
-in the ``is_in`` clause to get the result in a single database query like this:
+You can also pass a subquery into the ``is_in`` clause:
 
 .. code-block:: python
 
     await Band.select().where(
-        Band.id.is_in(Concert.select(Concert.band_1).where(Concert.band_1 == 1))
+        Band.id.is_in(
+            Concert.select(Concert.band_1).where(
+                Concert.starts >= datetime.datetime(year=2025, month=1, day=1)
+            )
+        )
     )
 
-The same can be used in the ``not_in`` clause:
+.. hint::
+    In SQL there are often several ways of solving the same problem. You
+    can also solve the above using :meth:`join_on <piccolo.columns.base.Column.join_on>`.
+
+    .. code-block:: python
+
+        >>> await Band.select().where(
+        ...     Band.id.join_on(Concert.band_1).starts >= datetime.datetime(
+        ...        year=2025, month=1, day=1
+        ...     )
+        ... )
+
+    Use whichever you prefer, and whichever suits the situation best.
+
+Subqueries can also be passed into the ``not_in`` clause:
 
 .. code-block:: python
 
     await Band.select().where(
-        Band.id.not_in(Concert.select(Concert.band_1).where(Concert.band_1 == 1))
+        Band.id.not_in(
+            Concert.select(Concert.band_1).where(
+                Concert.starts >= datetime.datetime(year=2025, month=1, day=1)
+            )
+        )
     )
+
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/query_clauses/where.rst
+++ b/docs/src/piccolo/query_clauses/where.rst
@@ -112,7 +112,7 @@ And all rows with a value not contained in the list:
         Band.name.not_in(['Terrible Band', 'Awful Band'])
     )
 
-For tables with a foreign key relationships, you can use a subquery 
+For tables with a foreign key relationships, you can use a subquery
 in the ``is_in`` clause to get the result in a single database query like this:
 
 .. code-block:: python
@@ -121,7 +121,7 @@ in the ``is_in`` clause to get the result in a single database query like this:
         Band.id.is_in(Concert.select(Concert.band_1).where(Concert.band_1 == 1))
     )
 
-The same can be used in the ``not_in`` clause like this:
+The same can be used in the ``not_in`` clause:
 
 .. code-block:: python
 

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -600,7 +600,7 @@ class Column(Selectable):
 
         return True
 
-    def is_in(self, values: Union[Select, list[Any]]) -> Where:
+    def is_in(self, values: Union[Select, QueryString, list[Any]]) -> Where:
         from piccolo.query.methods.select import Select
 
         if isinstance(values, list):
@@ -614,13 +614,11 @@ class Column(Selectable):
                 raise ValueError(
                     "A sub select must only return a single column."
                 )
-            return Where(
-                column=self, values=values.querystrings[0], operator=In
-            )
+            values = values.querystrings[0]
 
         return Where(column=self, values=values, operator=In)
 
-    def not_in(self, values: Union[Select, list[Any]]) -> Where:
+    def not_in(self, values: Union[Select, QueryString, list[Any]]) -> Where:
         from piccolo.query.methods.select import Select
 
         if isinstance(values, list):
@@ -634,9 +632,7 @@ class Column(Selectable):
                 raise ValueError(
                     "A sub select must only return a single column."
                 )
-            return Where(
-                column=self, values=values.querystrings[0], operator=NotIn
-            )
+            values = values.querystrings[0]
 
         return Where(column=self, values=values, operator=NotIn)
 

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -46,6 +46,7 @@ from piccolo.utils.warnings import colored_warning
 
 if TYPE_CHECKING:  # pragma: no cover
     from piccolo.columns.column_types import ForeignKey
+    from piccolo.query.methods.select import Select
     from piccolo.table import Table
 
 
@@ -599,18 +600,38 @@ class Column(Selectable):
 
         return True
 
-    def is_in(self, values: list[Any]) -> Where:
-        if len(values) == 0:
-            raise ValueError(
-                "The `values` list argument must contain at least one value."
-            )
+    def is_in(self, values: Union[Select, list[Any]]) -> Where:
+        from piccolo.query.methods.select import Select
+
+        if isinstance(values, list):
+            if len(values) == 0:
+                raise ValueError(
+                    "The `values` list argument must contain at least one "
+                    "value."
+                )
+        elif isinstance(values, Select):
+            if len(values.columns_delegate.selected_columns) != 1:
+                raise ValueError(
+                    "A sub select must only return a single column."
+                )
+
         return Where(column=self, values=values, operator=In)
 
-    def not_in(self, values: list[Any]) -> Where:
-        if len(values) == 0:
-            raise ValueError(
-                "The `values` list argument must contain at least one value."
-            )
+    def not_in(self, values: Union[Select, list[Any]]) -> Where:
+        from piccolo.query.methods.select import Select
+
+        if isinstance(values, list):
+            if len(values) == 0:
+                raise ValueError(
+                    "The `values` list argument must contain at least one "
+                    "value."
+                )
+        elif isinstance(values, Select):
+            if len(values.columns_delegate.selected_columns) != 1:
+                raise ValueError(
+                    "A sub select must only return a single column."
+                )
+
         return Where(column=self, values=values, operator=NotIn)
 
     def like(self, value: str) -> Where:

--- a/piccolo/columns/base.py
+++ b/piccolo/columns/base.py
@@ -614,6 +614,9 @@ class Column(Selectable):
                 raise ValueError(
                     "A sub select must only return a single column."
                 )
+            return Where(
+                column=self, values=values.querystrings[0], operator=In
+            )
 
         return Where(column=self, values=values, operator=In)
 
@@ -631,6 +634,9 @@ class Column(Selectable):
                 raise ValueError(
                     "A sub select must only return a single column."
                 )
+            return Where(
+                column=self, values=values.querystrings[0], operator=NotIn
+            )
 
         return Where(column=self, values=values, operator=NotIn)
 

--- a/piccolo/columns/combination.py
+++ b/piccolo/columns/combination.py
@@ -13,6 +13,7 @@ from piccolo.utils.sql_values import convert_to_sql_value
 
 if TYPE_CHECKING:
     from piccolo.columns.base import Column
+    from piccolo.query.methods.select import Select
 
 
 class CombinableMixin(object):
@@ -146,17 +147,21 @@ class Where(CombinableMixin):
         self,
         column: Column,
         value: Any = UNDEFINED,
-        values: Union[CustomIterable, Undefined] = UNDEFINED,
+        values: Union[CustomIterable, Undefined, Select] = UNDEFINED,
         operator: type[ComparisonOperator] = ComparisonOperator,
     ) -> None:
         """
         We use the UNDEFINED value to show the value was deliberately
         omitted, vs None, which is a valid value for a where clause.
         """
+        from piccolo.query.methods.select import Select
+
         self.column = column
 
         self.value = value if value == UNDEFINED else self.clean_value(value)
         if values == UNDEFINED:
+            self.values = values
+        elif isinstance(values, Select):
             self.values = values
         else:
             self.values = [self.clean_value(i) for i in values]  # type: ignore
@@ -190,10 +195,15 @@ class Where(CombinableMixin):
 
     @property
     def values_querystring(self) -> QueryString:
+        from piccolo.query.methods.select import Select
+
         values = self.values
 
         if isinstance(values, Undefined):
             raise ValueError("values is undefined")
+
+        if isinstance(values, Select):
+            return values.querystrings[0]
 
         template = ", ".join("{}" for _ in values)
         return QueryString(template, *values)

--- a/tests/columns/test_combination.py
+++ b/tests/columns/test_combination.py
@@ -1,6 +1,6 @@
 import unittest
 
-from tests.example_apps.music.tables import Band
+from tests.example_apps.music.tables import Band, Concert
 
 
 class TestWhere(unittest.TestCase):
@@ -29,6 +29,20 @@ class TestWhere(unittest.TestCase):
         with self.assertRaises(ValueError):
             Band.name.is_in([])
 
+    def test_is_in_subquery(self):
+        _where = Band.id.is_in(
+            Concert.select(Concert.band_1).where(Concert.band_1 == 1)
+        )
+        sql = _where.__str__()
+        self.assertEqual(
+            sql,
+            '"band"."id" IN (SELECT ALL "concert"."band_1" AS "band_1" FROM "concert" WHERE "concert"."band_1" = 1)',  # noqa: E501
+        )
+
+        # a sub select must only return a single column
+        with self.assertRaises(ValueError):
+            Band.id.is_in(Concert.select().where(Concert.band_1 == 1))
+
     def test_not_in(self):
         _where = Band.name.not_in(["CSharps"])
         sql = _where.__str__()
@@ -36,6 +50,20 @@ class TestWhere(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             Band.name.not_in([])
+
+    def test_not_in_subquery(self):
+        _where = Band.id.not_in(
+            Concert.select(Concert.band_1).where(Concert.band_1 == 1)
+        )
+        sql = _where.__str__()
+        self.assertEqual(
+            sql,
+            '"band"."id" NOT IN (SELECT ALL "concert"."band_1" AS "band_1" FROM "concert" WHERE "concert"."band_1" = 1)',  # noqa: E501
+        )
+
+        # a sub select must only return a single column
+        with self.assertRaises(ValueError):
+            Band.id.not_in(Concert.select().where(Concert.band_1 == 1))
 
 
 class TestAnd(unittest.TestCase):

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -258,6 +258,64 @@ class TestSelect(DBTestCase):
 
         self.assertEqual(response, [{"name": "Rustaceans"}])
 
+    def test_is_in(self):
+        self.insert_rows()
+
+        response = (
+            Band.select(Band.name)
+            .where(Band.manager._.name.is_in(["Guido"]))
+            .run_sync()
+        )
+
+        self.assertListEqual(response, [{"name": "Pythonistas"}])
+
+    def test_is_in_subquery(self):
+        self.insert_rows()
+
+        # This is a contrived example, just for testing.
+        response = (
+            Band.select(Band.name)
+            .where(
+                Band.manager.is_in(
+                    Manager.select(Manager.id).where(Manager.name == "Guido")
+                )
+            )
+            .run_sync()
+        )
+
+        self.assertListEqual(response, [{"name": "Pythonistas"}])
+
+    def test_not_in(self):
+        self.insert_rows()
+
+        response = (
+            Band.select(Band.name)
+            .where(Band.manager._.name.not_in(["Guido"]))
+            .run_sync()
+        )
+
+        self.assertListEqual(
+            response, [{"name": "Rustaceans"}, {"name": "CSharps"}]
+        )
+
+    def test_not_in_subquery(self):
+        self.insert_rows()
+
+        # This is a contrived example, just for testing.
+        response = (
+            Band.select(Band.name)
+            .where(
+                Band.manager.not_in(
+                    Manager.select(Manager.id).where(Manager.name == "Guido")
+                )
+            )
+            .run_sync()
+        )
+
+        self.assertListEqual(
+            response, [{"name": "Rustaceans"}, {"name": "CSharps"}]
+        )
+
     def test_where_is_null(self):
         self.insert_rows()
 


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/785

Based on #786. Also adds a subquery to the `not_in` clause, tests and docs. These subqueries will be useful in `m2m` columns to [replace this code](https://github.com/piccolo-orm/piccolo/blob/master/piccolo/columns/m2m.py#L376-L394) with a subquery with just one database query (and no additional empty list check) like this
```python
# use a subquery to make only one db query (for efficiency)
results = await secondary_table.objects().where(
    secondary_table._meta.primary_key.is_in(
        joining_table.select(
            getattr(
                self.m2m._meta.secondary_foreign_key,
                secondary_table._meta.primary_key._meta.name,
            )
        ).where(self.m2m._meta.primary_foreign_key == self.row)
    )
)
```