### PR TITLE
Pin GitHub Actions to commit SHAs and declare workflow permissions

### DIFF
--- a/.github/workflows/plumber.yaml
+++ b/.github/workflows/plumber.yaml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+
+      - uses: getplumber/plumber@7ad9d267ee5a00163cec9e5c749a088d5f565167 # v0.4.26
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: "Publish release"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v5"
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.13
       - name: "Install dependencies"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,9 @@ jobs:
                 python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
@@ -55,9 +55,9 @@ jobs:
                 ports:
                     - 5432:5432
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
@@ -107,9 +107,9 @@ jobs:
                     - 5432:5432
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
@@ -133,7 +133,7 @@ jobs:
                   PG_DATABASE: piccolo
                   PG_PASSWORD: postgres
             - name: Upload coverage
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1.5.2
               if: matrix.python-version == '3.13'
 
     cockroach:
@@ -144,9 +144,9 @@ jobs:
                 python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
                 cockroachdb-version: ["v25.4.3"]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
@@ -167,7 +167,7 @@ jobs:
                   PG_HOST: localhost
                   PG_DATABASE: piccolo
             - name: Upload coverage
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1.5.2
               if: matrix.python-version == '3.13'
 
     sqlite:
@@ -178,9 +178,9 @@ jobs:
                 python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
@@ -192,5 +192,5 @@ jobs:
             - name: Test with pytest, SQLite
               run: ./scripts/test-sqlite.sh
             - name: Upload coverage
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1.5.2
               if: matrix.python-version == '3.13'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,9 @@ on:
         paths-ignore:
             - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
     linters:
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Release](https://github.com/piccolo-orm/piccolo/actions/workflows/release.yaml/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/piccolo-orm/badge/?version=latest)](https://piccolo-orm.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/piccolo?color=%2334D058&label=pypi)](https://pypi.org/project/piccolo/)
+[![Plumber Score](https://score.getplumber.io/github.com/piccolo-orm/piccolo.svg)](https://score.getplumber.io/github.com/piccolo-orm/piccolo)
 [![codecov](https://codecov.io/gh/piccolo-orm/piccolo/branch/master/graph/badge.svg?token=V19CWH7MXX)](https://codecov.io/gh/piccolo-orm/piccolo)
 
 Piccolo is a fast, user friendly ORM and query builder which supports asyncio. [Read the docs](https://piccolo-orm.readthedocs.io/en/latest/).


### PR DESCRIPTION
Hi, drive-by CI hardening in three commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v1` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token, including in `release.yaml` which publishes to PyPI. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). All shas were resolved from the upstream repos and cross checked against their release tags. The pins stay maintainable: if you want them bumped automatically, a dependabot config with the `github-actions` ecosystem does it, one small block. Worth knowing: `codecov/codecov-action` is still on v1, bumping it to a current major would be a good separate change, this PR only freezes what you already run.

**Commit 2 adds `permissions: contents: read` to both workflows.** The scope is exact, not guessed: all six jobs only check out, test, or publish through dedicated secrets (codecov token, PyPI token), the GitHub token itself is never used.

**Commit 3 adds [Plumber](https://github.com/getplumber/plumber) to CI**, the tool I used to find the issues in the first place, so none of this quietly drifts back:

- Scans the workflows on each push to master and on each PR, fails when something regresses: an unpinned action, a job without permissions, an archived dependency, a known CVE.
- Runs on its built-in defaults, no config file to review. Findings land in the security tab as SARIF.
- Adds a score badge to the README. It works like OpenSSF Scorecard's published results: runs publish the score to score.getplumber.io, the badge shows the state of master, a failed publish never fails your CI, and it reads UNKNOWN in gray until the first run.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v1`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I remove that commit from the PR, the two hardening commits are the part that matters and they stand entirely on their own.