### PR TITLE
Add GroupByRaw query expression

### DIFF
--- a/docs/src/piccolo/query_clauses/group_by.rst
+++ b/docs/src/piccolo/query_clauses/group_by.rst
@@ -39,3 +39,25 @@ Other aggregate functions
 -------------------------
 
 These work the same as ``Count``. See :ref:`aggregate functions <AggregateFunctions>`.
+
+-------------------------------------------------------------------------------
+
+``GroupByRaw``
+--------------
+
+For more complex cases, use ``GroupByRaw`` to group by a raw SQL expression or
+an alias created by ``SelectRaw``. For example:
+
+.. code-block:: python
+
+    from piccolo.query import GroupByRaw, SelectRaw
+    from piccolo.query.functions.aggregate import Count
+
+    await Band.select(
+        SelectRaw("DATE(created_at) AS created_date"),
+        Count(),
+    ).group_by(
+        GroupByRaw("created_date")
+    )
+
+As with other raw query helpers, only use trusted SQL strings.

--- a/piccolo/query/__init__.py
+++ b/piccolo/query/__init__.py
@@ -18,7 +18,7 @@ from .methods import (
     Update,
 )
 from .methods.select import SelectRaw
-from .mixins import OrderByRaw
+from .mixins import GroupByRaw, OrderByRaw
 
 __all__ = [
     "Alter",
@@ -29,6 +29,7 @@ __all__ = [
     "Delete",
     "DropIndex",
     "Exists",
+    "GroupByRaw",
     "Insert",
     "Max",
     "Min",

--- a/piccolo/query/methods/select.py
+++ b/piccolo/query/methods/select.py
@@ -27,6 +27,7 @@ from piccolo.query.mixins import (
     ColumnsDelegate,
     DistinctDelegate,
     GroupByDelegate,
+    GroupByRaw,
     LimitDelegate,
     LockRowsDelegate,
     LockStrength,
@@ -204,12 +205,19 @@ class Select(Query[TableInstance, list[dict[str, Any]]]):
         self.distinct_delegate.distinct(enabled=True, on=on)
         return self
 
-    def group_by(self: Self, *columns: Union[Column, str]) -> Self:
-        _columns: list[Column] = [
-            i
-            for i in self.table._process_column_args(*columns)
-            if isinstance(i, Column)
-        ]
+    def group_by(self: Self, *columns: Union[Column, str, GroupByRaw]) -> Self:
+        """
+        :param columns:
+            Either a :class:`piccolo.columns.base.Column` instance, a string
+            representing a column name, or :class:`piccolo.query.GroupByRaw`
+            for grouping by a raw SQL expression or select alias.
+        """
+        _columns: list[Union[Column, GroupByRaw]] = []
+        for column in columns:
+            if isinstance(column, str):
+                _columns.append(self.table._meta.get_column_by_name(column))
+            else:
+                _columns.append(column)
         self.group_by_delegate.group_by(*_columns)
         return self
 

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -593,18 +593,32 @@ class OffsetDelegate:
 
 
 @dataclass
+class GroupByRaw:
+    __slots__ = ("sql",)
+
+    sql: str
+
+
+@dataclass
 class GroupBy:
     __slots__ = ("columns",)
 
-    columns: Sequence[Column]
+    columns: Sequence[Union[Column, GroupByRaw]]
 
     @property
     def querystring(self) -> QueryString:
-        columns_names = ", ".join(
-            i._meta.get_full_name(with_alias=False) for i in self.columns
-        )
+        column_names: list[str] = []
+        for column in self.columns:
+            if isinstance(column, Column):
+                column_names.append(
+                    column._meta.get_full_name(with_alias=False)
+                )
+            elif isinstance(column, GroupByRaw):
+                column_names.append(column.sql)
+            else:  # pragma: no cover
+                raise ValueError("Unrecognised group_by")
 
-        return QueryString(f" GROUP BY {columns_names}")
+        return QueryString(f" GROUP BY {', '.join(column_names)}")
 
     def __str__(self):
         return self.querystring.__str__()
@@ -621,7 +635,7 @@ class GroupByDelegate:
 
     _group_by: Optional[GroupBy] = None
 
-    def group_by(self, *columns: Column):
+    def group_by(self, *columns: Union[Column, GroupByRaw]):
         self._group_by = GroupBy(columns=columns)
 
 

--- a/tests/table/test_select.py
+++ b/tests/table/test_select.py
@@ -6,7 +6,7 @@ import pytest
 from piccolo.apps.user.tables import BaseUser
 from piccolo.columns import Date, Varchar
 from piccolo.columns.combination import WhereRaw
-from piccolo.query import OrderByRaw
+from piccolo.query import GroupByRaw, OrderByRaw
 from piccolo.query.functions.aggregate import Avg, Count, Max, Min, Sum
 from piccolo.query.methods.select import SelectRaw
 from piccolo.query.mixins import DistinctOnError
@@ -634,6 +634,16 @@ class TestSelect(DBTestCase):
                 {"name": "Rustaceans", "count": 2},
             ],
         )
+
+    def test_group_by_raw(self):
+        """
+        Raw expressions and select aliases can be used in GROUP BY clauses.
+        """
+        query = Band.select(
+            SelectRaw("SUBSTR(name, 1, 1) AS initial"), Count()
+        ).group_by(GroupByRaw("initial"), Band.popularity)
+
+        self.assertIn('GROUP BY initial, "band"."popularity"', str(query))
 
     def test_count_with_alias_group_by(self):
         """


### PR DESCRIPTION
Fixes #1387.

Adds a public `GroupByRaw` expression following the existing `OrderByRaw` pattern. `Select.group_by` now accepts columns, column-name strings, and trusted raw grouping expressions, and mixed raw/column clauses render in order.

The documentation includes a `SelectRaw` alias example and an explicit trusted-SQL warning.

Verification:
- `PICCOLO_CONF=tests.sqlite_conf python -m pytest tests/table/test_select.py -q` — 74 passed, 7 skipped
- `python -m compileall -q piccolo/query`
- Black/isort applied to changed code
- `git diff --check`

I also ran mypy over the changed modules; it reaches an existing unrelated return-type error at `piccolo/table.py:194` (`Column | None` vs `Column`).