### PR TITLE
adds CockroachDB as an option to the Piccolo playground

### DIFF
--- a/docs/src/piccolo/getting_started/playground.rst
+++ b/docs/src/piccolo/getting_started/playground.rst
@@ -37,8 +37,8 @@ A ``piccolo.sqlite`` file will get created in the current directory.
 Advanced usage
 ---------------
 
-To see how to use the playground with Postgres, and other advanced usage, see
-:ref:`PlaygroundAdvanced`.
+To see how to use the playground with Postgres or Cockroach, and other
+advanced usage, see :ref:`PlaygroundAdvanced`.
 
 -------------------------------------------------------------------------------
 

--- a/docs/src/piccolo/playground/advanced.rst
+++ b/docs/src/piccolo/playground/advanced.rst
@@ -54,17 +54,17 @@ first.
 Install CockroachDB
 ~~~~~~~~~~~~~~~~~~~
 
-See `installation guide for your OS <https://www.cockroachlabs.com/docs/v25.2/install-cockroachdb-linux/>`_.
+See the `installation guide for your OS <https://www.cockroachlabs.com/docs/v25.2/install-cockroachdb-linux/>`_.
 
 Create database
 ~~~~~~~~~~~~~~~
-The playground is for testing and learning purposes only, so you can start a CockroachDB 
-`single node with the insecure flag <https://www.cockroachlabs.com/docs/v25.2/cockroach-start-single-node.html/>`_ 
-(for non-production testing only) like this: 
+The playground is for testing and learning purposes only, so you can start a CockroachDB
+`single node with the insecure flag <https://www.cockroachlabs.com/docs/v25.2/cockroach-start-single-node.html/>`_
+(for non-production testing only) like this:
 
 .. code-block:: bash
 
-    cockroach start-single-node --insecure 
+    cockroach start-single-node --insecure
 
 After that, in a new terminal window, you can create a database like this:
 

--- a/docs/src/piccolo/playground/advanced.rst
+++ b/docs/src/piccolo/playground/advanced.rst
@@ -44,6 +44,56 @@ When you have the database setup, you can connect to it as follows:
 
     piccolo playground run --engine=postgres
 
+CockroachDB
+-----------
+
+If you want to use CockroachDB instead of SQLite, you need to create a database
+first.
+
+
+Install CockroachDB
+~~~~~~~~~~~~~~~~~~~
+
+See `installation guide for your OS <https://www.cockroachlabs.com/docs/v25.2/install-cockroachdb-linux/>`_.
+
+Create database
+~~~~~~~~~~~~~~~
+The playground is for testing and learning purposes only, so you can start a CockroachDB 
+`single node with the insecure flag <https://www.cockroachlabs.com/docs/v25.2/cockroach-start-single-node.html/>`_ 
+(for non-production testing only) like this: 
+
+.. code-block:: bash
+
+    cockroach start-single-node --insecure 
+
+After that, in a new terminal window, you can create a database like this:
+
+.. code-block:: bash
+
+    cockroach sql --insecure --execute="DROP DATABASE IF EXISTS piccolo_playground CASCADE;CREATE DATABASE piccolo_playground;"
+
+By default the playground expects a local database to exist with the following
+credentials:
+
+
+.. code-block:: bash
+
+    user: "root"
+    password: ""
+    host: "localhost"  # or 127.0.0.1
+    database: "piccolo_playground"
+    port: 26257
+
+
+Connecting
+~~~~~~~~~~
+
+When you have the database setup, you can connect to it as follows:
+
+.. code-block:: bash
+
+    piccolo playground run --engine=cockroach
+
 iPython
 -------
 

