### PR TITLE
Add `Case` / `When` conditional function

### DIFF
--- a/docs/src/piccolo/functions/conditional.rst
+++ b/docs/src/piccolo/functions/conditional.rst
@@ -13,3 +13,15 @@ NullIf
 ------
 
 .. autoclass:: NullIf
+
+
+Case
+----
+
+.. autoclass:: Case
+
+
+When
+----
+
+.. autoclass:: When

--- a/piccolo/query/functions/__init__.py
+++ b/piccolo/query/functions/__init__.py
@@ -6,7 +6,7 @@ from .array import (
     ArrayRemove,
     ArrayReplace,
 )
-from .conditional import Coalesce, NullIf
+from .conditional import Case, Coalesce, NullIf, When
 from .datetime import (
     AtTimeZone,
     Day,
@@ -39,6 +39,7 @@ __all__ = (
     "ArrayReplace",
     "AtTimeZone",
     "Avg",
+    "Case",
     "Cast",
     "Ceil",
     "Coalesce",
@@ -64,5 +65,6 @@ __all__ = (
     "Strftime",
     "Sum",
     "Upper",
+    "When",
     "Year",
 )

--- a/piccolo/query/functions/conditional.py
+++ b/piccolo/query/functions/conditional.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+import decimal
+import math
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from piccolo.custom_types import BasicTypes
+from piccolo.custom_types import BasicTypes, Combinable
 from piccolo.querystring import QueryString
 
 if TYPE_CHECKING:
@@ -120,3 +122,141 @@ class NullIf(QueryString):
         #######################################################################
 
         super().__init__("NULLIF({}, {})", identifier, value, alias=alias)
+
+
+def get_case_value_string(
+    value: Union[Column, QueryString, BasicTypes, None],
+) -> tuple[str, list[Any]]:
+    """
+    Works out how a ``THEN`` / ``ELSE`` value should appear in the SQL.
+
+    Most values are passed to the database as query parameters, but numbers,
+    booleans and ``None`` are added to the query directly. This is because
+    Postgres can't infer the type of a bare parameter inside a ``CASE``
+    statement, so it assumes it's text, and the query then fails::
+
+        CASE WHEN "band"."popularity" > $1 THEN $2 ELSE $3 END
+        # asyncpg.exceptions.DataError: invalid input for query argument
+        # $2: 1 (expected str, got int)
+
+    There's no SQL injection risk, because we only do this once we know the
+    value is a Python number or boolean.
+
+    :returns:
+        A template fragment (either the literal SQL, or a ``{}`` placeholder),
+        along with any args which belong to it.
+
+    """
+    if value is None:
+        return ("NULL", [])
+    elif isinstance(value, bool):
+        return ("true" if value else "false", [])
+    elif isinstance(value, int):
+        return (str(value), [])
+    elif isinstance(value, float) and math.isfinite(value):
+        return (repr(value), [])
+    elif isinstance(value, decimal.Decimal) and value.is_finite():
+        return (str(value), [])
+    else:
+        return ("{}", [value])
+
+
+class When(QueryString):
+    def __init__(
+        self,
+        condition: Union[Combinable, QueryString],
+        then: Union[Column, QueryString, BasicTypes, None],
+    ):
+        """
+        A single branch of a :class:`Case` statement - don't use it directly.
+
+        :param condition:
+            A where clause, for example ``Band.popularity > 1000``.
+        :param then:
+            The value to return if the condition is true.
+
+        """
+        from piccolo.columns.combination import Combination, Where, WhereRaw
+
+        if isinstance(condition, (Where, WhereRaw, Combination)):
+            condition = condition.querystring
+        elif not isinstance(condition, QueryString):
+            raise ValueError("The condition must be a where clause.")
+
+        then_string, then_args = get_case_value_string(then)
+
+        super().__init__(
+            f"WHEN {{}} THEN {then_string}",
+            condition,
+            *then_args,
+        )
+
+
+class Case(QueryString):
+    def __init__(
+        self,
+        *whens: When,
+        default: Union[Column, QueryString, BasicTypes, None] = None,
+        alias: Optional[str] = None,
+    ):
+        """
+        A SQL ``CASE`` statement - it returns a different value depending on
+        which condition is matched first. It's the SQL equivalent of an
+        ``if / elif / else`` block.
+
+        Here's an example to try in the playground::
+
+            >>> from piccolo.query.functions import Case, When
+
+            >>> await Band.select(
+            ...     Band.name,
+            ...     Case(
+            ...         When(Band.popularity > 900, then='super popular'),
+            ...         When(Band.popularity > 500, then='popular'),
+            ...         default='not popular',
+            ...         alias='popularity_label',
+            ...     ),
+            ... )
+            [
+                {'name': 'Pythonistas', 'popularity_label': 'super popular'},
+                {'name': 'Rustaceans', 'popularity_label': 'not popular'},
+                {'name': 'C-Sharps', 'popularity_label': 'popular'}
+            ]
+
+        It can also be used in a ``where`` clause, and to sort results::
+
+            >>> await Band.select(Band.name).order_by(
+            ...     Case(
+            ...         When(Band.name == 'Rustaceans', then=1),
+            ...         default=2,
+            ...     )
+            ... )
+
+        :param whens:
+            Each branch of the statement, which are evaluated in order.
+        :param default:
+            The value to return if none of the conditions match (``ELSE`` in
+            SQL). If not specified, ``null`` is returned.
+        :param alias:
+            The name of the column in the response.
+
+        """
+        if not whens:
+            raise ValueError("At least one `When` must be passed in.")
+
+        if not all(isinstance(when, When) for when in whens):
+            raise ValueError("Only `When` instances can be passed in.")
+
+        template = " ".join("{}" for _ in whens)
+        args: list[Any] = list(whens)
+
+        if default is not None:
+            default_string, default_args = get_case_value_string(default)
+            template += f" ELSE {default_string}"
+            args.extend(default_args)
+
+        super().__init__(
+            f"CASE {template} END",
+            *args,
+            alias=alias or "case",
+        )

--- a/tests/query/functions/test_conditional.py
+++ b/tests/query/functions/test_conditional.py
@@ -252,6 +252,30 @@ class TestCaseFunction(AsyncTableTest):
             ],
         )
 
