### PR TITLE
Add Postgres full text search functions

### DIFF
--- a/docs/src/piccolo/functions/index.rst
+++ b/docs/src/piccolo/functions/index.rst
@@ -17,5 +17,6 @@ Functions can be used to modify how queries are run, and what is returned.
     ./datetime
     ./math
     ./string
+    ./text_search
     ./type_conversion
     ./custom

--- a/docs/src/piccolo/functions/text_search.rst
+++ b/docs/src/piccolo/functions/text_search.rst
@@ -1,0 +1,52 @@
+Text search functions
+=====================
+
+.. currentmodule:: piccolo.query.functions.text_search
+
+.. note:: Postgres only. SQLite has its own, unrelated FTS extension, and
+    CockroachDB's support is incomplete. Passing a column belonging to any
+    other engine into these functions raises a ``ValueError``.
+
+Postgres full text search works in two steps - the text being searched is
+converted into a ``tsvector``, the search terms are converted into a
+``tsquery``, and the two are compared with the ``@@`` operator.
+
+.. code-block:: python
+
+    from piccolo.query.functions import (
+        Matches,
+        ToTsVector,
+        WebsearchToTsQuery,
+    )
+
+    await Band.select(Band.name).where(
+        Matches(
+            ToTsVector(Band.name, config='english'),
+            WebsearchToTsQuery('pythonistas', config='english'),
+        )
+    )
+
+ToTsVector
+----------
+
+.. autoclass:: ToTsVector
+
+ToTsQuery
+---------
+
+.. autoclass:: ToTsQuery
+
+PlainToTsQuery
+--------------
+
+.. autoclass:: PlainToTsQuery
+
+WebsearchToTsQuery
+------------------
+
+.. autoclass:: WebsearchToTsQuery
+
+Matches
+-------
+
+.. autoclass:: Matches

--- a/piccolo/query/functions/__init__.py
+++ b/piccolo/query/functions/__init__.py
@@ -28,6 +28,13 @@ from .string import (
     Rtrim,
     Upper,
 )
