### PR TITLE
Reverse relations - `get_related_objects` and `prefetch_related`

### DIFF
--- a/docs/src/piccolo/query_types/objects.rst
+++ b/docs/src/piccolo/query_types/objects.rst
@@ -242,6 +242,91 @@ prefer.
         Ticket.concert.all_related()
     ).first()
 
+``get_related_objects``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``get_related`` follows a :class:`ForeignKey <piccolo.columns.column_types.ForeignKey>`
+forwards. To go the other way - to get every row whose foreign key points at
+this one - use ``get_related_objects``.
+
+.. code-block:: python
+
+    manager = await Manager.objects().where(
+        Manager.name == 'Guido'
+    ).first()
+
+    >>> await manager.get_related_objects(Band.manager)
+    [<Band: 1>]
+
+A query is returned rather than the rows themselves, so you can narrow it down
+like any other:
+
+.. code-block:: python
+
+    await manager.get_related_objects(Band.manager).where(
+        Band.popularity > 500
+    )
+
+Each reverse relation also has an accessor name, which is derived from the
+tablename containing the foreign key. It's handy when the other table isn't
+imported:
+
+.. code-block:: python
+
+    >>> await manager.band_set
+    [<Band: 1>]
+
+    # The same thing, spelled out:
+    >>> await manager.get_related_objects('band_set')
+    [<Band: 1>]
+
+The names are listed on the table's metadata:
+
+.. code-block:: python
+
+    >>> Manager._meta.reverse_relations
+    {'band_manager_set': Band.manager, 'band_set': Band.manager}
+
+Each relation gets a name including the column (``band_manager_set``), and a
+shorter one without it (``band_set``). The shorter name is only added when it's
+unambiguous - if a table has two foreign keys pointing at this one, only the
+longer names are available.
+
+``prefetch_related``
+~~~~~~~~~~~~~~~~~~~~
+
+Fetching a reverse relation for each row in a loop means a query per row.
+``prefetch_related`` fetches them all in one go instead:
+
+.. code-block:: python
+
+    # 2 queries in total, no matter how many managers there are:
+    managers = await Manager.objects().prefetch_related(Band.manager)
+
+    for manager in managers:
+        print(await manager.band_set)
+
+Each row keeps its own related rows, so accessing the relation afterwards
+doesn't hit the database again. Narrowing the relation in any way runs a
+query, as the prefetched rows can't answer it:
+
+.. code-block:: python
+
+    # Answered from memory:
+    await manager.band_set
+
+    # Runs a query:
+    await manager.band_set.where(Band.popularity > 500)
+
+If you already have the rows, you can prefetch them directly:
+
+.. code-block:: python
+
+    from piccolo.query.methods.objects import prefetch_related
+
+    managers = await Manager.objects()
+    await prefetch_related(managers, Band.manager)
+
 -------------------------------------------------------------------------------
 
 ``get_or_create``

--- a/piccolo/query/methods/objects.py
+++ b/piccolo/query/methods/objects.py
@@ -29,6 +29,7 @@ from piccolo.query.mixins import (
     OrderByDelegate,
     OutputDelegate,
     PrefetchDelegate,
+    PrefetchRelatedDelegate,
     WhereDelegate,
 )
 from piccolo.query.proxy import Proxy
@@ -298,6 +299,72 @@ class GetRelated(Generic[ReferencedTable]):
 ###############################################################################
 
 
