### PR TITLE
Stop skipping some Cockroach tests

### DIFF
--- a/scripts/test-cockroach.sh
+++ b/scripts/test-cockroach.sh
@@ -9,6 +9,6 @@ python -m pytest \
     --cov=piccolo \
     --cov-report=xml \
     --cov-report=html \
-    --cov-fail-under=80 \
-    -m "not integration and not cockroach_array_slow" \
+    --cov-fail-under=85 \
+    -m "not integration" \
     -s $@

--- a/tests/apps/schema/commands/test_generate.py
+++ b/tests/apps/schema/commands/test_generate.py
@@ -151,7 +151,6 @@ class TestGenerate(TestCase):
         assert SmallTable_ is not None
         self._compare_table_columns(SmallTable, SmallTable_)
 
-    @engines_skip("cockroach")
     def test_self_referencing_fk(self) -> None:
         """
         Make sure self-referencing foreign keys are handled correctly.

--- a/tests/columns/test_array.py
+++ b/tests/columns/test_array.py
@@ -2,8 +2,6 @@ import datetime
 from decimal import Decimal
 from unittest import TestCase
 
-import pytest
-
 from piccolo.columns.column_types import (
     Array,
     BigInt,
@@ -42,20 +40,10 @@ class TestArray(TableTest):
 
     tables = [MyTable]
 
-    @pytest.mark.cockroach_array_slow
     def test_storage(self):
         """
         Make sure data can be stored and retrieved.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        """
         MyTable(value=[1, 2, 3]).save().run_sync()
 
         row = MyTable.objects().first().run_sync()
@@ -63,20 +51,10 @@ class TestArray(TableTest):
         self.assertEqual(row.value, [1, 2, 3])
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_index(self):
         """
         Indexes should allow individual array elements to be queried.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        """
         MyTable(value=[1, 2, 3]).save().run_sync()
 
         self.assertEqual(
@@ -84,21 +62,11 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_all(self):
         """
         Make sure rows can be retrieved where all items in an array match a
         given value.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        """
         MyTable(value=[1, 1, 1]).save().run_sync()
 
         # We have to explicitly specify the type, so CockroachDB works.
@@ -120,22 +88,11 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_any(self):
         """
         Make sure rows can be retrieved where any items in an array match a
         given value.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
-
+        """
         MyTable(value=[1, 2, 3]).save().run_sync()
 
         # We have to explicitly specify the type, so CockroachDB works.
@@ -157,22 +114,11 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_not_any(self):
         """
         Make sure rows can be retrieved where the array doesn't contain a
         certain value.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
-
+        """
         MyTable(value=[1, 2, 3]).save().run_sync()
         MyTable(value=[4, 5, 6]).save().run_sync()
 
@@ -185,20 +131,11 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_cat(self):
         """
-        Make sure values can be appended to an array and that we can concatenate two arrays.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        Make sure values can be appended to an array and that we can
+        concatenate two arrays.
+        """
         MyTable(value=[5]).save().run_sync()
 
         MyTable.update(
@@ -256,20 +193,10 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_prepend(self):
         """
         Make sure values can be added to the beginning of the array.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        """
         MyTable(value=[1, 1, 1]).save().run_sync()
 
         MyTable.update(
@@ -295,20 +222,10 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_append(self):
         """
         Make sure values can be appended to an array.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        """
         MyTable(value=[1, 1, 1]).save().run_sync()
 
         MyTable.update(
@@ -334,20 +251,10 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_replace(self):
         """
         Make sure values can be swapped in the array.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        """
         MyTable(value=[1, 1, 1]).save().run_sync()
 
         MyTable.update(
@@ -373,20 +280,10 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
-    @pytest.mark.cockroach_array_slow
     def test_remove(self):
         """
         Make sure values can be removed from an array.
