### PR TITLE
Add `Table.filter` and `Table.criteria`

### DIFF
--- a/docs/src/piccolo/query_types/django_comparison.rst
+++ b/docs/src/piccolo/query_types/django_comparison.rst
@@ -115,6 +115,9 @@ In bulk:
 filter
 ~~~~~~
 
+Piccolo's recommended style is an explicit column comparison passed to
+``where``:
+
 .. code-block:: python
 
     # Django
@@ -124,6 +127,42 @@ filter
     # Piccolo
     >>> Band.objects().where(Band.name == "Pythonistas").run_sync()
     [<Band: 1>]
+
+Piccolo also has :ref:`filter <Filter>`, which takes Django-style keyword
+lookups. It's useful when the criteria arrive as data:
+
+.. code-block:: python
+
+    # Piccolo
+    >>> Band.filter(popularity__gte=1000, manager__name="Guido").run_sync()
+    [<Band: 1>]
+
+Q objects
+~~~~~~~~~
+
+Django uses ``Q`` objects to build ``OR`` conditions, because its expressions
+don't compose. Piccolo's do, so an ordinary expression is usually enough:
+
+.. code-block:: python
+
+    # Django
+    >>> Band.objects.filter(Q(name="Pythonistas") | Q(name="Rustaceans"))
+
+    # Piccolo
+    >>> Band.objects().where(
+    ...     (Band.name == "Pythonistas") | (Band.name == "Rustaceans")
+    ... ).run_sync()
+
+If you're using keyword lookups, :ref:`criteria <Criteria>` is the equivalent
+of a ``Q`` object:
+
+.. code-block:: python
+
+    # Piccolo
+    >>> Band.filter(
+    ...     Band.criteria(name="Pythonistas")
+    ...     | Band.criteria(name="Rustaceans")
+    ... ).run_sync()
 
 values_list
 ~~~~~~~~~~~

--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -38,6 +38,105 @@ To filter the rows we use the :ref:`where` clause:
     >>> await Band.objects().where(Band.name == 'Pythonistas')
     [<Band: 1>]
 
