### PR TITLE
1222 Float columns - cast `int` defaults to `float`

### DIFF
--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -1553,6 +1553,10 @@ class Real(Column):
         default: Union[float, Enum, Callable[[], float], None] = 0.0,
         **kwargs: Unpack[ColumnKwargs],
     ) -> None:
+        if isinstance(default, int):
+            # For example, allow `0` as a valid default.
+            default = float(default)
+
         self._validate_default(default, (float, None))
         self.default = default
         super().__init__(default=default, **kwargs)


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1222