+    async def test_query_string_condition(self):
+        """
+        A condition can be a ``QueryString`` as well as a where clause - a
+        function wrapping a column returns one, and ``When`` passes it
+        straight through.
+        """
+        response = await Ticket.select(
+            Ticket.name,
+            Case(
+                When(Upper(Ticket.name).like("SEAT%"), then=1),
+                default=0,
+                alias="seated",
+            ),
+        ).order_by(Ticket.name)
+
+        self.assertListEqual(
+            response,
+            [
+                {"name": "Seated", "seated": 1},
+                {"name": "Standing", "seated": 0},
+                {"name": "VIP", "seated": 0},
+            ],
+        )
+
 
 class TestCaseValidation(TestCase):
 

--- a/tests/query/functions/test_conditional.py
+++ b/tests/query/functions/test_conditional.py
@@ -1,5 +1,8 @@
+from unittest import TestCase
+
 from piccolo.columns import Integer, Text, Varchar
-from piccolo.query.functions.conditional import Coalesce, NullIf
+from piccolo.query.functions.conditional import Case, Coalesce, NullIf, When
+from piccolo.query.functions.string import Upper
 from piccolo.table import Table
 from piccolo.testing.test_case import AsyncTableTest
 
@@ -42,3 +45,224 @@ class TestNullIf(AsyncTableTest):
         self.assertListEqual(
             response, [{"name": "Amazing Venue", "address": None}]
         )
