### PR TITLE
Add `ArrayOverlap` function (`&&`)

### DIFF
--- a/docs/src/piccolo/functions/array.rst
+++ b/docs/src/piccolo/functions/array.rst
@@ -8,6 +8,11 @@ ArrayCat
 
 .. autoclass:: ArrayCat
 
+ArrayOverlap
+------------
+
+.. autoclass:: ArrayOverlap
+
 ArrayAppend
 -----------
 

--- a/docs/src/piccolo/schema/column_types.rst
+++ b/docs/src/piccolo/schema/column_types.rst
@@ -444,6 +444,12 @@ all
 
 .. automethod:: Array.all
 
+=======
+overlap
+=======
+
+.. automethod:: Array.overlap
+
 ===
 cat
 ===

--- a/piccolo/columns/column_types.py
+++ b/piccolo/columns/column_types.py
@@ -2986,6 +2986,28 @@ class Array(Column):
 
         return ArrayAppend(array=self, value=value)
 
+    def overlap(self, value: ArrayType) -> QueryString:
+        """
+        A convenient way of accessing the
+        :class:`ArrayOverlap <piccolo.query.functions.array.ArrayOverlap>`
+        function.
+
+        Used in a ``where`` clause to find rows where the array has any
+        values in common with the given array.
+
+        .. code-block:: python
+
+            >>> await Ticket.select().where(
+            ...     Ticket.seat_numbers.overlap([510, 511])
+            ... )
+
+        .. note:: Postgres / CockroachDB only
+
+        """
+        from piccolo.query.functions.array import ArrayOverlap
+
+        return ArrayOverlap(array_1=self, array_2=value)
+
     def replace(
         self, old_value: ArrayItemType, new_value: ArrayItemType
     ) -> QueryString:

