### PR TITLE
1303 `add_m2m` return ID of joining table row

### DIFF
--- a/piccolo/columns/m2m.py
+++ b/piccolo/columns/m2m.py
@@ -311,11 +311,8 @@ class M2MAddRelated:
         transaction, or wrapped in a new transaction.
         """
         engine = self.rows[0]._meta.db
-        if engine.transaction_exists():
-            await self._run()
-        else:
-            async with engine.transaction():
-                await self._run()
+        async with engine.transaction():
+            return await self._run()
 
     def run_sync(self):
         return run_sync(self.run())


### PR DESCRIPTION
Resolves https://github.com/piccolo-orm/piccolo/issues/1303

When using `add_m2m`, the docs says that the query returns the ID of the row added to the joining table. This isn't the current behaviour of the code though.

https://piccolo-orm.readthedocs.io/en/latest/piccolo/schema/m2m.html#add-m2m

There's no harm in adding it - it could be useful to know.