+
+
+class Ticket(Table):
+    name = Varchar()
+    price = Integer()
+
+
+class TestCaseFunction(AsyncTableTest):
+
+    tables = [Ticket]
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+
+        await Ticket.insert(
+            Ticket({Ticket.name: "Standing", Ticket.price: 10}),
+            Ticket({Ticket.name: "Seated", Ticket.price: 50}),
+            Ticket({Ticket.name: "VIP", Ticket.price: 100}),
+        )
+
+    async def test_string_values(self):
+        response = await Ticket.select(
+            Ticket.name,
+            Case(
+                When(Ticket.price >= 100, then="expensive"),
+                When(Ticket.price >= 50, then="mid range"),
+                default="cheap",
+                alias="price_band",
+            ),
+        ).order_by(Ticket.price)
+
+        self.assertListEqual(
+            response,
+            [
+                {"name": "Standing", "price_band": "cheap"},
+                {"name": "Seated", "price_band": "mid range"},
+                {"name": "VIP", "price_band": "expensive"},
+            ],
+        )
+
+    async def test_integer_values(self):
+        """
+        Make sure integers work - Postgres can't infer the type of a bare
+        query parameter inside a ``CASE`` statement.
+        """
+        response = await Ticket.select(
+            Ticket.name,
+            Case(
+                When(Ticket.price >= 50, then=1),
+                default=0,
+                alias="is_pricey",
+            ),
+        ).order_by(Ticket.price)
+
+        self.assertListEqual(
+            response,
+            [
+                {"name": "Standing", "is_pricey": 0},
+                {"name": "Seated", "is_pricey": 1},
+                {"name": "VIP", "is_pricey": 1},
+            ],
+        )
+
+    async def test_no_default(self):
+        """
+        If no ``default`` is given, then null should be returned.
+        """
+        response = await Ticket.select(
+            Ticket.name,
+            Case(
+                When(Ticket.price >= 100, then="expensive"),
+                alias="price_band",
+            ),
+        ).order_by(Ticket.price)
+
+        self.assertListEqual(
+            response,
+            [
+                {"name": "Standing", "price_band": None},
+                {"name": "Seated", "price_band": None},
+                {"name": "VIP", "price_band": "expensive"},
+            ],
+        )
+
+    async def test_combined_condition(self):
+        """
+        Make sure ``and`` / ``or`` conditions work.
+        """
+        response = await Ticket.select(
+            Ticket.name,
+            Case(
+                When(
+                    (Ticket.price >= 50) & (Ticket.name == "Seated"),
+                    then=True,
+                ),
+                default=False,
+                alias="matched",
+            ),
+        ).order_by(Ticket.price)
+
+        self.assertListEqual(
+            response,
+            [
+                {"name": "Standing", "matched": False},
+                {"name": "Seated", "matched": True},
+                {"name": "VIP", "matched": False},
+            ],
+        )
+
+    async def test_column_value(self):
+        """
+        Make sure a column can be returned by a branch.
+        """
+        response = await Ticket.select(
+            Ticket.name,
+            Case(
+                When(Ticket.price >= 50, then=Ticket.price),
+                default=0,
+                alias="premium_price",
+            ),
+        ).order_by(Ticket.price)
+
+        self.assertListEqual(
+            response,
+            [
+                {"name": "Standing", "premium_price": 0},
+                {"name": "Seated", "premium_price": 50},
+                {"name": "VIP", "premium_price": 100},
+            ],
+        )
+
+    async def test_nested_function(self):
+        """
+        Make sure other functions can be used inside a ``Case``.
+        """
+        response = await Ticket.select(
+            Case(
+                When(Ticket.price >= 100, then=Upper(Ticket.name)),
+                default=Ticket.name,
+                alias="label",
+            ),
+        ).order_by(Ticket.price)
+
+        self.assertListEqual(
+            response,
+            [
+                {"label": "Standing"},
+                {"label": "Seated"},
+                {"label": "VIP"},
+            ],
+        )
+
+    async def test_where_clause(self):
+        """
+        Make sure a ``Case`` can be used in a where clause.
+        """
+        response = (
+            await Ticket.select(Ticket.name)
+            .where(
+                Case(
+                    When(Ticket.price >= 50, then=1),
+                    default=0,
+                )
+                == 1
+            )
+            .order_by(Ticket.price)
+        )
+
+        self.assertListEqual(
+            response,
+            [{"name": "Seated"}, {"name": "VIP"}],
+        )
+
+    async def test_order_by(self):
+        """
+        Make sure a ``Case`` can be used to sort the results.
+        """
+        response = await Ticket.select(Ticket.name).order_by(
+            Case(
+                When(Ticket.name == "Seated", then=1),
+                default=2,
+            ),
+            Ticket.name,
+        )
+
+        self.assertListEqual(
+            response,
+            [{"name": "Seated"}, {"name": "Standing"}, {"name": "VIP"}],
+        )
+
+    async def test_default_alias(self):
+        """
+        If no alias is given, then ``case`` should be used.
+        """
+        response = await Ticket.select(
+            Case(When(Ticket.price >= 100, then="expensive"))
+        ).order_by(Ticket.price)
+
+        self.assertListEqual(
+            response,
+            [
+                {"case": None},
+                {"case": None},
+                {"case": "expensive"},
+            ],
+        )
+
+
+class TestCaseValidation(TestCase):
+
+    def test_no_whens(self):
+        with self.assertRaises(ValueError):
+            Case(default=1)
+
+    def test_invalid_when(self):
+        with self.assertRaises(ValueError):
+            Case("not a when")  # type: ignore
+
+    def test_invalid_condition(self):
+        with self.assertRaises(ValueError):
+            When("not a condition", then=1)  # type: ignore


