### PR TITLE
remove sniffio dependency

### DIFF
--- a/piccolo/apps/asgi/commands/new.py
+++ b/piccolo/apps/asgi/commands/new.py
@@ -13,7 +13,7 @@ ROUTER_DEPENDENCIES = {
     "starlette": ["starlette"],
     "fastapi": ["fastapi"],
     "blacksheep": ["blacksheep[full]"],
-    "litestar": ["litestar", "sniffio"],
+    "litestar": ["litestar"],
     "esmerald": ["esmerald"],
     "lilya": ["lilya"],
     "quart": ["quart", "quart_schema"],


### PR DESCRIPTION
Remove `sniffio` as it is now properly included in [Litestar](https://github.com/litestar-org/litestar/releases/tag/v2.19.0) as a dependency.