--- a/piccolo/query/functions/__init__.py
+++ b/piccolo/query/functions/__init__.py
@@ -2,6 +2,7 @@ from .aggregate import Avg, Count, Max, Min, Sum
 from .array import (
     ArrayAppend,
     ArrayCat,
+    ArrayOverlap,
     ArrayPrepend,
     ArrayRemove,
     ArrayReplace,
@@ -34,6 +35,7 @@ __all__ = (
     "Abs",
     "ArrayAppend",
     "ArrayCat",
+    "ArrayOverlap",
     "ArrayPrepend",
     "ArrayRemove",
     "ArrayReplace",

--- a/piccolo/query/functions/array.py
+++ b/piccolo/query/functions/array.py
@@ -142,10 +142,41 @@ class ArrayRemove(ArrayQueryString):
         super().__init__("array_remove({}, {})", array, value)
 
 
+class ArrayOverlap(QueryString):
+    def __init__(self, array_1: ArrayType, array_2: ArrayType):
+        """
+        Check whether two arrays have any values in common. This uses the
+        Postgres ``&&`` operator, and can make use of a GIN index, so it's
+        much faster than testing each value in turn.
+
+        .. code-block:: python
+
+            >>> await Ticket.select().where(
+            ...     ArrayOverlap(Ticket.seat_numbers, [510, 511])
+            ... )
+
+        :param array_1:
+            The first array.
+        :param array_2:
+            The second array.
+
+        """
+        for value in (array_1, array_2):
+            if isinstance(value, Column):
+                engine_type = value._meta.engine_type
+                if engine_type not in ("postgres", "cockroach"):
+                    raise ValueError(
+                        "Only Postgres and Cockroach support array overlap."
+                    )
+
+        super().__init__("{} && {}", array_1, array_2)
+
+
 __all__ = (
     "ArrayCat",
     "ArrayAppend",
     "ArrayPrepend",
     "ArrayReplace",
     "ArrayRemove",
+    "ArrayOverlap",
 )

--- a/tests/columns/test_array.py
+++ b/tests/columns/test_array.py
@@ -131,6 +131,82 @@ class TestArray(TableTest):
         )
 
     @engines_skip("sqlite")
+    def test_overlap(self):
+        """
+        Make sure rows can be retrieved where the array has values in common
+        with another array.
+        """
+        MyTable(value=[1, 2, 3]).save().run_sync()
+        MyTable(value=[4, 5, 6]).save().run_sync()
+
+        # We have to explicitly specify the type, so CockroachDB works.
+        self.assertEqual(
+            MyTable.select(MyTable.value)
+            .where(
+                MyTable.value.overlap(QueryString("{}::INTEGER[]", [3, 99]))
+            )
+            .run_sync(),
+            [{"value": [1, 2, 3]}],
+        )
+
+        self.assertEqual(
+            MyTable.select(MyTable.value)
+            .where(MyTable.value.overlap(QueryString("{}::INTEGER[]", [1, 6])))
+            .order_by(MyTable.value)
+            .run_sync(),
+            [{"value": [1, 2, 3]}, {"value": [4, 5, 6]}],
+        )
+
+        self.assertEqual(
+            MyTable.select(MyTable.value)
+            .where(MyTable.value.overlap(QueryString("{}::INTEGER[]", [99])))
+            .run_sync(),
+            [],
+        )
+
+    @engines_only("postgres")
+    def test_overlap_plain_list(self):
+        """
+        Postgres can infer the type of the array from the column, so a plain
+        Python list works too.
+        """
+        MyTable(value=[1, 2, 3]).save().run_sync()
+
+        self.assertEqual(
+            MyTable.select(MyTable.value)
+            .where(MyTable.value.overlap([3, 99]))
+            .run_sync(),
+            [{"value": [1, 2, 3]}],
+        )
+
+    @engines_skip("sqlite")
+    def test_overlap_two_columns(self):
+        """
+        Make sure two array columns can be compared.
+        """
+        MyTable(value=[1, 2, 3]).save().run_sync()
+
+        self.assertEqual(
+            MyTable.select(MyTable.value)
+            .where(MyTable.value.overlap(MyTable.value))
+            .run_sync(),
+            [{"value": [1, 2, 3]}],
+        )
+
+    @sqlite_only
+    def test_overlap_sqlite(self):
+        """
+        If using SQLite then an exception should be raised currently.
+        """
+        with self.assertRaises(ValueError) as manager:
+            MyTable.value.overlap([2])
+
+        self.assertEqual(
+            str(manager.exception),
+            "Only Postgres and Cockroach support array overlap.",
+        )
+
+    @engines_skip("sqlite")
     def test_cat(self):
         """
         Make sure values can be appended to an array and that we can


### PR DESCRIPTION
`piccolo.query.functions.array` covers `array_cat`, `array_append`,
`array_prepend`, `array_replace` and `array_remove`, but not the `&&` overlap
operator.

The gap it fills: "does this array contain any of these values?". Today that has
to be written as an `OR` of `any()` calls, one per value, which can't use a GIN
index. `&&` is a single indexable test.

```python
from piccolo.query.functions import ArrayOverlap

await Ticket.select().where(
    ArrayOverlap(Ticket.seat_numbers, [510, 511])
)
```

There's also a column method, matching `cat` / `remove` / `append` / `prepend` /
`replace`:

```python
await Ticket.select().where(Ticket.seat_numbers.overlap([510, 511]))
```

### Notes

* Postgres / CockroachDB only, raising the same `ValueError` on SQLite as the
  other array functions.
* `ArrayOverlap` subclasses `QueryString` rather than `ArrayQueryString` —
  `ArrayQueryString` overrides `__add__` / `__radd__` to mean concatenation,
  which doesn't apply here as `&&` returns a boolean, not an array.
* On CockroachDB the array needs an explicit type, the same as `any()` /
  `not_any()` — the tests use `QueryString("{}::INTEGER[]", [...])` for that
  reason. On Postgres a plain list works, since the type is inferred from the
  column.

### Testing

Added `test_overlap`, `test_overlap_plain_list`, `test_overlap_two_columns` and
`test_overlap_sqlite` to `tests/columns/test_array.py`:

```
$ ./scripts/test-postgres.sh tests/columns/test_array.py
18 passed, 6 skipped

$ ./scripts/test-sqlite.sh tests/columns/test_array.py
12 passed, 12 skipped
```

I don't have a CockroachDB instance to hand, so that path is untested beyond
following the existing convention.