+def get_relation_key(foreign_key: ForeignKey) -> str:
+    """
+    A unique name for a reverse relation, which is used to cache the related
+    rows on a ``Table`` instance.
+    """
+    return (
+        f"{foreign_key._meta.table._meta.tablename}."
+        f"{foreign_key._meta.name}"
+    )
+
+
+async def prefetch_related(
+    rows: Sequence[Table],
+    *foreign_keys: ForeignKey,
+    node: Optional[str] = None,
+    in_pool: bool = True,
+) -> None:
+    """
+    Fetch reverse relations for lots of rows at once, using a single query per
+    relation, rather than one query per row.
+
+    .. code-block:: python
+
+        managers = await Manager.objects()
+        await prefetch_related(managers, Band.manager)
+
+        # No additional queries are run:
+        for manager in managers:
+            print(await manager.band_set)
+
+    Most of the time you won't need to call this directly - use
+    :meth:`Objects.prefetch_related` instead.
+
+    :param rows:
+        The rows which the foreign keys point at.
+    :param foreign_keys:
+        The foreign key columns to follow backwards.
+
+    """
+    if not rows:
+        return
+
+    primary_key_name = rows[0]._meta.primary_key._meta.name
+    primary_key_values = [getattr(row, primary_key_name) for row in rows]
+
+    for foreign_key in foreign_keys:
+        related_rows = (
+            await foreign_key._meta.table.objects()
+            .where(foreign_key.is_in(primary_key_values))
+            .run(node=node, in_pool=in_pool)
+        )
+
+        grouped: dict[Any, list[Table]] = {}
+        for related_row in related_rows:
+            grouped.setdefault(
+                getattr(related_row, foreign_key._meta.name), []
+            ).append(related_row)
+
+        relation_key = get_relation_key(foreign_key)
+
+        for row in rows:
+            row._prefetched_relations[relation_key] = grouped.get(
+                getattr(row, primary_key_name), []
+            )
+
+
 class Objects(
     Query[TableInstance, list[TableInstance]], Generic[TableInstance]
 ):