--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -15,7 +15,7 @@ ROUTER_DEPENDENCIES = {
     "blacksheep": ["blacksheep"],
     "litestar": ["litestar"],
     "esmerald": ["esmerald"],
-    "lilya": ["lilya", "orjson"],
+    "lilya": ["lilya"],
     "quart": ["quart", "quart_schema"],
     "falcon": ["falcon"],
     "sanic": ["sanic", "sanic_ext"],

--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -15,7 +15,7 @@ ROUTER_DEPENDENCIES = {
     "blacksheep": ["blacksheep"],
     "litestar": ["litestar"],
     "esmerald": ["esmerald"],
-    "lilya": ["lilya"],
+    "lilya": ["lilya", "orjson"],
     "quart": ["quart", "quart_schema"],
     "falcon": ["falcon"],
     "sanic": ["sanic", "sanic_ext"],

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -25,7 +25,7 @@ from piccolo.columns import (
     Varchar,
 )
 from piccolo.columns.readable import Readable
-from piccolo.engine import PostgresEngine, SQLiteEngine
+from piccolo.engine import CockroachEngine, PostgresEngine, SQLiteEngine
 from piccolo.engine.base import Engine
 from piccolo.table import Table
 from piccolo.utils.warnings import colored_string
@@ -295,7 +295,8 @@ def run(
     Creates a test database to play with.
 
     :param engine:
-        Which database engine to use - options are sqlite or postgres
+        Which database engine to use - options are sqlite, postgres or
+        cockroach
     :param user:
         Postgres user
     :param password:
@@ -327,6 +328,16 @@ def run(
                 "user": user,
                 "password": password,
                 "port": port,
+            }
+        )
+    elif engine.upper() == "COCKROACH":
+        db = CockroachEngine(
+            {
+                "host": host,
+                "database": database,
+                "user": "root",
+                "password": "",
+                "port": 26257,
             }
         )
     else:

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -8,6 +8,7 @@ import sys
 import uuid
 from decimal import Decimal
 from enum import Enum
+from typing import Optional
 
 from piccolo.columns import (
     JSON,
@@ -288,7 +289,7 @@ def run(
     password: str = "piccolo",
     database: str = "piccolo_playground",
     host: str = "localhost",
-    port: int = 5432,
+    port: Optional[int] = None,
     ipython_profile: bool = False,
 ):
     """
@@ -327,7 +328,7 @@ def run(
                 "database": database,
                 "user": user,
                 "password": password,
-                "port": port,
+                "port": port or 5432,
             }
         )
     elif engine.upper() == "COCKROACH":
@@ -337,7 +338,7 @@ def run(
                 "database": database,
                 "user": "root",
                 "password": "",
-                "port": 26257,
+                "port": port or 26257,
             }
         )
     else:

--- a/piccolo/apps/playground/commands/run.py
+++ b/piccolo/apps/playground/commands/run.py
@@ -285,8 +285,8 @@ def populate():
 
 def run(
     engine: str = "sqlite",
-    user: str = "piccolo",
-    password: str = "piccolo",
+    user: Optional[str] = None,
+    password: Optional[str] = None,
     database: str = "piccolo_playground",
     host: str = "localhost",
     port: Optional[int] = None,
@@ -299,15 +299,15 @@ def run(
         Which database engine to use - options are sqlite, postgres or
         cockroach
     :param user:
-        Postgres user
+        Database user (ignored for SQLite)
     :param password:
-        Postgres password
+        Database password (ignored for SQLite)
     :param database:
-        Postgres database
+        Database name (ignored for SQLite)
     :param host:
-        Postgres host
+        Database host (ignored for SQLite)
     :param port:
-        Postgres port
+        Database port (ignored for SQLite)
     :param ipython_profile:
         Set to true to use your own IPython profile. Located at ~/.ipython/.
         For more info see the IPython docs
@@ -326,8 +326,8 @@ def run(
             {
                 "host": host,
                 "database": database,
-                "user": user,
-                "password": password,
+                "user": user or "piccolo",
+                "password": password or "piccolo",
                 "port": port or 5432,
             }
         )
@@ -336,8 +336,8 @@ def run(
             {
                 "host": host,
                 "database": database,
-                "user": "root",
-                "password": "",
+                "user": user or "root",
+                "password": password or "",
                 "port": port or 26257,
             }
         )


### PR DESCRIPTION
Related to #1228. Also add `orjson` to the `Lilya` asgi template as it seems that `orjson` is now a hard dependency for `Lilya` (without that change our integration test would fail for Lilya with `ModuleNotFoundError: No module named 'orjson'`).