+from .text_search import (
+    Matches,
+    PlainToTsQuery,
+    ToTsQuery,
+    ToTsVector,
+    WebsearchToTsQuery,
+)
 from .type_conversion import Cast
 
 __all__ = (
@@ -52,10 +59,12 @@ __all__ = (
     "Length",
     "Lower",
     "Ltrim",
+    "Matches",
     "Max",
     "Min",
     "Month",
     "NullIf",
+    "PlainToTsQuery",
     "Replace",
     "Reverse",
     "Round",
@@ -63,6 +72,9 @@ __all__ = (
     "Second",
     "Strftime",
     "Sum",
+    "ToTsQuery",
+    "ToTsVector",
     "Upper",
+    "WebsearchToTsQuery",
     "Year",
 )

--- a/piccolo/query/functions/text_search.py
+++ b/piccolo/query/functions/text_search.py
@@ -1,0 +1,280 @@
+"""
+Postgres only.
+
+These functions mirror their counterparts in the Postgres docs:
+
+https://www.postgresql.org/docs/current/functions-textsearch.html
+
+Full text search is a Postgres feature - SQLite has its own, unrelated FTS
+extension, and CockroachDB's support is incomplete. Passing a column belonging
+to a non-Postgres engine into any of these raises a ``ValueError``.
+
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Union
+
+from piccolo.columns.base import Column
+from piccolo.custom_types import BasicTypes
+from piccolo.querystring import QueryString
+
+TEXT_SEARCH_CONFIG_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def check_engine(*values: Union[Column, QueryString, BasicTypes]) -> None:
+    """
+    Full text search is Postgres only, so reject columns which belong to any
+    other engine.
+    """
+    for value in values:
+        if isinstance(value, Column):
+            if value._meta.engine_type != "postgres":
+                raise ValueError("Only Postgres supports full text search.")
+
+
+def get_config_string(config: Optional[str]) -> str:
+    """
+    The text search configuration is written into the query, rather than being
+    passed in as a query parameter.
+
+    Postgres only resolves ``to_tsvector(config, text)`` when the config is a
+    constant, and an expression index over it is only ``IMMUTABLE`` because of
+    it - so it can't be a parameter.
+
+    As it isn't parameterised, we make sure it's a plain identifier (such as
+    ``english``), so it can't be used for SQL injection.
+
+    """
+    if config is None:
+        return ""
+
+    if not TEXT_SEARCH_CONFIG_PATTERN.match(config):
+        raise ValueError(
+            "The text search config must be an identifier, for example "
+            "'english'."
+        )
+
+    return f"'{config}', "
+
+
+class ToTsVector(QueryString):
+    def __init__(
+        self,
+        document: Union[Column, QueryString, str],
+        config: Optional[str] = None,
+        alias: Optional[str] = None,
+    ):
+        """
+        Postgres only. Converts text into a ``tsvector`` - the sorted list of
+        normalised words which full text search matches against.
+
+        .. code-block:: python
+
+            >>> await Band.select(ToTsVector(Band.name, config='english'))
+            [{'to_tsvector': "'pythonista':1"}]
+
+        Most of the time you'll use it with :class:`Matches`, to search:
+
+        .. code-block:: python
+
+            >>> await Band.select(Band.name).where(
+            ...     Matches(
+            ...         ToTsVector(Band.name, config='english'),
+            ...         ToTsQuery('pythonistas', config='english'),
+            ...     )
+            ... )
+            [{'name': 'Pythonistas'}]
+
+        :param document:
+            The text to convert - usually a column.
+        :param config:
+            The text search configuration to use, for example ``'english'``.
+            If ``None``, the database's ``default_text_search_config`` is
+            used. Note that the single argument form of ``to_tsvector`` is
+            ``STABLE`` rather than ``IMMUTABLE``, so it can't be used in an
+            expression index - pass a config explicitly if you need one.
+        :raises ValueError:
+            If the engine isn't Postgres, or the config isn't an identifier.
+
+        """
+        check_engine(document)
+
+        super().__init__(
+            f"to_tsvector({get_config_string(config)}{{}})",
+            document,
+            alias=alias or "to_tsvector",
+        )
+
+
+class ToTsQuery(QueryString):
+    def __init__(
+        self,
+        query: Union[Column, QueryString, str],
+        config: Optional[str] = None,
+        alias: Optional[str] = None,
+    ):
+        """
+        Postgres only. Converts a search query into a ``tsquery``.
+
+        .. code-block:: python
+
+            >>> await Band.select(Band.name).where(
+            ...     Matches(
+            ...         ToTsVector(Band.name),
+            ...         ToTsQuery('python & rust'),
+            ...     )
+            ... )
+
+        .. warning::
+            ``to_tsquery`` expects search operators (``&``, ``|``, ``!``,
+            ``<->``, ``:*``), and raises a database error if the input
+            contains a stray one. Don't pass unsanitised user input into it -
+            use :class:`PlainToTsQuery` or :class:`WebsearchToTsQuery`
+            instead, which accept any text.
+
+        :param query:
+            The search query, using ``tsquery`` syntax.
+        :param config:
+            The text search configuration to use, for example ``'english'``.
+            If ``None``, the database's ``default_text_search_config`` is
+            used.
+        :raises ValueError:
+            If the engine isn't Postgres, or the config isn't an identifier.
+
+        """
+        check_engine(query)
+
+        super().__init__(
+            f"to_tsquery({get_config_string(config)}{{}})",
+            query,
+            alias=alias or "to_tsquery",
+        )
+
+
+class PlainToTsQuery(QueryString):
+    def __init__(
+        self,
+        query: Union[Column, QueryString, str],
+        config: Optional[str] = None,
+        alias: Optional[str] = None,
+    ):
+        """
+        Postgres only. Converts plain text into a ``tsquery``, with every word
+        combined using ``AND``. Unlike :class:`ToTsQuery` it accepts any text,
+        so it's safe to use with user input.
+
+        .. code-block:: python
+
+            >>> await Band.select(Band.name).where(
+            ...     Matches(
+            ...         ToTsVector(Band.name),
+            ...         PlainToTsQuery('the pythonistas'),
+            ...     )
+            ... )
+            [{'name': 'Pythonistas'}]
+
+        :param query:
+            The text to search for.
+        :param config:
+            The text search configuration to use, for example ``'english'``.
+            If ``None``, the database's ``default_text_search_config`` is
+            used.
+        :raises ValueError:
+            If the engine isn't Postgres, or the config isn't an identifier.
+
+        """
+        check_engine(query)
+
+        super().__init__(
+            f"plainto_tsquery({get_config_string(config)}{{}})",
+            query,
+            alias=alias or "plainto_tsquery",
+        )
+
+
+class WebsearchToTsQuery(QueryString):
+    def __init__(
+        self,
+        query: Union[Column, QueryString, str],
+        config: Optional[str] = None,
+        alias: Optional[str] = None,
+    ):
+        """
+        Postgres only. Converts text into a ``tsquery``, using the syntax
+        people expect from a web search engine - quoted phrases, ``or``, and
+        ``-`` to exclude. Like :class:`PlainToTsQuery` it accepts any text, so
+        it's safe to use with user input.
+
+        .. code-block:: python
+
+            >>> await Band.select(Band.name).where(
+            ...     Matches(
+            ...         ToTsVector(Band.name),
+            ...         WebsearchToTsQuery('"pythonistas" -rustaceans'),
+            ...     )
+            ... )
+            [{'name': 'Pythonistas'}]
+
+        :param query:
+            The text to search for.
+        :param config:
+            The text search configuration to use, for example ``'english'``.
+            If ``None``, the database's ``default_text_search_config`` is
+            used.
+        :raises ValueError:
+            If the engine isn't Postgres, or the config isn't an identifier.
+
+        """
+        check_engine(query)
+
+        super().__init__(
+            f"websearch_to_tsquery({get_config_string(config)}{{}})",
+            query,
+            alias=alias or "websearch_to_tsquery",
+        )
+
+
+class Matches(QueryString):
+    def __init__(
+        self,
+        document: Union[Column, QueryString],
+        query: Union[Column, QueryString],
+        alias: Optional[str] = None,
+    ):
+        """
+        Postgres only. The full text search operator (``@@``) - it returns
+        ``True`` if the ``tsvector`` matches the ``tsquery``.
+
+        .. code-block:: python
+
+            >>> await Band.select(Band.name).where(
+            ...     Matches(
+            ...         ToTsVector(Band.name, config='english'),
+            ...         PlainToTsQuery('pythonistas', config='english'),
+            ...     )
+            ... )
+            [{'name': 'Pythonistas'}]
+
+        :param document:
+            A ``tsvector`` - see :class:`ToTsVector`.
+        :param query:
+            A ``tsquery`` - see :class:`PlainToTsQuery`,
+            :class:`WebsearchToTsQuery` and :class:`ToTsQuery`.
+        :raises ValueError:
+            If the engine isn't Postgres.
+
+        """
+        check_engine(document, query)
+
+        super().__init__("{} @@ {}", document, query, alias=alias)
+
+
+__all__ = (
+    "Matches",
+    "PlainToTsQuery",
+    "ToTsQuery",
+    "ToTsVector",
+    "WebsearchToTsQuery",
+)

--- a/tests/query/functions/test_text_search.py
+++ b/tests/query/functions/test_text_search.py
@@ -1,0 +1,138 @@
+from unittest import TestCase
+
+from piccolo.columns import Varchar
+from piccolo.query.functions.text_search import (
+    Matches,
+    PlainToTsQuery,
+    ToTsQuery,
+    ToTsVector,
+    WebsearchToTsQuery,
+)
+from piccolo.table import Table
+from piccolo.testing.test_case import AsyncTableTest
+from tests.base import engines_only, engines_skip
+
+
+class Band(Table):
+    name = Varchar()
+
+
+@engines_only("postgres")
+class TestTextSearch(AsyncTableTest):
+
+    tables = [Band]
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+
+        await Band.insert(
+            Band({Band.name: "Pythonistas play rock"}),
+            Band({Band.name: "Rustaceans play jazz"}),
+        )
+
+    async def test_to_tsvector(self):
+        response = await Band.select(
+            ToTsVector(Band.name, config="simple")
+        ).order_by(Band.name)
+
+        self.assertListEqual(
+            response,
+            [
+                {"to_tsvector": "'play':2 'pythonistas':1 'rock':3"},
+                {"to_tsvector": "'jazz':3 'play':2 'rustaceans':1"},
+            ],
+        )
+
+    async def test_matches(self):
+        response = await Band.select(Band.name).where(
+            Matches(
+                ToTsVector(Band.name, config="english"),
+                ToTsQuery("rock", config="english"),
+            )
+        )
+
+        self.assertListEqual(response, [{"name": "Pythonistas play rock"}])
+
+    async def test_to_tsquery_operators(self):
+        """
+        ``to_tsquery`` understands the full query syntax.
+        """
+        response = await Band.select(Band.name).where(
+            Matches(
+                ToTsVector(Band.name, config="english"),
+                ToTsQuery("play & !rock", config="english"),
+            )
+        )
+
+        self.assertListEqual(response, [{"name": "Rustaceans play jazz"}])
+
+    async def test_plainto_tsquery(self):
+        """
+        Every word is combined with ``AND``.
+        """
+        response = await Band.select(Band.name).where(
+            Matches(
+                ToTsVector(Band.name, config="english"),
+                PlainToTsQuery("play jazz", config="english"),
+            )
+        )
+
+        self.assertListEqual(response, [{"name": "Rustaceans play jazz"}])
+
+    async def test_websearch_to_tsquery(self):
+        """
+        Web search syntax - a quoted phrase, and ``-`` to exclude.
+        """
+        response = await Band.select(Band.name).where(
+            Matches(
+                ToTsVector(Band.name, config="english"),
+                WebsearchToTsQuery("play -jazz", config="english"),
+            )
+        )
+
+        self.assertListEqual(response, [{"name": "Pythonistas play rock"}])
+
+    async def test_no_config(self):
+        """
+        The database's default config should be used.
+        """
+        response = await Band.select(Band.name).where(
+            Matches(ToTsVector(Band.name), PlainToTsQuery("rock"))
+        )
+
+        self.assertListEqual(response, [{"name": "Pythonistas play rock"}])
+
+    async def test_no_match(self):
+        response = await Band.select(Band.name).where(
+            Matches(
+                ToTsVector(Band.name, config="english"),
+                PlainToTsQuery("clarinet", config="english"),
+            )
+        )
+
+        self.assertListEqual(response, [])
+
+
+class TestTextSearchValidation(TestCase):
+
+    @engines_only("postgres")
+    def test_invalid_config(self):
+        """
+        The config is written into the query, so it must be an identifier.
+        """
+        for config in ("english'; DROP TABLE band; --", "en glish", ""):
+            with self.assertRaises(ValueError):
+                ToTsVector(Band.name, config=config)
+
+    @engines_skip("postgres")
+    def test_wrong_engine(self):
+        """
+        Full text search is Postgres only.
+        """
+        with self.assertRaises(ValueError) as manager:
+            ToTsVector(Band.name)
+
+        self.assertEqual(
+            str(manager.exception),
+            "Only Postgres supports full text search.",
+        )


### PR DESCRIPTION
**Postgres only.** SQLite's FTS is a separate, unrelated extension, and
CockroachDB's `tsvector` support is incomplete — so passing a column belonging
to either engine into any of these raises
`ValueError("Only Postgres supports full text search.")`, following the same
pattern as the array functions. A SQLite user gets that error at query-build
time, not a confusing database error.

There's currently no way to express Postgres full text search through Piccolo,
so it has to be written as raw SQL. This adds the pieces as composable
`QueryString`s.

```python
from piccolo.query.functions import Matches, ToTsVector, WebsearchToTsQuery

await Band.select(Band.name).where(
    Matches(
        ToTsVector(Band.name, config='english'),
        WebsearchToTsQuery('pythonistas', config='english'),
    )
)
```

| Class | SQL |
| --- | --- |
| `ToTsVector` | `to_tsvector` |
| `ToTsQuery` | `to_tsquery` |
| `PlainToTsQuery` | `plainto_tsquery` |
| `WebsearchToTsQuery` | `websearch_to_tsquery` |
| `Matches` | `@@` |

### The text search config can't be a query parameter

Postgres only resolves `to_tsvector(config, text)` when the config is a
constant, and an expression index over it is only `IMMUTABLE` because of that.
So `config` is a `str` which is written into the query rather than bound.

Since it isn't parameterised, it's validated against `^[A-Za-z_][A-Za-z0-9_]*$`
before it goes in, so it can't be used for injection. `config=None` (the
default) emits the single-argument form, which uses the database's
`default_text_search_config` — the docstring notes that this form is `STABLE`
rather than `IMMUTABLE`, so it can't be used in an expression index.

### Sanitising user input

`to_tsquery` raises a database error on a stray operator, so it's the wrong
thing to hand a raw search box to. `PlainToTsQuery` and `WebsearchToTsQuery`
accept any text, so they're the safe entry points — that's called out in
`ToTsQuery`'s docstring with a `.. warning::` pointing at them.

**A question for you:** the one thing `to_tsquery` can do that the safe
variants can't is prefix matching (`python:*`), which is what you want for
type-ahead search. Doing that safely means a helper which strips the input to
word characters, `AND`s them, and appends `:*` to the last word. I've left it
out — it's a policy decision rather than a wrapper around a Postgres function,
and it's the kind of thing that belongs in the docs as a recipe if you don't
want it in the library. Happy to add it if you do.

### Deliberately left out

* `ts_rank` / `ts_rank_cd` / `ts_headline` — the obvious follow-ups, but they
  have fussier signatures (normalization flags, option strings) and this PR is
  already the whole matching path.
* `tsvector` / `tsquery` **column types**, and GIN index support for them.
  Right now the vector has to be computed per query, or the user has to add the
  column and index through a raw migration. That's the bigger piece of work and
  I didn't want to bundle it in.
* Relaxing the engine check for CockroachDB — it has had partial `tsvector`
  support since v23.2, but I have no instance to verify against, so I've been
  conservative. It's a one-line change to `check_engine` if you'd rather allow
  it.

### Naming

`Matches` is the least obvious name here — the operator has no function name in
Postgres. Alternatives would be `TsMatch` or `TextSearchMatch`. Happy to rename.

### Testing

New file `tests/query/functions/test_text_search.py` — 7 Postgres-only
behaviour tests plus config validation and a check that the wrong engine
raises.

```
$ ./scripts/test-postgres.sh tests/query/functions/
43 passed, 2 skipped

$ ./scripts/test-sqlite.sh tests/query/functions/
31 passed, 14 skipped
```

Full suite against Postgres — `1 failed, 891 passed, 34 skipped`. The one
failure is `tests/table/test_update.py::TestOperators::test_operators`, which
fails on `master` for me too.