@@ -315,8 +382,10 @@ class Objects(
         "output_delegate",
         "callback_delegate",
         "prefetch_delegate",
+        "prefetch_related_delegate",
         "where_delegate",
         "lock_rows_delegate",
+        "_prefetched_results",
     )
 
     def __init__(
@@ -335,10 +404,17 @@ class Objects(
         self.callback_delegate = CallbackDelegate()
         self.prefetch_delegate = PrefetchDelegate()
         self.prefetch(*prefetch)
+        self.prefetch_related_delegate = PrefetchRelatedDelegate()
         self.where_delegate = WhereDelegate()
         self.lock_rows_delegate = LockRowsDelegate()
 
+        # If this query was returned by `Table.get_related_objects`, and the
+        # rows were already fetched by `prefetch_related`, then they're stored
+        # here so we don't have to query the database again.
+        self._prefetched_results: Optional[list[TableInstance]] = None
+
     def output(self: Self, load_json: bool = False) -> Self:
+        self._discard_prefetched_results()
         self.output_delegate.output(
             as_list=False, as_json=False, load_json=load_json
         )
@@ -350,26 +426,57 @@ class Objects(
         *,
         on: CallbackType = CallbackType.success,
     ) -> Self:
+        self._discard_prefetched_results()
         self.callback_delegate.callback(callbacks, on=on)
         return self
 
     def as_of(self, interval: str = "-1s") -> Objects:
         if self.engine_type != "cockroach":
             raise NotImplementedError("Only CockroachDB supports AS OF")
+        self._discard_prefetched_results()
         self.as_of_delegate.as_of(interval)
         return self
 
     def limit(self: Self, number: int) -> Self:
+        self._discard_prefetched_results()
         self.limit_delegate.limit(number)
         return self
 
     def prefetch(
         self: Self, *fk_columns: Union[ForeignKey, list[ForeignKey]]
     ) -> Self:
+        self._discard_prefetched_results()
         self.prefetch_delegate.prefetch(*fk_columns)
         return self
 
+    def prefetch_related(self: Self, *foreign_keys: ForeignKey) -> Self:
+        """
+        Fetch reverse relations for every row returned by this query, using a
+        single extra query per relation instead of one query per row.
+
+        .. code-block:: python
+
+            # 2 queries in total, no matter how many managers there are:
+            managers = await Manager.objects().prefetch_related(Band.manager)
+
+            for manager in managers:
+                print(await manager.band_set)
+
+        Each row keeps its own related rows, so accessing the relation
+        afterwards doesn't hit the database again. Narrowing the relation in
+        any way (with ``where``, ``order_by``, ``limit`` etc.) runs a query, as
+        the prefetched rows can't answer it.
+
+        :param foreign_keys:
+            The foreign key columns which point at this table.
+
+        """
+        self._discard_prefetched_results()
+        self.prefetch_related_delegate.prefetch_related(*foreign_keys)
+        return self
+
     def offset(self: Self, number: int) -> Self:
+        self._discard_prefetched_results()
         self.offset_delegate.offset(number)
         return self
 
@@ -383,12 +490,21 @@ class Objects(
             else:
                 _columns.append(column)
 
+        self._discard_prefetched_results()
         self.order_by_delegate.order_by(*_columns, ascending=ascending)
         return self
 
     def where(self: Self, *where: Union[Combinable, QueryString]) -> Self:
+        self._discard_prefetched_results()
         self.where_delegate.where(*where)
         return self
+
+    def _discard_prefetched_results(self) -> None:
+        """
+        Any change to the query means the rows cached by ``prefetch_related``
+        can no longer answer it.
+        """
+        self._prefetched_results = None
 
     ###########################################################################
 
@@ -411,12 +527,14 @@ class Objects(
         skip_locked: bool = False,
         of: tuple[type[Table], ...] = (),
     ) -> Self:
+        self._discard_prefetched_results()
         self.lock_rows_delegate.lock_rows(
             lock_strength, nowait, skip_locked, of
         )
         return self
 
     def get(self, where: Combinable) -> Get[TableInstance]:
+        self._discard_prefetched_results()
         self.where_delegate.where(where)
         self.limit_delegate.limit(1)
         return Get[TableInstance](query=First[TableInstance](query=self))
@@ -494,7 +612,18 @@ class Objects(
         in_pool: bool = True,
         use_callbacks: bool = True,
     ) -> list[TableInstance]:
-        results = await super().run(node=node, in_pool=in_pool)
+        if self._prefetched_results is not None:
+            results = self._prefetched_results
+        else:
+            results = await super().run(node=node, in_pool=in_pool)
+
+            if self.prefetch_related_delegate.foreign_keys:
+                await prefetch_related(
+                    results,
+                    *self.prefetch_related_delegate.foreign_keys,
+                    node=node,
+                    in_pool=in_pool,
+                )
 
         if use_callbacks:
             # With callbacks, the user can return any data that they want.

--- a/piccolo/query/mixins.py
+++ b/piccolo/query/mixins.py
@@ -471,6 +471,21 @@ class CallbackDelegate:
 
 
 @dataclass
+class PrefetchRelatedDelegate:
+    """
+    Example usage:
+
+    .prefetch_related(Band.manager)
+    """
+
+    foreign_keys: list[ForeignKey] = field(default_factory=list)
+
+    def prefetch_related(self, *foreign_keys: ForeignKey):
+        combined = [*self.foreign_keys, *foreign_keys]
+        self.foreign_keys = combined
+
+
+@dataclass
 class PrefetchDelegate:
     """
     Example usage:

--- a/piccolo/table.py
+++ b/piccolo/table.py
@@ -48,7 +48,11 @@ from piccolo.query import (
 )
 from piccolo.query.methods.create_index import CreateIndex
 from piccolo.query.methods.indexes import Indexes
-from piccolo.query.methods.objects import GetRelated, UpdateSelf
+from piccolo.query.methods.objects import (
+    GetRelated,
+    UpdateSelf,
+    get_relation_key,
+)
 from piccolo.query.methods.refresh import Refresh
 from piccolo.querystring import QueryString
 from piccolo.utils import _camel_to_snake
@@ -67,6 +71,9 @@ TABLENAME_WARNING = (
 
 
 TABLE_REGISTRY: list[type[Table]] = []
+
+# The suffix used for reverse relation accessor names - e.g. `band_set`.
+REVERSE_RELATION_SUFFIX = "_set"
 
 
 @dataclass
@@ -130,6 +137,53 @@ class TableMeta:
         foreign_keys.extend(lazy_column_references)
 
         return foreign_keys
+
+    @property
+    def reverse_relations(self) -> dict[str, ForeignKey]:
+        """
+        Maps an accessor name to the ``ForeignKey`` column which points at
+        this table. It's the reverse of ``foreign_key_columns``.
+
+        The names follow the same convention as Django - the tablename of the
+        table containing the foreign key, followed by ``_set``::
+
+            class Manager(Table):
+                name = Varchar()
+
+            class Band(Table):
+                name = Varchar()
+                manager = ForeignKey(Manager)
+
+            >>> Manager._meta.reverse_relations
+            {'band_manager_set': Band.manager, 'band_set': Band.manager}
+
+        Each relation gets a name which includes the column
+        (``band_manager_set``), and a shorter one which doesn't
+        (``band_set``). The shorter name is only added when it's unambiguous -
+        if a table has two foreign keys pointing at this one, then only the
+        longer names are available for them.
+
+        """
+        foreign_keys = self.foreign_key_references
+
+        counts: dict[str, int] = {}
+        for foreign_key in foreign_keys:
+            tablename = foreign_key._meta.table._meta.tablename
+            counts[tablename] = counts.get(tablename, 0) + 1
+
+        relations: dict[str, ForeignKey] = {}
+        for foreign_key in foreign_keys:
+            tablename = foreign_key._meta.table._meta.tablename
+            column_name = foreign_key._meta.name
+            relations[
+                f"{tablename}_{column_name}{REVERSE_RELATION_SUFFIX}"
+            ] = foreign_key
+            if counts[tablename] == 1:
+                relations[f"{tablename}{REVERSE_RELATION_SUFFIX}"] = (
+                    foreign_key
+                )
+
+        return relations
 
     @property
     def db(self) -> Engine:
@@ -457,6 +511,10 @@ class Table(metaclass=TableMetaclass):
         # was an existing row or not.
         self._was_created: Optional[bool] = None
 
+        # Populated by `prefetch_related` - maps a reverse relation to the
+        # rows belonging to this one.
+        self._prefetched_relations: dict[str, list[Table]] = {}
+
         for column in self._meta.columns:
             value = _data.get(column, ...)
 
@@ -689,6 +747,101 @@ class Table(metaclass=TableMetaclass):
             )
 
         return GetRelated(foreign_key=foreign_key, row=self)
+
+    def get_related_objects(
+        self, foreign_key: Union[str, ForeignKey]
+    ) -> Objects:
+        """
+        The reverse of :meth:`get_related` - it returns a query for all of the
+        rows whose foreign key points at this one.
+
+        .. code-block:: python
+
+            manager = await Manager.objects().get(Manager.name == 'Guido')
+
+            >>> await manager.get_related_objects(Band.manager)
+            [<Band: 1>]
+
+        A query is returned rather than the rows themselves, so it can be
+        narrowed down like any other::
+
+            >>> await manager.get_related_objects(Band.manager).where(
+            ...     Band.popularity > 500
+            ... )
+
+        The accessor name can be used instead of the column, which is useful
+        when the table containing the foreign key isn't imported::
+
+            >>> await manager.get_related_objects('band_set')
+
+        See :attr:`TableMeta.reverse_relations` for how the accessor names are
+        derived. Attribute access works too - ``manager.band_set`` is the same
+        as ``manager.get_related_objects('band_set')``.
+
+        :param foreign_key:
+            A ``ForeignKey`` column which points at this table, or the name of
+            a reverse relation.
+        :raises ValueError:
+            If the foreign key doesn't point at this table, or the row hasn't
+            been saved to the database yet.
+
+        """
+        if isinstance(foreign_key, str):
+            reverse_relations = self._meta.reverse_relations
+            if foreign_key not in reverse_relations:
+                raise ValueError(
+                    f"{foreign_key} isn't a reverse relation of "
+                    f"{self._meta.tablename}. The options are: "
+                    f"{', '.join(sorted(reverse_relations))}"
+                )
+            foreign_key = reverse_relations[foreign_key]
+
+        if not isinstance(foreign_key, ForeignKey):
+            raise ValueError(
+                "foreign_key isn't a ForeignKey instance, or the name of a "
+                "reverse relation."
+            )
+
+        references = foreign_key._foreign_key_meta.resolved_references
+        if references._meta.tablename != self._meta.tablename:
+            raise ValueError(
+                f"{foreign_key} doesn't reference {self._meta.tablename}."
+            )
+
+        primary_key_value = getattr(self, self._meta.primary_key._meta.name)
+        if primary_key_value is None or isinstance(
+            primary_key_value, QueryString
+        ):
+            # An unsaved row with a `Serial` primary key has a `QueryString`
+            # (`DEFAULT`) as its value.
+            raise ValueError("The object doesn't exist in the database.")
+
+        query = foreign_key._meta.table.objects().where(
+            foreign_key == primary_key_value
+        )
+        query._prefetched_results = getattr(
+            self, "_prefetched_relations", {}
+        ).get(get_relation_key(foreign_key))
+        return query
+
+    def __getattr__(self, name: str) -> Objects:
+        """
+        Reverse relations are resolved here, as they're not real attributes -
+        for example ``manager.band_set``. See
+        :meth:`get_related_objects`.
+        """
+        if name.startswith("_"):
+            raise AttributeError(name)
+
+        reverse_relations = self._meta.reverse_relations
+        if name not in reverse_relations:
+            raise AttributeError(
+                f"{self.__class__.__name__} has no attribute {name!r}. Its "
+                f"reverse relations are: "
+                f"{', '.join(sorted(reverse_relations))}"
+            )
+
+        return self.get_related_objects(reverse_relations[name])
 
     def get_m2m(self, m2m: M2M) -> M2MGetRelated:
         """

--- a/tests/table/test_reverse_relations.py
+++ b/tests/table/test_reverse_relations.py
@@ -1,0 +1,325 @@
+from unittest import TestCase
+
+from piccolo.columns import ForeignKey, Integer, Varchar
+from piccolo.query.methods.objects import prefetch_related
+from piccolo.table import Table
+from piccolo.testing.test_case import AsyncTableTest
+
+
+class Retailer(Table):
+    name = Varchar()
+
+
+class Product(Table):
+    name = Varchar()
+    retailer = ForeignKey(Retailer)
+    price = Integer(default=0)
+
+
+class Trade(Table):
+    """
+    Has two foreign keys pointing at the same table.
+    """
+
+    buyer = ForeignKey(Retailer)
+    seller = ForeignKey(Retailer)
+
+
+class Rating(Table):
+    product = ForeignKey(Product)
+    stars = Integer(default=0)
+
+
+class TestReverseRelations(TestCase):
+
+    def test_names(self):
+        """
+        Each relation should have a name which includes the column, and a
+        shorter one which doesn't.
+        """
+        self.assertEqual(
+            Product._meta.reverse_relations,
+            {
+                "rating_product_set": Rating.product,
+                "rating_set": Rating.product,
+            },
+        )
+
+    def test_ambiguous_names(self):
+        """
+        If a table has two foreign keys pointing at this one, then only the
+        names which include the column should be available for them.
+        """
+        self.assertEqual(
+            Retailer._meta.reverse_relations,
+            {
+                "product_retailer_set": Product.retailer,
+                "product_set": Product.retailer,
+                "trade_buyer_set": Trade.buyer,
+                "trade_seller_set": Trade.seller,
+            },
+        )
+
+    def test_no_reverse_relations(self):
+        """
+        A table which nothing points at should have no reverse relations.
+        """
+        self.assertEqual(Rating._meta.reverse_relations, {})
+
+
+class TestGetRelatedObjects(AsyncTableTest):
+
+    tables = [Retailer, Product]
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+
+        self.retailer = Retailer({Retailer.name: "Acme"})
+        await self.retailer.save()
+
+        self.other_retailer = Retailer({Retailer.name: "Globex"})
+        await self.other_retailer.save()
+
+        await Product.insert(
+            Product(
+                {
+                    Product.name: "Anvil",
+                    Product.retailer: self.retailer,
+                    Product.price: 100,
+                }
+            ),
+            Product(
+                {
+                    Product.name: "Rocket",
+                    Product.retailer: self.retailer,
+                    Product.price: 10,
+                }
+            ),
+            Product(
+                {
+                    Product.name: "Widget",
+                    Product.retailer: self.other_retailer,
+                    Product.price: 50,
+                }
+            ),
+        )
+
+    async def test_get_related_objects(self):
+        products = await self.retailer.get_related_objects(Product.retailer)
+
+        self.assertListEqual(
+            sorted(product.name for product in products),
+            ["Anvil", "Rocket"],
+        )
+
+    async def test_accessor_name(self):
+        """
+        Passing in the accessor name should be the same as passing in the
+        column.
+        """
+        products = await self.retailer.get_related_objects("product_set")
+
+        self.assertListEqual(
+            sorted(product.name for product in products),
+            ["Anvil", "Rocket"],
+        )
+
+    async def test_attribute_access(self):
+        """
+        The accessor names should also work as attributes.
+        """
+        for products in (
+            await self.retailer.product_set,
+            await self.retailer.product_retailer_set,
+        ):
+            self.assertListEqual(
+                sorted(product.name for product in products),
+                ["Anvil", "Rocket"],
+            )
+
+    async def test_query_is_lazy(self):
+        """
+        A query should be returned, so it can be narrowed down.
+        """
+        products = await self.retailer.product_set.where(Product.price > 50)
+
+        self.assertListEqual([product.name for product in products], ["Anvil"])
+
+    async def test_unknown_attribute(self):
+        with self.assertRaises(AttributeError):
+            self.retailer.abc123
+
+    async def test_unknown_accessor_name(self):
+        with self.assertRaises(ValueError):
+            self.retailer.get_related_objects("abc123")
+
+    async def test_not_a_foreign_key(self):
+        with self.assertRaises(ValueError):
+            self.retailer.get_related_objects(Product.name)  # type: ignore
+
+    async def test_wrong_table(self):
+        """
+        The foreign key has to point at this table.
+        """
+        with self.assertRaises(ValueError):
+            self.retailer.get_related_objects(Rating.product)
+
+    async def test_not_in_database(self):
+        """
+        A row which hasn't been saved has no primary key to match on.
+        """
+        with self.assertRaises(ValueError):
+            Retailer({Retailer.name: "Initech"}).get_related_objects(
+                Product.retailer
+            )
+
+
+class TestPrefetchRelated(AsyncTableTest):
+
+    tables = [Retailer, Product]
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+
+        self.retailer = Retailer({Retailer.name: "Acme"})
+        await self.retailer.save()
+
+        self.other_retailer = Retailer({Retailer.name: "Globex"})
+        await self.other_retailer.save()
+
+        await Product.insert(
+            Product(
+                {
+                    Product.name: "Anvil",
+                    Product.retailer: self.retailer,
+                    Product.price: 100,
+                }
+            ),
+            Product(
+                {
+                    Product.name: "Rocket",
+                    Product.retailer: self.retailer,
+                    Product.price: 10,
+                }
+            ),
+            Product(
+                {
+                    Product.name: "Widget",
+                    Product.retailer: self.other_retailer,
+                    Product.price: 50,
+                }
+            ),
+        )
+
+    async def get_response(self, retailers) -> dict:
+        return {
+            retailer.name: sorted(
+                product.name for product in await retailer.product_set
+            )
+            for retailer in retailers
+        }
+
+    async def test_prefetch_related(self):
+        retailers = await Retailer.objects().prefetch_related(Product.retailer)
+
+        self.assertDictEqual(
+            await self.get_response(retailers),
+            {"Acme": ["Anvil", "Rocket"], "Globex": ["Widget"]},
+        )
+
+    async def test_no_extra_queries(self):
+        """
+        Once prefetched, accessing the relation shouldn't hit the database.
+        """
+        retailers = await Retailer.objects().prefetch_related(Product.retailer)
+
+        # If the database is queried again, we'll get an empty response.
+        await Product.delete(force=True)
+
+        self.assertDictEqual(
+            await self.get_response(retailers),
+            {"Acme": ["Anvil", "Rocket"], "Globex": ["Widget"]},
+        )
+
+    async def test_narrowing_bypasses_the_cache(self):
+        """
+        Any change to the query means the prefetched rows can no longer
+        answer it.
+        """
+        retailers = await Retailer.objects().prefetch_related(Product.retailer)
+        retailer = [i for i in retailers if i.name == "Acme"][0]
+
+        products = await retailer.product_set.where(Product.price > 50)
+        self.assertListEqual([product.name for product in products], ["Anvil"])
+
+        await Product.delete(force=True)
+
+        products = await retailer.product_set.where(Product.price > 50)
+        self.assertListEqual(products, [])
+
+    async def test_no_related_rows(self):
+        """
+        A row with no related rows should get an empty list, rather than an
+        error.
+        """
+        retailer = Retailer({Retailer.name: "Initech"})
+        await retailer.save()
+
+        retailers = await Retailer.objects().prefetch_related(Product.retailer)
+        initech = [i for i in retailers if i.name == "Initech"][0]
+
+        self.assertListEqual(await initech.product_set, [])
+
+    async def test_standalone_function(self):
+        """
+        ``prefetch_related`` can also be called with rows we already have.
+        """
+        retailers = await Retailer.objects()
+        await prefetch_related(retailers, Product.retailer)
+
+        await Product.delete(force=True)
+
+        self.assertDictEqual(
+            await self.get_response(retailers),
+            {"Acme": ["Anvil", "Rocket"], "Globex": ["Widget"]},
+        )
+
+    async def test_no_rows(self):
+        """
+        Prefetching with no rows shouldn't run any queries.
+        """
+        await prefetch_related([], Product.retailer)
+
+
+class TestPrefetchMultipleRelations(AsyncTableTest):
+
+    tables = [Retailer, Trade]
+
+    async def test_multiple_relations(self):
+        """
+        More than one relation can be prefetched at a time, including two
+        which come from the same table.
+        """
+        buyer = Retailer({Retailer.name: "Acme"})
+        await buyer.save()
+
+        seller = Retailer({Retailer.name: "Globex"})
+        await seller.save()
+
+        await Trade({Trade.buyer: buyer, Trade.seller: seller}).save()
+
+        retailers = await Retailer.objects().prefetch_related(
+            Trade.buyer, Trade.seller
+        )
+
+        await Trade.delete(force=True)
+
+        response = {
+            retailer.name: (
+                len(await retailer.trade_buyer_set),
+                len(await retailer.trade_seller_set),
+            )
+            for retailer in retailers
+        }
+
+        self.assertDictEqual(response, {"Acme": (1, 0), "Globex": (0, 1)})


### PR DESCRIPTION
Closes #378 (if the API looks right to you).

Piccolo already records inbound foreign keys on
`Table._meta.foreign_key_references`, but there's no way to walk them, so
"give me every band this manager manages" means writing the query by hand every
time. This adds three things on top of what's already there, and needs no
change to anyone's schema.

### 1. `Table._meta.reverse_relations`

Accessor name → the `ForeignKey` which points at this table.

```python
>>> Manager._meta.reverse_relations
{'band_manager_set': Band.manager, 'band_set': Band.manager}
```

Each relation gets a name which includes the column (`band_manager_set`), and a
shorter one which doesn't (`band_set`). The shorter name is only added when it's
unambiguous — a table with two foreign keys pointing here (`Concert.band_1` /
`Concert.band_2`) only gets the long names, so nothing silently resolves to the
wrong column.

### 2. `get_related_objects` — the reverse of `get_related`

```python
manager = await Manager.objects().where(Manager.name == 'Guido').first()

>>> await manager.get_related_objects(Band.manager)
[<Band: 1>]
```

It returns a **query**, not rows, so it composes:

```python
await manager.get_related_objects(Band.manager).where(Band.popularity > 500)
```

The accessor name works too, which helps when the other table isn't imported —
and it's also available as an attribute:

```python
>>> await manager.get_related_objects('band_set')
>>> await manager.band_set
```

### 3. `prefetch_related` — one query per relation, not one per row

```python
# 2 queries in total, however many managers there are:
managers = await Manager.objects().prefetch_related(Band.manager)

for manager in managers:
    print(await manager.band_set)
```

Measured on 25 managers with a band each, counting calls to
`run_querystring`:

```
without prefetch_related: 26 queries
with prefetch_related: 2 queries
```

Each row keeps its own related rows. Accessing the relation afterwards is
answered from memory; **narrowing it in any way goes back to the database**,
because the prefetched rows can't answer a different question. That's Django's
rule for `.all()` vs `.filter()` on a prefetched related manager.

There's also a standalone `prefetch_related(rows, *foreign_keys)` for when you
already have the rows.

### Design decisions I'd like your call on

I've picked a default for each of these rather than block on them, and none is
hard to change.

1. **Accessor naming.** I used Django's `<tablename>_set`, plus a
   column-qualified `<tablename>_<column>_set`. The alternative is to offer only
   the qualified form (never ambiguous, uglier), or nothing automatic at all.
2. **`related_name` / `reverse_lookup`.** In #378 you suggested
   `ForeignKey(Manager, reverse_lookup='bands')`, mainly for tab completion. I've
   deliberately left that out — it's a new `ForeignKey` param, which means
   migration serialisation, and it can be added later on top of this without
   breaking the derived names. Say the word if you'd rather have it in from the
   start.
3. **The `__getattr__` accessor.** `manager.band_set` needs `Table.__getattr__`,
   which Piccolo doesn't currently have. It bails out immediately on any name
   starting with `_`, so dunder lookups (pickle, copy) are unaffected, and it
   raises `AttributeError` listing the available relations otherwise. If you'd
   rather not have any attribute magic on `Table`, dropping it leaves
   `get_related_objects` working exactly as it does now.
4. **Prefetch cache semantics.** The cache lives on the `Objects` query
   (`_prefetched_results`) and is discarded by every method which changes the
   query. That means one extra line in `where`, `order_by`, `limit`, `offset`,
   `prefetch`, `output`, `callback`, `as_of`, `lock_rows` and `get` — the least
   invasive alternative I found. Happy to move it into a subclass of `Objects`
   returned only by `get_related_objects` if you'd prefer `Objects` untouched.
5. **Scope.** `prefetch_related` could be a follow-up PR. I've kept it here
   because without it the accessor is an N+1 waiting to happen, but I'm happy to
   split it.

### Relationship to the earlier attempt

#599 approached this from the select side (`Manager.select(Manager.artists())`,
modelled on `M2M`) and needed a `ReverseLookup` declared on the table. This is
the objects-side equivalent instead, derived from the foreign keys which are
already registered — so existing tables get it without any schema change. The
two aren't mutually exclusive.

### Testing

New file: `tests/table/test_reverse_relations.py` (19 tests). It defines its own
tables rather than using the music example app, because
`foreign_key_references` accumulates globally and several test modules define
throwaway tables with the same tablenames.

```
$ ./scripts/test-postgres.sh tests/table/test_reverse_relations.py
19 passed

$ ./scripts/test-sqlite.sh tests/table/test_reverse_relations.py
19 passed
```

Full suite:

```
$ ./scripts/test-postgres.sh
1 failed, 902 passed, 33 skipped

$ ./scripts/test-sqlite.sh
736 passed, 200 skipped
```

The one Postgres failure is `tests/table/test_update.py::TestOperators::test_operators`,
which fails on `master` for me too.