-
-        In CockroachDB <= v22.2.0 we had this error:
-
-        * https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        In newer CockroachDB versions, it runs but is very slow:
-
-        * https://github.com/piccolo-orm/piccolo/issues/1005
-
-        """  # noqa: E501
+        """
         MyTable(value=[1, 2, 3]).save().run_sync()
 
         MyTable.update(
@@ -523,9 +420,9 @@ class TestNestedArray(TestCase):
         """
         Make sure data can be stored and retrieved.
 
-        🐛 Cockroach bug: https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-
-        """  # noqa: E501
+        🐛 Cockroach bug: https://go.crdb.dev/issue-v/32552/v25.4
+        asyncpg.exceptions.FeatureNotSupportedError
+        """
         NestedArrayTable(value=[[1, 2, 3], [4, 5, 6]]).save().run_sync()
 
         row = NestedArrayTable.objects().first().run_sync()

--- a/tests/columns/test_choices.py
+++ b/tests/columns/test_choices.py
@@ -3,7 +3,6 @@ import enum
 from piccolo.columns.column_types import Array, Varchar
 from piccolo.table import Table
 from piccolo.testing.test_case import TableTest
-from tests.base import engines_only
 from tests.example_apps.music.tables import Shirt
 
 
@@ -82,11 +81,7 @@ class Ticket(Table):
     extras = Array(Varchar(), choices=Extras)
 
 
-@engines_only("postgres", "sqlite")
 class TestArrayChoices(TableTest):
-    """
-    🐛 Cockroach bug: https://github.com/cockroachdb/cockroach/issues/71908 "could not decorrelate subquery" error under asyncpg
-    """  # noqa: E501
 
     tables = [Ticket]
 

--- a/tests/columns/test_db_column_name.py
+++ b/tests/columns/test_db_column_name.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from piccolo.columns.column_types import ForeignKey, Integer, Serial, Varchar
 from piccolo.table import Table, create_db_tables_sync, drop_db_tables_sync
-from tests.base import DBTestCase, engine_is, engines_only, engines_skip
+from tests.base import DBTestCase, engine_is, engines_only
 
 
 class Manager(Table):
@@ -220,7 +220,6 @@ class TestDBColumnName(DBTestCase):
                 ],
             )
 
-    @engines_skip("cockroach")
     def test_delete(self):
         """
         Make sure delete queries work correctly.
@@ -235,13 +234,13 @@ class TestDBColumnName(DBTestCase):
             bands,
             [
                 {
-                    "id": 1,
+                    "id": bands[0]["id"],
                     "regrettable_column_name": "Pythonistas",
                     "popularity": 1000,
                     "manager_fk": None,
                 },
                 {
-                    "id": 2,
+                    "id": bands[1]["id"],
                     "regrettable_column_name": "Rustaceans",
                     "popularity": 500,
                     "manager_fk": None,
@@ -256,7 +255,7 @@ class TestDBColumnName(DBTestCase):
             bands,
             [
                 {
-                    "id": 1,
+                    "id": bands[0]["id"],
                     "regrettable_column_name": "Pythonistas",
                     "popularity": 1000,
                     "manager_fk": None,
@@ -264,7 +263,6 @@ class TestDBColumnName(DBTestCase):
             ],
         )
 
-    @engines_only("cockroach")
     def test_delete_alt(self):
         """
         Make sure delete queries work correctly.

--- a/tests/columns/test_jsonb.py
+++ b/tests/columns/test_jsonb.py
@@ -1,7 +1,7 @@
 from piccolo.columns.column_types import JSONB, ForeignKey, Varchar
 from piccolo.table import Table
 from piccolo.testing.test_case import AsyncTableTest, TableTest
-from tests.base import engines_only, engines_skip
+from tests.base import engines_only
 
 
 class RecordingStudio(Table):
@@ -28,7 +28,6 @@ class TestJSONB(TableTest):
         row.save().run_sync()
         self.assertEqual(row.facilities, '{"mixing_desk": true}')
 
-    @engines_skip("cockroach")
     def test_raw(self):
         """
         Make sure raw queries convert the Python value into a JSON string.
@@ -39,18 +38,19 @@ class TestJSONB(TableTest):
             '{"mixing_desk": true}',
         ).run_sync()
 
+        recording_studio = RecordingStudio.select().run_sync()
+
         self.assertEqual(
-            RecordingStudio.select().run_sync(),
+            recording_studio,
             [
                 {
-                    "id": 1,
+                    "id": recording_studio[0]["id"],
                     "name": "Abbey Road",
                     "facilities": '{"mixing_desk": true}',
                 }
             ],
         )
 
-    @engines_only("cockroach")
     def test_raw_alt(self):
         """
         Make sure raw queries convert the Python value into a JSON string.

--- a/tests/query/test_querystring.py
+++ b/tests/query/test_querystring.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 from piccolo.querystring import QueryString
-from tests.base import postgres_only
 
 
 # TODO - add more extensive tests (increased nesting and argument count).
@@ -31,7 +30,6 @@ class TestQueryString(TestCase):
         self.assertEqual(qs.compile_string(), ("SELECT name FROM band", []))
 
 
-@postgres_only
 class TestQueryStringOperators(TestCase):
     """
     Make sure basic operations can be used on ``QueryString``.

--- a/tests/table/instance/test_save.py
+++ b/tests/table/instance/test_save.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 from piccolo.table import create_db_tables_sync, drop_db_tables_sync
-from tests.base import engines_only, engines_skip
 from tests.example_apps.music.tables import Band, Manager
 
 
@@ -37,7 +36,6 @@ class TestSave(TestCase):
         self.assertTrue("Maz2" in names)
         self.assertTrue("Maz" not in names)
 
-    @engines_skip("cockroach")
     def test_save_specific_columns(self):
         """
         Make sure that we can save a subset of columns.
@@ -52,9 +50,9 @@ class TestSave(TestCase):
             Band.select().run_sync(),
             [
                 {
-                    "id": 1,
+                    "id": band.id,
                     "name": "Pythonistas",
-                    "manager": 1,
+                    "manager": manager.id,
                     "popularity": 1000,
                 }
             ],
@@ -69,9 +67,9 @@ class TestSave(TestCase):
             Band.select().run_sync(),
             [
                 {
-                    "id": 1,
+                    "id": band.id,
                     "name": "Pythonistas 2",
-                    "manager": 1,
+                    "manager": manager.id,
                     "popularity": 1000,
                 }
             ],
@@ -87,15 +85,14 @@ class TestSave(TestCase):
             Band.select().run_sync(),
             [
                 {
-                    "id": 1,
+                    "id": band.id,
                     "name": "Pythonistas 2",
-                    "manager": 1,
+                    "manager": manager.id,
                     "popularity": 3000,
                 }
             ],
         )
 
-    @engines_only("cockroach")
     def test_save_specific_columns_alt(self):
         """
         Make sure that we can save a subset of columns.

--- a/tests/testing/test_model_builder.py
+++ b/tests/testing/test_model_builder.py
@@ -17,7 +17,6 @@ from piccolo.columns import (
 )
 from piccolo.table import Table, create_db_tables_sync, drop_db_tables_sync
 from piccolo.testing.model_builder import ModelBuilder
-from tests.base import engines_skip
 from tests.example_apps.music.tables import (
     Band,
     Concert,
@@ -76,8 +75,6 @@ TABLES = (
 )
 
 
-# Cockroach Bug: Can turn ON when resolved: https://github.com/cockroachdb/cockroach/issues/71908  # noqa: E501
-@engines_skip("cockroach")
 class TestModelBuilder(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Cockroach tests have been updated because we have updated Cockroach version which allows some tests to stop skipping.