+.. _Filter:
+
+filter
+------
+
+``where`` is the recommended way of filtering rows. When the criteria arrive as
+data rather than being written by hand, ``filter`` builds the same query from
+keyword arguments:
+
+.. code-block:: python
+
+    # These are the same query:
+    >>> await Band.filter(popularity__gte=1000, manager__name='Guido')
+    [<Band: 1>]
+
+    >>> await Band.objects().where(
+    ...     Band.popularity >= 1000,
+    ...     Band.manager.name == 'Guido',
+    ... )
+    [<Band: 1>]
+
+Each keyword is a ``field[__related_field...][__transform][__op]`` lookup.
+Supported operators are ``in``, ``gte``, ``lte``, ``gt`` and ``lt``; supported
+datetime transforms are ``year``, ``month``, ``day``, ``hour``, ``minute`` and
+``second``; a bare field means equality.
+
+A column always beats a suffix which shares its name, so both of these work:
+
+.. code-block:: python
+
+    >>> await Event.filter(year=2020)          # the `year` column
+    >>> await Event.filter(starts__year=2020)  # the `year` transform
+
+The same applies to operators - if a related table has a column called ``lt``,
+then ``room__lt=1`` means ``Room.lt == 1``, not ``Booking.room < 1``. There's no
+way to spell the other meaning, so use ``where`` for those columns.
+
+It returns an ``objects`` query, so it chains as usual:
+
+.. code-block:: python
+
+    >>> await Band.filter(popularity__gte=1000).order_by(Band.name).first()
+    <Band: 1>
+
+.. _Criteria:
+
+criteria
+--------
+
+Keyword lookups are combined with ``AND``. For ``OR``, use
+:meth:`criteria <piccolo.table.Table.criteria>`, which returns the lookups as a
+where clause instead of a query:
+
+.. code-block:: python
+
+    >>> await Band.filter(
+    ...     Band.criteria(manager__name='Guido')
+    ...     | Band.criteria(manager__name='Graydon'),
+    ...     popularity__gte=1000,
+    ... )
+    [<Band: 1>]
+
+It's an ordinary where clause, so it also works in :ref:`where`, alongside the
+usual expressions:
+
+.. code-block:: python
+
+    >>> await Band.objects().where(
+    ...     Band.criteria(popularity__gte=1000)
+    ...     | (Band.name == 'Pythonistas')
+    ... )
+    [<Band: 1>]
+
+Filtering on untrusted input
+----------------------------
+
+Because the lookups are strings, a lookup from a payload is the lookup you pass
+to the query - there's no mapping layer in between:
+
+.. code-block:: python
+
+    # GET /bands?popularity__gte=1000&manager__name=Guido
+    async def list_bands(request):
+        criteria = parse_params(request.query_params)
+        return await Band.filter(**criteria)
+
+.. warning::
+   ``parse_params`` above isn't optional.
+   ``Band.filter(**request.query_params)`` lets a client filter on *any*
+   column, including ones you don't expose, and across foreign keys into other
+   tables. Allow-list the lookups you accept.
+
+   It also has to convert the values. Piccolo doesn't coerce them, and query
+   params are always strings, so ``popularity__gte="1000"`` is passed to the
+   database as-is - which SQLite accepts and Postgres rejects. That's the same
+   as ``where(Band.popularity >= "1000")``; ``filter`` doesn't change it.
+
+-------------------------------------------------------------------------------
+
 To get a single row (or ``None`` if it doesn't exist) use the :ref:`first`
 clause:
 

--- a/piccolo/query/lookups.py
+++ b/piccolo/query/lookups.py
@@ -1,0 +1,209 @@
+"""
+Lookup parsing for :meth:`Table.filter <piccolo.table.Table.filter>` and
+:meth:`Table.criteria <piccolo.table.Table.criteria>`.
+
+A lookup is a string of the form
+``field[__related_field...][__transform][__op]`` which is parsed into a where
+clause:
+
+.. code-block:: python
+
+    "name"                 -> Band.name == value
+    "popularity__gte"      -> Band.popularity >= value
+    "manager__name__in"    -> Band.manager.name.is_in(value)
+    "starts__year__gte"    -> Year(Concert.starts) >= value
+
+"""
+
+from __future__ import annotations
+
+from operator import eq, ge, gt, le, lt
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional
+
+from piccolo.columns.base import Column
+from piccolo.columns.column_types import Date, Time, Timestamp, Timestamptz
+from piccolo.columns.combination import WhereRaw
+from piccolo.query.functions.datetime import (
+    Day,
+    Hour,
+    Minute,
+    Month,
+    Second,
+    Year,
+)
+from piccolo.querystring import QueryString
+
+if TYPE_CHECKING:
+    from piccolo.custom_types import Combinable
+    from piccolo.table import Table
+
+
+class Transform(NamedTuple):
+    function: Callable[[Any], QueryString]
+    column_types: tuple[type[Column], ...]
+
+
+DATE_COLUMNS = (Date, Timestamp, Timestamptz)
+TIME_COLUMNS = (Time, Timestamp, Timestamptz)
+
+LOOKUP_TRANSFORMS: dict[str, Transform] = {
+    "year": Transform(Year, DATE_COLUMNS),
+    "month": Transform(Month, DATE_COLUMNS),
+    "day": Transform(Day, DATE_COLUMNS),
+    "hour": Transform(Hour, TIME_COLUMNS),
+    "minute": Transform(Minute, TIME_COLUMNS),
+    "second": Transform(Second, TIME_COLUMNS),
+}
+
+
+def _is_in(expression: Any, value: Any) -> Any:
+    """
+    ``Column.is_in`` expands the values into one placeholder each, but
+    ``QueryString.is_in`` binds the whole list as a single parameter, which
+    isn't valid SQL. Transforms give us a ``QueryString``, so that case is
+    built here instead.
+    """
+    from piccolo.query.methods.select import Select
+
+    if isinstance(value, (str, bytes)):
+        raise ValueError(
+            "An `in` lookup needs a sequence of values, not a string."
+        )
+
+    values: Any
+    if isinstance(value, (Select, QueryString)):
+        values = value
+    else:
+        # Normalise tuples, sets and other iterables - `Column.is_in` only
+        # rejects an empty `list`, and `IN ()` isn't valid SQL.
+        values = list(value)
+        if not values:
+            raise ValueError(
+                "The `values` list argument must contain at least one value."
+            )
+
+    if not isinstance(expression, QueryString):
+        return expression.is_in(values)
+
+    if isinstance(values, Select):
+        if len(values.columns_delegate.selected_columns) != 1:
+            raise ValueError("A sub select must only return a single column.")
+        values = values.querystrings[0]
+
+    if isinstance(values, QueryString):
+        return QueryString("{} IN ({})", expression, values)
+
+    placeholders = ", ".join("{}" for _ in values)
+    return QueryString(f"{{}} IN ({placeholders})", expression, *values)
+
+
+LOOKUP_OPERATORS: dict[str, Callable[[Any, Any], Any]] = {
+    "gte": ge,
+    "lte": le,
+    "gt": gt,
+    "lt": lt,
+    "in": _is_in,
+}
+
+
+def build_expression(
+    table: type[Table], lookup: str, value: Any
+) -> Combinable:
+    """
+    Turn a single ``lookup`` string and its ``value`` into a where clause
+    against ``table``.
+    """
+    tokens = lookup.split("__")
+
+    # A column always wins over a suffix which happens to share its name -
+    # `Event.year` beats the `year` transform, and a related `lt` column beats
+    # the `lt` operator - so a suffix is only stripped once the lookup has
+    # failed to resolve as it stands.
+    column = _find_column(table, tokens)
+    operator = eq
+    transform: Optional[Transform] = None
+
+    if column is None and len(tokens) > 1 and tokens[-1] in LOOKUP_OPERATORS:
+        operator = LOOKUP_OPERATORS[tokens.pop()]
+        column = _find_column(table, tokens)
+
+    if column is None and len(tokens) > 1 and tokens[-1] in LOOKUP_TRANSFORMS:
+        transform = LOOKUP_TRANSFORMS[tokens.pop()]
+        column = _find_column(table, tokens)
+
+    if column is None:
+        raise ValueError(f"Invalid lookup - {lookup}")
+
+    if transform is None:
+        return _as_combinable(operator(column, value), column)
+
+    if not isinstance(column, transform.column_types):
+        raise ValueError(
+            f"Invalid lookup - {lookup} - a transform needs a date or time "
+            f"column, and {column._meta.name} is {type(column).__name__}."
+        )
+
+    return _as_combinable(operator(transform.function(column), value), column)
+
+
+def _find_column(table: type[Table], tokens: list[str]) -> Optional[Column]:
+    """
+    The column the lookup points at, or ``None`` if there isn't one.
+
+    ``get_column_by_name`` walks the path with ``getattr``, so a lookup like
+    ``name__like`` resolves to a *method* on the column - hence the type
+    check, otherwise it would be compared against the value.
+
+    Anything the walk raises means "not a column": as well as ``ValueError``,
+    an over-long path through a self-referencing foreign key raises a bare
+    ``Exception`` from ``ForeignKey.__getattribute__``.
+    """
+    try:
+        column = table._meta.get_column_by_name(".".join(tokens))
+    except Exception:
+        return None
+
+    return column if isinstance(column, Column) else None
+
+
+def _as_combinable(clause: Any, column: Column) -> Combinable:
+    """
+    Transforms return a ``QueryString`` rather than a ``Combinable``.
+    ``WhereDelegate.where`` normalises those the same way when they're passed
+    to ``where`` - we have to do it here too, so that ``|`` on the result
+    means ``OR``. On a ``QueryString`` it means ``COALESCE``.
+    """
+    if not isinstance(clause, QueryString):
+        return clause
+
+    if column._meta.call_chain:
+        return JoinedWhereRaw(column, clause.template, *clause.args)
+
+    return WhereRaw(clause.template, *clause.args)
+
+
+class JoinedWhereRaw(WhereRaw):
+    """
+    A ``WhereRaw`` which references a joined table.
+
+    ``update`` and ``delete`` can't join, so ``Where`` rewrites a clause on a
+    related column into a sub select. ``WhereRaw`` has no way of knowing it
+    needs to - it just returns its SQL, which then names a table that isn't in
+    the query - so the rewrite is repeated here.
+    """
+
+    __slots__ = ("column",)
+
+    def __init__(self, column: Column, sql: str, *args: Any) -> None:
+        super().__init__(sql, *args)
+        self.column = column
+
+    @property
+    def querystring_for_update_and_delete(self) -> QueryString:
+        root_column = self.column._meta.call_chain[0]
+        sub_query = root_column._meta.table.select(root_column).where(self)
+
+        return QueryString(
+            f'"{root_column._meta.db_column_name}" IN ({{}})',
+            sub_query.querystrings[0],
+        )

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -6,7 +6,9 @@ import types
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from functools import reduce
 from graphlib import TopologicalSorter
+from operator import and_
 from typing import TYPE_CHECKING, Any, Optional, Union, cast, overload
 
 from piccolo.columns import Column
@@ -30,7 +32,7 @@ from piccolo.columns.m2m import (
 from piccolo.columns.readable import Readable
 from piccolo.columns.reference import LAZY_COLUMN_REFERENCES
 from piccolo.constraints import Constraint
-from piccolo.custom_types import TableInstance
+from piccolo.custom_types import Combinable, TableInstance
 from piccolo.engine import Engine, engine_finder
 from piccolo.query import (
     Alter,
@@ -46,6 +48,7 @@ from piccolo.query import (
     TableExists,
     Update,
 )
+from piccolo.query.lookups import build_expression
 from piccolo.query.methods.create_index import CreateIndex
 from piccolo.query.methods.indexes import Indexes
 from piccolo.query.methods.objects import GetRelated, UpdateSelf
@@ -1254,6 +1257,85 @@ class Table(metaclass=TableMetaclass):
 
         """
         return Objects[TableInstance](table=cls, prefetch=prefetch)
+
+    @classmethod
+    def filter(
+        cls: type[TableInstance],
+        /,
+        *where: Combinable,
+        **lookups: Any,
+    ) -> Objects[TableInstance]:
+        """
+        A shorthand for :meth:`objects` with a ``where`` clause built from
+        keyword arguments, for when the criteria arrive as data rather than
+        being written by hand::
+
+            # These are equivalent:
+            await Band.filter(popularity__gte=1000, manager__name="Guido")
+
+            await Band.objects().where(
+                Band.popularity >= 1000,
+                Band.manager.name == "Guido",
+            )
+
+        Each keyword is a ``field[__related_field...][__transform][__op]``
+        lookup - see :mod:`piccolo.query.lookups` for the grammar. They're
+        combined with ``AND``; for ``OR``, pass :meth:`criteria` in as a
+        positional argument::
+
+            await Band.filter(
+                Band.criteria(manager__name="Guido")
+                | Band.criteria(manager__name="Graydon"),
+                popularity__gte=1000,
+            )
+
+        Returns an :class:`Objects <piccolo.query.methods.objects.Objects>`
+        query, so it chains like any other
+        (``.where(...).order_by(...).first()``).
+
+        .. warning::
+           Lookups from an untrusted source (query params, say) need an
+           allow-list - otherwise a client can filter on any column, and
+           across foreign keys into other tables. Values aren't converted
+           either.
+
+        """
+        expressions = [
+            build_expression(cls, lookup, value)
+            for lookup, value in lookups.items()
+        ]
+        return cls.objects().where(*where, *expressions)
+
+    @classmethod
+    def criteria(cls, /, **lookups: Any) -> Combinable:
+        """
+        The same lookups as :meth:`filter`, but returned as a where clause
+        instead of a query, so they can be combined with ``|`` and ``&``::
+
+            await Band.filter(
+                Band.criteria(manager__name="Guido")
+                | Band.criteria(manager__name="Graydon")
+            )
+
+        It's an ordinary where clause, so it also works in :meth:`where`,
+        alongside the usual expressions::
+
+            await Band.objects().where(
+                Band.criteria(popularity__gte=1000)
+                | (Band.name == "Pythonistas")
+            )
+
+        """
+        if not lookups:
+            raise ValueError("At least one lookup is required.")
+
+        return reduce(
+            and_,
+            (
+                build_expression(cls, lookup, value)
+                for lookup, value in lookups.items()
+            ),
+        )
 
     @classmethod
     def count(

--- a/tests/table/test_filter.py
+++ b/tests/table/test_filter.py
@@ -1,0 +1,459 @@
+import datetime
+from unittest import TestCase
+
+from piccolo.columns.column_types import (
+    ForeignKey,
+    Integer,
+    Timestamp,
+    Varchar,
+)
+from piccolo.table import Table
+from piccolo.testing.test_case import TableTest
+from tests.base import DBTestCase
+from tests.example_apps.music.tables import Band
+
+
+class Event(Table):
+    """
+    ``year`` shares its name with a transform, so it's used to check that a
+    column wins over a transform.
+    """
+
+    name = Varchar()
+    year = Integer()
+    starts = Timestamp()
+
+
+class Ticket(Table):
+    """
+    Used to check that ``event__year`` resolves to ``Event.year`` rather than
+    ``Year(Ticket.event)``.
+    """
+
+    event = ForeignKey(Event)
+
+
+class Room(Table):
+    """
+    ``lt`` shares its name with an operator, so it's used to check that a
+    column wins over an operator.
+    """
+
+    name = Varchar()
+    lt = Integer()
+
+
+class Booking(Table):
+    room = ForeignKey(Room)
+
+
+class Employee(Table):
+    """
+    Self-referencing, so a lookup can walk far enough to hit Piccolo's call
+    chain limit.
+    """
+
+    name = Varchar()
+    boss: ForeignKey["Employee"] = ForeignKey(references="Employee")
+
+
+class TestFilter(DBTestCase):
+    def test_equals(self):
+        self.insert_rows()
+
+        response = Band.filter(name="Pythonistas").run_sync()
+
+        self.assertEqual([band.name for band in response], ["Pythonistas"])
+
+    def test_no_criteria_returns_all(self):
+        self.insert_rows()
+
+        response = Band.filter().run_sync()
+
+        self.assertEqual(len(response), 3)
+
+    def test_gte(self):
+        self.insert_rows()
+
+        response = (
+            Band.filter(popularity__gte=1000).order_by(Band.name).run_sync()
+        )
+
+        self.assertEqual(
+            [band.name for band in response], ["Pythonistas", "Rustaceans"]
+        )
+
+    def test_lt(self):
+        self.insert_rows()
+
+        response = Band.filter(popularity__lt=1000).run_sync()
+
+        self.assertEqual([band.name for band in response], ["CSharps"])
+
+    def test_in(self):
+        self.insert_rows()
+
+        response = (
+            Band.filter(name__in=["Pythonistas", "CSharps"])
+            .order_by(Band.name)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [band.name for band in response], ["CSharps", "Pythonistas"]
+        )
+
+    def test_multiple_lookups(self):
+        self.insert_rows()
+
+        response = Band.filter(
+            name="Pythonistas", popularity__gte=1000
+        ).run_sync()
+
+        self.assertEqual([band.name for band in response], ["Pythonistas"])
+
+    def test_related_field(self):
+        self.insert_rows()
+
+        response = Band.filter(manager__name="Guido").run_sync()
+
+        self.assertEqual([band.name for band in response], ["Pythonistas"])
+
+    def test_related_field_in(self):
+        self.insert_rows()
+
+        response = (
+            Band.filter(manager__name__in=["Guido", "Graydon"])
+            .order_by(Band.name)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [band.name for band in response], ["Pythonistas", "Rustaceans"]
+        )
+
+    def test_chains_with_where(self):
+        self.insert_rows()
+
+        response = (
+            Band.filter(popularity__gte=1000)
+            .where(Band.name == "Rustaceans")
+            .run_sync()
+        )
+
+        self.assertEqual([band.name for band in response], ["Rustaceans"])
+
+
+class TestCriteria(DBTestCase):
+    def test_or(self):
+        self.insert_rows()
+
+        response = (
+            Band.filter(
+                Band.criteria(name="Pythonistas")
+                | Band.criteria(name="CSharps")
+            )
+            .order_by(Band.name)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [band.name for band in response], ["CSharps", "Pythonistas"]
+        )
+
+    def test_or_combined_with_lookups(self):
+        self.insert_rows()
+
+        response = Band.filter(
+            Band.criteria(name="Pythonistas") | Band.criteria(name="CSharps"),
+            popularity__gte=1000,
+        ).run_sync()
+
+        self.assertEqual([band.name for band in response], ["Pythonistas"])
+
+    def test_works_in_where(self):
+        self.insert_rows()
+
+        response = (
+            Band.objects()
+            .where(
+                Band.criteria(popularity__gte=2000) | (Band.name == "CSharps")
+            )
+            .order_by(Band.name)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [band.name for band in response], ["CSharps", "Rustaceans"]
+        )
+
+    def test_multiple_lookups_are_anded(self):
+        self.insert_rows()
+
+        response = (
+            Band.objects()
+            .where(Band.criteria(name="Pythonistas", popularity__gte=2000))
+            .run_sync()
+        )
+
+        self.assertEqual(response, [])
+
+    def test_no_lookups(self):
+        with self.assertRaises(ValueError):
+            Band.criteria()
+
+
+class TestTransforms(TableTest):
+    tables = [Event, Ticket]
+
+    def setUp(self):
+        """
+        The ``year`` column and the year of ``starts`` disagree on purpose, so
+        a test can tell which of the two a lookup used.
+        """
+        super().setUp()
+
+        mismatched, other = events = [
+            Event(
+                name="Mismatched",
+                year=1999,
+                starts=datetime.datetime(2020, 6, 1, 9),
+            ),
+            Event(
+                name="Other",
+                year=2020,
+                starts=datetime.datetime(1999, 6, 1, 14),
+            ),
+        ]
+        Event.insert(*events).run_sync()
+
+        Ticket.insert(Ticket(event=mismatched), Ticket(event=other)).run_sync()
+
+    def test_transform(self):
+        response = Event.filter(starts__year=2020).run_sync()
+
+        self.assertEqual([event.name for event in response], ["Mismatched"])
+
+    def test_transform_with_operator(self):
+        response = Event.filter(starts__year__gte=2020).run_sync()
+
+        self.assertEqual([event.name for event in response], ["Mismatched"])
+
+    def test_transform_with_in(self):
+        """
+        ``Column.is_in`` expands the values, but ``QueryString.is_in`` binds
+        the whole list as one parameter - which isn't valid SQL.
+        """
+        response = (
+            Event.filter(starts__year__in=[2020, 1999])
+            .order_by(Event.name)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [event.name for event in response], ["Mismatched", "Other"]
+        )
+
+    def test_transform_with_empty_in(self):
+        with self.assertRaises(ValueError):
+            Event.filter(starts__year__in=[])
+
+    def test_transform_with_sub_select(self):
+        """
+        ``Other.year`` is 2020, and ``Mismatched.starts`` is the row in 2020.
+        """
+        response = Event.filter(
+            starts__year__in=Event.select(Event.year).where(
+                Event.name == "Other"
+            )
+        ).run_sync()
+
+        self.assertEqual([event.name for event in response], ["Mismatched"])
+
+    def test_related_transform(self):
+        response = (
+            Ticket.filter(event__starts__year=2020)
+            .prefetch(Ticket.event)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [ticket.event.name for ticket in response], ["Mismatched"]
+        )
+
+    def test_related_transform_with_in(self):
+        response = (
+            Ticket.filter(event__starts__year__in=[2020])
+            .prefetch(Ticket.event)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [ticket.event.name for ticket in response], ["Mismatched"]
+        )
+
+    def test_hour_transform(self):
+        response = Event.filter(starts__hour=14).run_sync()
+
+        self.assertEqual([event.name for event in response], ["Other"])
+
+    def test_column_wins_over_transform(self):
+        """
+        ``year`` is both a column and a transform, and the column wins.
+        """
+        response = Event.filter(year=2020).run_sync()
+
+        self.assertEqual([event.name for event in response], ["Other"])
+
+    def test_related_column_wins_over_transform(self):
+        response = (
+            Ticket.filter(event__year=2020).prefetch(Ticket.event).run_sync()
+        )
+
+        self.assertEqual([ticket.event.name for ticket in response], ["Other"])
+
+    def test_combines_with_or(self):
+        """
+        Transforms return a ``QueryString``, where ``|`` means ``COALESCE`` -
+        so ``criteria`` has to normalise them for ``OR`` to work.
+        """
+        response = (
+            Event.objects()
+            .where(
+                Event.criteria(starts__year=2020)
+                | Event.criteria(starts__year=1999)
+            )
+            .order_by(Event.name)
+            .run_sync()
+        )
+
+        self.assertEqual(
+            [event.name for event in response], ["Mismatched", "Other"]
+        )
+
+    def test_related_transform_in_delete(self):
+        """
+        ``update``/``delete`` can't join, so a transform on a related column
+        has to be rewritten into a sub select.
+        """
+        Ticket.delete().where(
+            Ticket.criteria(event__starts__year=2020)
+        ).run_sync()
+
+        remaining = Ticket.objects().prefetch(Ticket.event).run_sync()
+
+        self.assertEqual(
+            [ticket.event.name for ticket in remaining], ["Other"]
+        )
+
+    def test_transform_in_delete(self):
+        Event.delete().where(Event.criteria(starts__year=2020)).run_sync()
+
+        self.assertEqual(
+            [event.name for event in Event.objects().run_sync()], ["Other"]
+        )
+
+
+class TestColumnNamedLikeAnOperator(TableTest):
+    tables = [Room, Booking]
+
+    def setUp(self):
+        super().setUp()
+
+        big, small = rooms = [
+            Room(name="Big", lt=100),
+            Room(name="Small", lt=1),
+        ]
+        Room.insert(*rooms).run_sync()
+        Booking.insert(Booking(room=big), Booking(room=small)).run_sync()
+
+    def test_column_wins_over_operator(self):
+        """
+        ``room__lt`` is ``Room.lt``, not ``Booking.room < value``.
+        """
+        response = Booking.filter(room__lt=1).prefetch(Booking.room).run_sync()
+
+        self.assertEqual(
+            [booking.room.name for booking in response], ["Small"]
+        )
+
+    def test_operator_still_works(self):
+        response = Room.filter(lt__gte=100).run_sync()
+
+        self.assertEqual([room.name for room in response], ["Big"])
+
+
+class TestLookupParsing(TestCase):
+    """
+    These never reach the database - the lookup is rejected while the query is
+    being built.
+    """
+
+    def test_unknown_column(self):
+        with self.assertRaises(ValueError):
+            Band.filter(genre="jazz")
+
+    def test_unknown_lookup_suffix(self):
+        """
+        An unrecognised suffix isn't an operator, so it's treated as part of
+        the column path - which then fails to resolve.
+        """
+        with self.assertRaises(ValueError):
+            Band.filter(name__nope="Pythonistas")
+
+    def test_column_method_isnt_a_lookup(self):
+        """
+        The column path is walked with ``getattr``, so ``name__like`` would
+        otherwise resolve to ``Varchar.like`` - a method, not a column.
+        """
+        with self.assertRaises(ValueError):
+            Band.filter(name__like="Py%")
+
+    def test_in_with_a_string(self):
+        """
+        A string is a sequence, so it would otherwise expand into one value
+        per character.
+        """
+        with self.assertRaises(ValueError):
+            Band.filter(name__in="Pythonistas")
+
+    def test_in_with_an_empty_sequence(self):
+        """
+        ``Column.is_in`` only rejects an empty ``list``, but ``IN ()`` isn't
+        valid SQL whatever the sequence was.
+        """
+        for values in ([], (), set(), range(0)):
+            with self.subTest(values=values):
+                with self.assertRaises(ValueError):
+                    Band.filter(name__in=values)
+
+    def test_transform_on_a_non_datetime_column(self):
+        """
+        Otherwise the transform is applied to whatever the path resolved to,
+        and the database is left to reject it.
+        """
+        with self.assertRaises(ValueError):
+            Band.filter(name__year=2020)
+
+        with self.assertRaises(ValueError):
+            Band.filter(popularity__month=6)
+
+    def test_lookup_named_like_the_classmethod_argument(self):
+        """
+        ``cls`` is positional-only, so it can't collide with a lookup.
+        """
+        with self.assertRaises(ValueError):
+            Band.filter(**{"cls": "x"})
+
+        with self.assertRaises(ValueError):
+            Band.criteria(**{"cls": "x"})
+
+    def test_call_chain_too_long(self):
+        """
+        Walking a long path through a self-referencing foreign key raises a
+        bare ``Exception``, which still has to come back as a bad lookup.
+        """
+        lookup = "__".join(["boss"] * 12 + ["name"])
+
+        with self.assertRaises(ValueError):
+            Employee.filter(**{lookup: "x"})

--- a/tests/type_checking.py
+++ b/tests/type_checking.py
@@ -119,6 +119,12 @@ if TYPE_CHECKING:
         assert_type(await ModelBuilder.build(Band), Band)
         assert_type(ModelBuilder.build_sync(Band), Band)
 
+    async def filter() -> None:
+        query = Band.filter(popularity__gte=1000)
+        assert_type(await query, list[Band])
+        assert_type(query.run_sync(), list[Band])
+        assert_type(await query.first(), Optional[Band])
+
     def run_sync_return_type() -> None:
         """
         Make sure `run_sync` returns the same type as the coroutine which is


### PR DESCRIPTION
Follows on from #1413. Draft — the shape is up for discussion.

### Why `filter` and not `where`

You asked whether the lookup syntax should go into `Table.where` too. I don't think it should:
kwargs can only ever mean AND, and `where` can do much more than that.

```python
# `where` today - fine
Band.objects().where((Band.name == "Pythonistas") | (Band.name == "CSharps"))

# the same thing as kwargs - impossible, there's no way to spell OR
Band.objects().where(name="Pythonistas", ???="CSharps")
```

Django hit this exact wall, which is why it has `Q` objects. Teaching `where` the kwargs syntax
would import that problem into the part of Piccolo that doesn't have it. A separate `filter` is
honest about being the limited one:

```python
Band.filter(popularity__gte=1000)              # AND of lookups, that's all it does
Band.filter(popularity__gte=1000).where(...)   # need more? `where` is right there
```

### What it does

```python
# these two are the same query
await Band.filter(popularity__gte=1000, manager__name="Guido")

await Band.objects().where(
    Band.popularity >= 1000,
    Band.manager.name == "Guido",
)
```

It returns `Objects`, so it chains as usual:

```python
await Band.filter(popularity__gte=1000).order_by(Band.name).first()
```

The payoff is that a lookup from a payload is the lookup you pass to the query:

```python
# GET /bands?popularity__gte=1000&manager__name=Guido
criteria = parse_params(request.query_params)   # allow-list + convert, see below
return await Band.filter(**criteria)
```

### `criteria` for OR

```python
await Band.filter(
    Band.criteria(manager__name="Guido") | Band.criteria(manager__name="Graydon"),
    popularity__gte=1000,
)
```

This is Django's `Q`, but it doesn't need to be a lazy expression tree the way Django's is —
Piccolo's expressions already compose, so `criteria` is just a constructor for clauses you
already have. Which means it drops into `where` untouched:

```python
await Band.objects().where(
    Band.criteria(popularity__gte=1000) | (Band.name == "Pythonistas")
)
```

That felt like a better answer to your question than putting lookups in `where`: you get the
data-driven case *and* keep one expression language.

### On `Table` rather than a compat module

I tried it as a `compat.django` mixin first, per your suggestion, and moved it back for three
reasons:

- **A mixin only reaches tables you define.** `BaseUser`, `SessionsBase`, piccolo_api's tables,
  anything from `table_reflection` — you can't add a mixin to those, and "filter this from query
  params" lands on them often.
- **`Model(Table)` doesn't work.** `objects` can't become a property: it's a classmethod taking
  `*prefetch`, called with arguments in `piccolo/query/methods/objects.py:107` and on user table
  classes in `piccolo/columns/m2m.py:366`, plus six places in piccolo_api. And with no `abstract=`
  flag on `__init_subclass__`, `Model` itself becomes a table called `model` that `table_finder`
  picks up.
- **A non-`Table` mixin can't type its own `cls`.** Both mypy and pyright reject
  `cls: type[TableInstance]` on one ("the erased type of self is not a supertype of its class"),
  so it needs a `Protocol` scaffold that disappears entirely inside `Table`.

`filter` is the 25th classmethod on `Table`, and shadows a same-named column exactly the way
`select`/`objects`/`delete` already do — I checked, a column called `select` works fine today.
There's an `assert_type` in `tests/type_checking.py` confirming `await Band.filter(...)` still
infers `list[Band]`.

Happy to move it back to `compat.django` if you'd rather — it's the same code either way.

### Lookups

`field[__related_field...][__transform][__op]`

| | |
|---|---|
| operators | `in`, `gte`, `lte`, `gt`, `lt` |
| transforms | `year`, `month`, `day`, `hour`, `minute`, `second` |
| bare field | equality |

A column always beats a suffix sharing its name, so both of these work:

```python
Event.filter(year=2020)          # the `year` column
Event.filter(starts__year=2020)  # the `year` transform
```

Two things worth knowing:

- Values aren't converted, so query params (always strings) need handling first —
  `popularity__gte="1000"` works on SQLite and fails on Postgres. That's true of
  `where(Band.popularity >= "1000")` too; `filter` doesn't change it. **Should it convert against
  `column.value_type`?** Django does. I left it out as it's a bigger decision.
- Untrusted lookups need an allow-list — otherwise a client can filter on any column, and across
  foreign keys into other tables. Documented with a warning.

Left out on purpose, happy to add: `exclude()`, `~criteria` (needs `__invert__` on
`CombinableMixin`), `__isnull`, `__contains`.

### Notes

- Datetime transforms return a `QueryString`, where `|` means `COALESCE`, not `OR` — so
  `criteria` normalises them to `WhereRaw` the way `WhereDelegate.where` does. There's a test.
- `update`/`delete` can't join, so `Where` rewrites a clause on a related column into a sub
  select. `WhereRaw` doesn't, so a transform over a foreign key needed a small `JoinedWhereRaw`
  in `lookups.py` that repeats the rewrite. If you'd rather that lived on `WhereRaw` itself,
  say so — it'd fix the same case for anyone passing a raw `QueryString` to `where`.
- piccolo_api hand-rolls this translation today — `OPERATOR_MAP` in `crud/endpoints.py:51`,
  applied around `:790-825` — and its version can't traverse joins, because line 792 is a flat
  `getattr(self.table, field_name)`.

### Questions

1. `criteria` — good name? It's `Q` in Django, but there are no uppercase-named methods anywhere
   in Piccolo, and `clause` is the word the docs use most.
2. Is a second method worth it at all, or should OR just go through `where` with ordinary
   expressions? Dropping `criteria` is a clean retreat.
3. Value conversion — see above.

Tests pass on SQLite and Postgres; `lint.sh` and `pyright` are clean.