### PR DESCRIPTION
`piccolo.query.functions.conditional` has `Coalesce` and `NullIf`, but there's no
way to express a SQL `CASE` statement. This adds `Case` and `When`, in the same
style as the existing functions.

```python
from piccolo.query.functions import Case, When

await Band.select(
    Band.name,
    Case(
        When(Band.popularity > 900, then='super popular'),
        When(Band.popularity > 500, then='popular'),
        default='not popular',
        alias='popularity_label',
    ),
)
```

Because it's a `QueryString`, it also works in `where` clauses and `order_by`:

```python
await Band.select(Band.name).order_by(
    Case(
        When(Band.name == 'Rustaceans', then=1),
        default=2,
    )
)
```

### The one non-obvious bit: `THEN` values aren't always query parameters

Postgres can't infer the type of a bare parameter inside a `CASE`, so it assumes
`text`. If you bind an integer, asyncpg then rejects it before the query is even
sent:

```
CASE WHEN "band"."popularity" > $1 THEN $2 ELSE $3 END
asyncpg.exceptions.DataError: invalid input for query argument $2: 1 (expected str, got int)
```

Strings happen to work, which makes it an easy trap to fall into — the obvious
example works and the second one doesn't.

So `get_case_value_string` writes numbers, booleans and `None` into the SQL
directly, and parameterises everything else. There's no injection risk, as the
branch is only taken once the value is known to be a Python `int` / `float` /
`Decimal` / `bool` (non-finite floats and decimals fall back to a parameter).

Alternatives I considered, in case you'd prefer one of them:

* **Wrap the values in `Cast` automatically.** Needs a Python-type → SQL-type
  mapping which Piccolo doesn't have today, and the guesses are lossy (is an
  `int` an `INTEGER` or a `BIGINT`?). It's also risky on SQLite, where
  `CAST(? AS TIMESTAMP)` would mangle a datetime.
* **Leave it to the user.** `Cast`'s own docstring already documents this class
  of problem, so there's precedent — but it makes the most obvious `Case`
  example fail, which felt like the wrong default.

Happy to change it either way.

### Notes

* `default` is optional. Omitting it omits the `ELSE`, which is the same thing
  as `ELSE NULL` in SQL.
* `alias` defaults to `"case"`, matching how `Function` derives its default
  alias — without it Postgres and SQLite name the column differently.
* `When` accepts a where clause (`Where` / `WhereRaw` / `And` / `Or`) or a
  `QueryString`, and `then` / `default` accept a column, another function, or a
  plain value.

### Testing

Added `TestCaseFunction` and `TestCaseValidation` to
`tests/query/functions/test_conditional.py`. Passing on both engines locally
(Postgres 18 and SQLite):

```
$ ./scripts/test-postgres.sh tests/query/functions/test_conditional.py
15 passed

$ ./scripts/test-sqlite.sh tests/query/functions/test_conditional.py
15 passed
```

Also ran the full suite against Postgres — the only failure is
`tests/table/test_update.py::TestOperators::test_operators`, which fails on
`master` for me too.
